### PR TITLE
Add preview of color schemes

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -202,3 +202,15 @@ pre {
         }
     }
 }
+.preview-color{
+	float:left;
+	padding-top:12.5%;
+	width:12.5%;
+}
+.preview-color-row{
+	overflow:auto;
+	width:100%;
+}
+.preview-color-block{
+	margin-bottom:15px;
+}

--- a/add-on-styling-color-preview.md
+++ b/add-on-styling-color-preview.md
@@ -1,0 +1,1913 @@
+---
+layout: page
+title: Preview of color schemes
+---
+<h3 id="base16-3024-dark">Base16 3024 Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#a5a2a2"></div>
+<div class="preview-color" style="background-color:#090300"></div>
+<div class="preview-color" style="background-color:#db2d20"></div>
+<div class="preview-color" style="background-color:#01a252"></div>
+<div class="preview-color" style="background-color:#fded02"></div>
+<div class="preview-color" style="background-color:#01a0e4"></div>
+<div class="preview-color" style="background-color:#a16a94"></div>
+<div class="preview-color" style="background-color:#b5e4f4"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#090300"></div>
+<div class="preview-color" style="background-color:#5c5855"></div>
+<div class="preview-color" style="background-color:#db2d20"></div>
+<div class="preview-color" style="background-color:#01a252"></div>
+<div class="preview-color" style="background-color:#fded02"></div>
+<div class="preview-color" style="background-color:#01a0e4"></div>
+<div class="preview-color" style="background-color:#a16a94"></div>
+<div class="preview-color" style="background-color:#b5e4f4"></div>
+</div>
+</div>
+<h3 id="base16-3024-light">Base16 3024 Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#4a4543"></div>
+<div class="preview-color" style="background-color:#090300"></div>
+<div class="preview-color" style="background-color:#db2d20"></div>
+<div class="preview-color" style="background-color:#01a252"></div>
+<div class="preview-color" style="background-color:#fded02"></div>
+<div class="preview-color" style="background-color:#01a0e4"></div>
+<div class="preview-color" style="background-color:#a16a94"></div>
+<div class="preview-color" style="background-color:#b5e4f4"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#f7f7f7"></div>
+<div class="preview-color" style="background-color:#5c5855"></div>
+<div class="preview-color" style="background-color:#db2d20"></div>
+<div class="preview-color" style="background-color:#01a252"></div>
+<div class="preview-color" style="background-color:#fded02"></div>
+<div class="preview-color" style="background-color:#01a0e4"></div>
+<div class="preview-color" style="background-color:#a16a94"></div>
+<div class="preview-color" style="background-color:#b5e4f4"></div>
+</div>
+</div>
+<h3 id="base16-apathy-dark">Base16 Apathy Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#81B5AC"></div>
+<div class="preview-color" style="background-color:#031A16"></div>
+<div class="preview-color" style="background-color:#3E9688"></div>
+<div class="preview-color" style="background-color:#883E96"></div>
+<div class="preview-color" style="background-color:#3E4C96"></div>
+<div class="preview-color" style="background-color:#96883E"></div>
+<div class="preview-color" style="background-color:#4C963E"></div>
+<div class="preview-color" style="background-color:#963E4C"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#031A16"></div>
+<div class="preview-color" style="background-color:#2B685E"></div>
+<div class="preview-color" style="background-color:#3E9688"></div>
+<div class="preview-color" style="background-color:#883E96"></div>
+<div class="preview-color" style="background-color:#3E4C96"></div>
+<div class="preview-color" style="background-color:#96883E"></div>
+<div class="preview-color" style="background-color:#4C963E"></div>
+<div class="preview-color" style="background-color:#963E4C"></div>
+</div>
+</div>
+<h3 id="base16-apathy-light">Base16 Apathy Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#184E45"></div>
+<div class="preview-color" style="background-color:#031A16"></div>
+<div class="preview-color" style="background-color:#3E9688"></div>
+<div class="preview-color" style="background-color:#883E96"></div>
+<div class="preview-color" style="background-color:#3E4C96"></div>
+<div class="preview-color" style="background-color:#96883E"></div>
+<div class="preview-color" style="background-color:#4C963E"></div>
+<div class="preview-color" style="background-color:#963E4C"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#D2E7E4"></div>
+<div class="preview-color" style="background-color:#2B685E"></div>
+<div class="preview-color" style="background-color:#3E9688"></div>
+<div class="preview-color" style="background-color:#883E96"></div>
+<div class="preview-color" style="background-color:#3E4C96"></div>
+<div class="preview-color" style="background-color:#96883E"></div>
+<div class="preview-color" style="background-color:#4C963E"></div>
+<div class="preview-color" style="background-color:#963E4C"></div>
+</div>
+</div>
+<h3 id="base16-ashes-dark">Base16 Ashes Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#C7CCD1"></div>
+<div class="preview-color" style="background-color:#1C2023"></div>
+<div class="preview-color" style="background-color:#C7AE95"></div>
+<div class="preview-color" style="background-color:#95C7AE"></div>
+<div class="preview-color" style="background-color:#AEC795"></div>
+<div class="preview-color" style="background-color:#AE95C7"></div>
+<div class="preview-color" style="background-color:#C795AE"></div>
+<div class="preview-color" style="background-color:#95AEC7"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#1C2023"></div>
+<div class="preview-color" style="background-color:#747C84"></div>
+<div class="preview-color" style="background-color:#C7AE95"></div>
+<div class="preview-color" style="background-color:#95C7AE"></div>
+<div class="preview-color" style="background-color:#AEC795"></div>
+<div class="preview-color" style="background-color:#AE95C7"></div>
+<div class="preview-color" style="background-color:#C795AE"></div>
+<div class="preview-color" style="background-color:#95AEC7"></div>
+</div>
+</div>
+<h3 id="base16-ashes-light">Base16 Ashes Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#565E65"></div>
+<div class="preview-color" style="background-color:#1C2023"></div>
+<div class="preview-color" style="background-color:#C7AE95"></div>
+<div class="preview-color" style="background-color:#95C7AE"></div>
+<div class="preview-color" style="background-color:#AEC795"></div>
+<div class="preview-color" style="background-color:#AE95C7"></div>
+<div class="preview-color" style="background-color:#C795AE"></div>
+<div class="preview-color" style="background-color:#95AEC7"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#F3F4F5"></div>
+<div class="preview-color" style="background-color:#747C84"></div>
+<div class="preview-color" style="background-color:#C7AE95"></div>
+<div class="preview-color" style="background-color:#95C7AE"></div>
+<div class="preview-color" style="background-color:#AEC795"></div>
+<div class="preview-color" style="background-color:#AE95C7"></div>
+<div class="preview-color" style="background-color:#C795AE"></div>
+<div class="preview-color" style="background-color:#95AEC7"></div>
+</div>
+</div>
+<h3 id="base16-atelierdune-dark">Base16 Atelierdune Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#a6a28c"></div>
+<div class="preview-color" style="background-color:#20201d"></div>
+<div class="preview-color" style="background-color:#d73737"></div>
+<div class="preview-color" style="background-color:#60ac39"></div>
+<div class="preview-color" style="background-color:#cfb017"></div>
+<div class="preview-color" style="background-color:#6684e1"></div>
+<div class="preview-color" style="background-color:#b854d4"></div>
+<div class="preview-color" style="background-color:#1fad83"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#20201d"></div>
+<div class="preview-color" style="background-color:#7d7a68"></div>
+<div class="preview-color" style="background-color:#d73737"></div>
+<div class="preview-color" style="background-color:#60ac39"></div>
+<div class="preview-color" style="background-color:#cfb017"></div>
+<div class="preview-color" style="background-color:#6684e1"></div>
+<div class="preview-color" style="background-color:#b854d4"></div>
+<div class="preview-color" style="background-color:#1fad83"></div>
+</div>
+</div>
+<h3 id="base16-atelierdune-light">Base16 Atelierdune Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#6e6b5e"></div>
+<div class="preview-color" style="background-color:#20201d"></div>
+<div class="preview-color" style="background-color:#d73737"></div>
+<div class="preview-color" style="background-color:#60ac39"></div>
+<div class="preview-color" style="background-color:#cfb017"></div>
+<div class="preview-color" style="background-color:#6684e1"></div>
+<div class="preview-color" style="background-color:#b854d4"></div>
+<div class="preview-color" style="background-color:#1fad83"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#fefbec"></div>
+<div class="preview-color" style="background-color:#7d7a68"></div>
+<div class="preview-color" style="background-color:#d73737"></div>
+<div class="preview-color" style="background-color:#60ac39"></div>
+<div class="preview-color" style="background-color:#cfb017"></div>
+<div class="preview-color" style="background-color:#6684e1"></div>
+<div class="preview-color" style="background-color:#b854d4"></div>
+<div class="preview-color" style="background-color:#1fad83"></div>
+</div>
+</div>
+<h3 id="base16-atelierforest-dark">Base16 Atelierforest Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#a8a19f"></div>
+<div class="preview-color" style="background-color:#1b1918"></div>
+<div class="preview-color" style="background-color:#f22c40"></div>
+<div class="preview-color" style="background-color:#5ab738"></div>
+<div class="preview-color" style="background-color:#d5911a"></div>
+<div class="preview-color" style="background-color:#407ee7"></div>
+<div class="preview-color" style="background-color:#6666ea"></div>
+<div class="preview-color" style="background-color:#00ad9c"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#1b1918"></div>
+<div class="preview-color" style="background-color:#766e6b"></div>
+<div class="preview-color" style="background-color:#f22c40"></div>
+<div class="preview-color" style="background-color:#5ab738"></div>
+<div class="preview-color" style="background-color:#d5911a"></div>
+<div class="preview-color" style="background-color:#407ee7"></div>
+<div class="preview-color" style="background-color:#6666ea"></div>
+<div class="preview-color" style="background-color:#00ad9c"></div>
+</div>
+</div>
+<h3 id="base16-atelierforest-light">Base16 Atelierforest Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#68615e"></div>
+<div class="preview-color" style="background-color:#1b1918"></div>
+<div class="preview-color" style="background-color:#f22c40"></div>
+<div class="preview-color" style="background-color:#5ab738"></div>
+<div class="preview-color" style="background-color:#d5911a"></div>
+<div class="preview-color" style="background-color:#407ee7"></div>
+<div class="preview-color" style="background-color:#6666ea"></div>
+<div class="preview-color" style="background-color:#00ad9c"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#f1efee"></div>
+<div class="preview-color" style="background-color:#766e6b"></div>
+<div class="preview-color" style="background-color:#f22c40"></div>
+<div class="preview-color" style="background-color:#5ab738"></div>
+<div class="preview-color" style="background-color:#d5911a"></div>
+<div class="preview-color" style="background-color:#407ee7"></div>
+<div class="preview-color" style="background-color:#6666ea"></div>
+<div class="preview-color" style="background-color:#00ad9c"></div>
+</div>
+</div>
+<h3 id="base16-atelierheath-dark">Base16 Atelierheath Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#ab9bab"></div>
+<div class="preview-color" style="background-color:#1b181b"></div>
+<div class="preview-color" style="background-color:#ca402b"></div>
+<div class="preview-color" style="background-color:#379a37"></div>
+<div class="preview-color" style="background-color:#bb8a35"></div>
+<div class="preview-color" style="background-color:#516aec"></div>
+<div class="preview-color" style="background-color:#7b59c0"></div>
+<div class="preview-color" style="background-color:#159393"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#1b181b"></div>
+<div class="preview-color" style="background-color:#776977"></div>
+<div class="preview-color" style="background-color:#ca402b"></div>
+<div class="preview-color" style="background-color:#379a37"></div>
+<div class="preview-color" style="background-color:#bb8a35"></div>
+<div class="preview-color" style="background-color:#516aec"></div>
+<div class="preview-color" style="background-color:#7b59c0"></div>
+<div class="preview-color" style="background-color:#159393"></div>
+</div>
+</div>
+<h3 id="base16-atelierheath-light">Base16 Atelierheath Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#695d69"></div>
+<div class="preview-color" style="background-color:#1b181b"></div>
+<div class="preview-color" style="background-color:#ca402b"></div>
+<div class="preview-color" style="background-color:#379a37"></div>
+<div class="preview-color" style="background-color:#bb8a35"></div>
+<div class="preview-color" style="background-color:#516aec"></div>
+<div class="preview-color" style="background-color:#7b59c0"></div>
+<div class="preview-color" style="background-color:#159393"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#f7f3f7"></div>
+<div class="preview-color" style="background-color:#776977"></div>
+<div class="preview-color" style="background-color:#ca402b"></div>
+<div class="preview-color" style="background-color:#379a37"></div>
+<div class="preview-color" style="background-color:#bb8a35"></div>
+<div class="preview-color" style="background-color:#516aec"></div>
+<div class="preview-color" style="background-color:#7b59c0"></div>
+<div class="preview-color" style="background-color:#159393"></div>
+</div>
+</div>
+<h3 id="base16-atelierlakeside-dark">Base16 Atelierlakeside Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#7ea2b4"></div>
+<div class="preview-color" style="background-color:#161b1d"></div>
+<div class="preview-color" style="background-color:#d22d72"></div>
+<div class="preview-color" style="background-color:#568c3b"></div>
+<div class="preview-color" style="background-color:#8a8a0f"></div>
+<div class="preview-color" style="background-color:#257fad"></div>
+<div class="preview-color" style="background-color:#5d5db1"></div>
+<div class="preview-color" style="background-color:#2d8f6f"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#161b1d"></div>
+<div class="preview-color" style="background-color:#5a7b8c"></div>
+<div class="preview-color" style="background-color:#d22d72"></div>
+<div class="preview-color" style="background-color:#568c3b"></div>
+<div class="preview-color" style="background-color:#8a8a0f"></div>
+<div class="preview-color" style="background-color:#257fad"></div>
+<div class="preview-color" style="background-color:#5d5db1"></div>
+<div class="preview-color" style="background-color:#2d8f6f"></div>
+</div>
+</div>
+<h3 id="base16-atelierlakeside-light">Base16 Atelierlakeside Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#516d7b"></div>
+<div class="preview-color" style="background-color:#161b1d"></div>
+<div class="preview-color" style="background-color:#d22d72"></div>
+<div class="preview-color" style="background-color:#568c3b"></div>
+<div class="preview-color" style="background-color:#8a8a0f"></div>
+<div class="preview-color" style="background-color:#257fad"></div>
+<div class="preview-color" style="background-color:#5d5db1"></div>
+<div class="preview-color" style="background-color:#2d8f6f"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#ebf8ff"></div>
+<div class="preview-color" style="background-color:#5a7b8c"></div>
+<div class="preview-color" style="background-color:#d22d72"></div>
+<div class="preview-color" style="background-color:#568c3b"></div>
+<div class="preview-color" style="background-color:#8a8a0f"></div>
+<div class="preview-color" style="background-color:#257fad"></div>
+<div class="preview-color" style="background-color:#5d5db1"></div>
+<div class="preview-color" style="background-color:#2d8f6f"></div>
+</div>
+</div>
+<h3 id="base16-atelierseaside-dark">Base16 Atelierseaside Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#8ca68c"></div>
+<div class="preview-color" style="background-color:#131513"></div>
+<div class="preview-color" style="background-color:#e6193c"></div>
+<div class="preview-color" style="background-color:#29a329"></div>
+<div class="preview-color" style="background-color:#c3c322"></div>
+<div class="preview-color" style="background-color:#3d62f5"></div>
+<div class="preview-color" style="background-color:#ad2bee"></div>
+<div class="preview-color" style="background-color:#1999b3"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#131513"></div>
+<div class="preview-color" style="background-color:#687d68"></div>
+<div class="preview-color" style="background-color:#e6193c"></div>
+<div class="preview-color" style="background-color:#29a329"></div>
+<div class="preview-color" style="background-color:#c3c322"></div>
+<div class="preview-color" style="background-color:#3d62f5"></div>
+<div class="preview-color" style="background-color:#ad2bee"></div>
+<div class="preview-color" style="background-color:#1999b3"></div>
+</div>
+</div>
+<h3 id="base16-atelierseaside-light">Base16 Atelierseaside Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#5e6e5e"></div>
+<div class="preview-color" style="background-color:#131513"></div>
+<div class="preview-color" style="background-color:#e6193c"></div>
+<div class="preview-color" style="background-color:#29a329"></div>
+<div class="preview-color" style="background-color:#c3c322"></div>
+<div class="preview-color" style="background-color:#3d62f5"></div>
+<div class="preview-color" style="background-color:#ad2bee"></div>
+<div class="preview-color" style="background-color:#1999b3"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#f0fff0"></div>
+<div class="preview-color" style="background-color:#687d68"></div>
+<div class="preview-color" style="background-color:#e6193c"></div>
+<div class="preview-color" style="background-color:#29a329"></div>
+<div class="preview-color" style="background-color:#c3c322"></div>
+<div class="preview-color" style="background-color:#3d62f5"></div>
+<div class="preview-color" style="background-color:#ad2bee"></div>
+<div class="preview-color" style="background-color:#1999b3"></div>
+</div>
+</div>
+<h3 id="base16-bespin-dark">Base16 Bespin Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#8a8986"></div>
+<div class="preview-color" style="background-color:#28211c"></div>
+<div class="preview-color" style="background-color:#cf6a4c"></div>
+<div class="preview-color" style="background-color:#54be0d"></div>
+<div class="preview-color" style="background-color:#f9ee98"></div>
+<div class="preview-color" style="background-color:#5ea6ea"></div>
+<div class="preview-color" style="background-color:#9b859d"></div>
+<div class="preview-color" style="background-color:#afc4db"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#28211c"></div>
+<div class="preview-color" style="background-color:#666666"></div>
+<div class="preview-color" style="background-color:#cf6a4c"></div>
+<div class="preview-color" style="background-color:#54be0d"></div>
+<div class="preview-color" style="background-color:#f9ee98"></div>
+<div class="preview-color" style="background-color:#5ea6ea"></div>
+<div class="preview-color" style="background-color:#9b859d"></div>
+<div class="preview-color" style="background-color:#afc4db"></div>
+</div>
+</div>
+<h3 id="base16-bespin-light">Base16 Bespin Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#5e5d5c"></div>
+<div class="preview-color" style="background-color:#28211c"></div>
+<div class="preview-color" style="background-color:#cf6a4c"></div>
+<div class="preview-color" style="background-color:#54be0d"></div>
+<div class="preview-color" style="background-color:#f9ee98"></div>
+<div class="preview-color" style="background-color:#5ea6ea"></div>
+<div class="preview-color" style="background-color:#9b859d"></div>
+<div class="preview-color" style="background-color:#afc4db"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#baae9e"></div>
+<div class="preview-color" style="background-color:#666666"></div>
+<div class="preview-color" style="background-color:#cf6a4c"></div>
+<div class="preview-color" style="background-color:#54be0d"></div>
+<div class="preview-color" style="background-color:#f9ee98"></div>
+<div class="preview-color" style="background-color:#5ea6ea"></div>
+<div class="preview-color" style="background-color:#9b859d"></div>
+<div class="preview-color" style="background-color:#afc4db"></div>
+</div>
+</div>
+<h3 id="base16-brewer-dark">Base16 Brewer Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#b7b8b9"></div>
+<div class="preview-color" style="background-color:#0c0d0e"></div>
+<div class="preview-color" style="background-color:#e31a1c"></div>
+<div class="preview-color" style="background-color:#31a354"></div>
+<div class="preview-color" style="background-color:#dca060"></div>
+<div class="preview-color" style="background-color:#3182bd"></div>
+<div class="preview-color" style="background-color:#756bb1"></div>
+<div class="preview-color" style="background-color:#80b1d3"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#0c0d0e"></div>
+<div class="preview-color" style="background-color:#737475"></div>
+<div class="preview-color" style="background-color:#e31a1c"></div>
+<div class="preview-color" style="background-color:#31a354"></div>
+<div class="preview-color" style="background-color:#dca060"></div>
+<div class="preview-color" style="background-color:#3182bd"></div>
+<div class="preview-color" style="background-color:#756bb1"></div>
+<div class="preview-color" style="background-color:#80b1d3"></div>
+</div>
+</div>
+<h3 id="base16-brewer-light">Base16 Brewer Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#515253"></div>
+<div class="preview-color" style="background-color:#0c0d0e"></div>
+<div class="preview-color" style="background-color:#e31a1c"></div>
+<div class="preview-color" style="background-color:#31a354"></div>
+<div class="preview-color" style="background-color:#dca060"></div>
+<div class="preview-color" style="background-color:#3182bd"></div>
+<div class="preview-color" style="background-color:#756bb1"></div>
+<div class="preview-color" style="background-color:#80b1d3"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#fcfdfe"></div>
+<div class="preview-color" style="background-color:#737475"></div>
+<div class="preview-color" style="background-color:#e31a1c"></div>
+<div class="preview-color" style="background-color:#31a354"></div>
+<div class="preview-color" style="background-color:#dca060"></div>
+<div class="preview-color" style="background-color:#3182bd"></div>
+<div class="preview-color" style="background-color:#756bb1"></div>
+<div class="preview-color" style="background-color:#80b1d3"></div>
+</div>
+</div>
+<h3 id="base16-bright-dark">Base16 Bright Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#e0e0e0"></div>
+<div class="preview-color" style="background-color:#000000"></div>
+<div class="preview-color" style="background-color:#fb0120"></div>
+<div class="preview-color" style="background-color:#a1c659"></div>
+<div class="preview-color" style="background-color:#fda331"></div>
+<div class="preview-color" style="background-color:#6fb3d2"></div>
+<div class="preview-color" style="background-color:#d381c3"></div>
+<div class="preview-color" style="background-color:#76c7b7"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#000000"></div>
+<div class="preview-color" style="background-color:#b0b0b0"></div>
+<div class="preview-color" style="background-color:#fb0120"></div>
+<div class="preview-color" style="background-color:#a1c659"></div>
+<div class="preview-color" style="background-color:#fda331"></div>
+<div class="preview-color" style="background-color:#6fb3d2"></div>
+<div class="preview-color" style="background-color:#d381c3"></div>
+<div class="preview-color" style="background-color:#76c7b7"></div>
+</div>
+</div>
+<h3 id="base16-bright-light">Base16 Bright Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#505050"></div>
+<div class="preview-color" style="background-color:#000000"></div>
+<div class="preview-color" style="background-color:#fb0120"></div>
+<div class="preview-color" style="background-color:#a1c659"></div>
+<div class="preview-color" style="background-color:#fda331"></div>
+<div class="preview-color" style="background-color:#6fb3d2"></div>
+<div class="preview-color" style="background-color:#d381c3"></div>
+<div class="preview-color" style="background-color:#76c7b7"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#ffffff"></div>
+<div class="preview-color" style="background-color:#b0b0b0"></div>
+<div class="preview-color" style="background-color:#fb0120"></div>
+<div class="preview-color" style="background-color:#a1c659"></div>
+<div class="preview-color" style="background-color:#fda331"></div>
+<div class="preview-color" style="background-color:#6fb3d2"></div>
+<div class="preview-color" style="background-color:#d381c3"></div>
+<div class="preview-color" style="background-color:#76c7b7"></div>
+</div>
+</div>
+<h3 id="base16-chalk-dark">Base16 Chalk Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#d0d0d0"></div>
+<div class="preview-color" style="background-color:#151515"></div>
+<div class="preview-color" style="background-color:#fb9fb1"></div>
+<div class="preview-color" style="background-color:#acc267"></div>
+<div class="preview-color" style="background-color:#ddb26f"></div>
+<div class="preview-color" style="background-color:#6fc2ef"></div>
+<div class="preview-color" style="background-color:#e1a3ee"></div>
+<div class="preview-color" style="background-color:#12cfc0"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#151515"></div>
+<div class="preview-color" style="background-color:#505050"></div>
+<div class="preview-color" style="background-color:#fb9fb1"></div>
+<div class="preview-color" style="background-color:#acc267"></div>
+<div class="preview-color" style="background-color:#ddb26f"></div>
+<div class="preview-color" style="background-color:#6fc2ef"></div>
+<div class="preview-color" style="background-color:#e1a3ee"></div>
+<div class="preview-color" style="background-color:#12cfc0"></div>
+</div>
+</div>
+<h3 id="base16-chalk-light">Base16 Chalk Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#303030"></div>
+<div class="preview-color" style="background-color:#151515"></div>
+<div class="preview-color" style="background-color:#fb9fb1"></div>
+<div class="preview-color" style="background-color:#acc267"></div>
+<div class="preview-color" style="background-color:#ddb26f"></div>
+<div class="preview-color" style="background-color:#6fc2ef"></div>
+<div class="preview-color" style="background-color:#e1a3ee"></div>
+<div class="preview-color" style="background-color:#12cfc0"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#f5f5f5"></div>
+<div class="preview-color" style="background-color:#505050"></div>
+<div class="preview-color" style="background-color:#fb9fb1"></div>
+<div class="preview-color" style="background-color:#acc267"></div>
+<div class="preview-color" style="background-color:#ddb26f"></div>
+<div class="preview-color" style="background-color:#6fc2ef"></div>
+<div class="preview-color" style="background-color:#e1a3ee"></div>
+<div class="preview-color" style="background-color:#12cfc0"></div>
+</div>
+</div>
+<h3 id="base16-codeschool-dark">Base16 Codeschool Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#9ea7a6"></div>
+<div class="preview-color" style="background-color:#232c31"></div>
+<div class="preview-color" style="background-color:#2a5491"></div>
+<div class="preview-color" style="background-color:#237986"></div>
+<div class="preview-color" style="background-color:#a03b1e"></div>
+<div class="preview-color" style="background-color:#484d79"></div>
+<div class="preview-color" style="background-color:#c59820"></div>
+<div class="preview-color" style="background-color:#b02f30"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#232c31"></div>
+<div class="preview-color" style="background-color:#3f4944"></div>
+<div class="preview-color" style="background-color:#2a5491"></div>
+<div class="preview-color" style="background-color:#237986"></div>
+<div class="preview-color" style="background-color:#a03b1e"></div>
+<div class="preview-color" style="background-color:#484d79"></div>
+<div class="preview-color" style="background-color:#c59820"></div>
+<div class="preview-color" style="background-color:#b02f30"></div>
+</div>
+</div>
+<h3 id="base16-codeschool-light">Base16 Codeschool Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#2a343a"></div>
+<div class="preview-color" style="background-color:#232c31"></div>
+<div class="preview-color" style="background-color:#2a5491"></div>
+<div class="preview-color" style="background-color:#237986"></div>
+<div class="preview-color" style="background-color:#a03b1e"></div>
+<div class="preview-color" style="background-color:#484d79"></div>
+<div class="preview-color" style="background-color:#c59820"></div>
+<div class="preview-color" style="background-color:#b02f30"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#b5d8f6"></div>
+<div class="preview-color" style="background-color:#3f4944"></div>
+<div class="preview-color" style="background-color:#2a5491"></div>
+<div class="preview-color" style="background-color:#237986"></div>
+<div class="preview-color" style="background-color:#a03b1e"></div>
+<div class="preview-color" style="background-color:#484d79"></div>
+<div class="preview-color" style="background-color:#c59820"></div>
+<div class="preview-color" style="background-color:#b02f30"></div>
+</div>
+</div>
+<h3 id="base16-colors-dark">Base16 Colors Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#bbbbbb"></div>
+<div class="preview-color" style="background-color:#111111"></div>
+<div class="preview-color" style="background-color:#ff4136"></div>
+<div class="preview-color" style="background-color:#2ecc40"></div>
+<div class="preview-color" style="background-color:#ffdc00"></div>
+<div class="preview-color" style="background-color:#0074d9"></div>
+<div class="preview-color" style="background-color:#b10dc9"></div>
+<div class="preview-color" style="background-color:#7fdbff"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#111111"></div>
+<div class="preview-color" style="background-color:#777777"></div>
+<div class="preview-color" style="background-color:#ff4136"></div>
+<div class="preview-color" style="background-color:#2ecc40"></div>
+<div class="preview-color" style="background-color:#ffdc00"></div>
+<div class="preview-color" style="background-color:#0074d9"></div>
+<div class="preview-color" style="background-color:#b10dc9"></div>
+<div class="preview-color" style="background-color:#7fdbff"></div>
+</div>
+</div>
+<h3 id="base16-colors-light">Base16 Colors Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#555555"></div>
+<div class="preview-color" style="background-color:#111111"></div>
+<div class="preview-color" style="background-color:#ff4136"></div>
+<div class="preview-color" style="background-color:#2ecc40"></div>
+<div class="preview-color" style="background-color:#ffdc00"></div>
+<div class="preview-color" style="background-color:#0074d9"></div>
+<div class="preview-color" style="background-color:#b10dc9"></div>
+<div class="preview-color" style="background-color:#7fdbff"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#ffffff"></div>
+<div class="preview-color" style="background-color:#777777"></div>
+<div class="preview-color" style="background-color:#ff4136"></div>
+<div class="preview-color" style="background-color:#2ecc40"></div>
+<div class="preview-color" style="background-color:#ffdc00"></div>
+<div class="preview-color" style="background-color:#0074d9"></div>
+<div class="preview-color" style="background-color:#b10dc9"></div>
+<div class="preview-color" style="background-color:#7fdbff"></div>
+</div>
+</div>
+<h3 id="base16-default-dark">Base16 Default Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#d8d8d8"></div>
+<div class="preview-color" style="background-color:#181818"></div>
+<div class="preview-color" style="background-color:#ab4642"></div>
+<div class="preview-color" style="background-color:#a1b56c"></div>
+<div class="preview-color" style="background-color:#f7ca88"></div>
+<div class="preview-color" style="background-color:#7cafc2"></div>
+<div class="preview-color" style="background-color:#ba8baf"></div>
+<div class="preview-color" style="background-color:#86c1b9"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#181818"></div>
+<div class="preview-color" style="background-color:#585858"></div>
+<div class="preview-color" style="background-color:#ab4642"></div>
+<div class="preview-color" style="background-color:#a1b56c"></div>
+<div class="preview-color" style="background-color:#f7ca88"></div>
+<div class="preview-color" style="background-color:#7cafc2"></div>
+<div class="preview-color" style="background-color:#ba8baf"></div>
+<div class="preview-color" style="background-color:#86c1b9"></div>
+</div>
+</div>
+<h3 id="base16-default-light">Base16 Default Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#383838"></div>
+<div class="preview-color" style="background-color:#181818"></div>
+<div class="preview-color" style="background-color:#ab4642"></div>
+<div class="preview-color" style="background-color:#a1b56c"></div>
+<div class="preview-color" style="background-color:#f7ca88"></div>
+<div class="preview-color" style="background-color:#7cafc2"></div>
+<div class="preview-color" style="background-color:#ba8baf"></div>
+<div class="preview-color" style="background-color:#86c1b9"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#f8f8f8"></div>
+<div class="preview-color" style="background-color:#585858"></div>
+<div class="preview-color" style="background-color:#ab4642"></div>
+<div class="preview-color" style="background-color:#a1b56c"></div>
+<div class="preview-color" style="background-color:#f7ca88"></div>
+<div class="preview-color" style="background-color:#7cafc2"></div>
+<div class="preview-color" style="background-color:#ba8baf"></div>
+<div class="preview-color" style="background-color:#86c1b9"></div>
+</div>
+</div>
+<h3 id="base16-eighties-dark">Base16 Eighties Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#d3d0c8"></div>
+<div class="preview-color" style="background-color:#2d2d2d"></div>
+<div class="preview-color" style="background-color:#f2777a"></div>
+<div class="preview-color" style="background-color:#99cc99"></div>
+<div class="preview-color" style="background-color:#ffcc66"></div>
+<div class="preview-color" style="background-color:#6699cc"></div>
+<div class="preview-color" style="background-color:#cc99cc"></div>
+<div class="preview-color" style="background-color:#66cccc"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#2d2d2d"></div>
+<div class="preview-color" style="background-color:#747369"></div>
+<div class="preview-color" style="background-color:#f2777a"></div>
+<div class="preview-color" style="background-color:#99cc99"></div>
+<div class="preview-color" style="background-color:#ffcc66"></div>
+<div class="preview-color" style="background-color:#6699cc"></div>
+<div class="preview-color" style="background-color:#cc99cc"></div>
+<div class="preview-color" style="background-color:#66cccc"></div>
+</div>
+</div>
+<h3 id="base16-eighties-light">Base16 Eighties Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#515151"></div>
+<div class="preview-color" style="background-color:#2d2d2d"></div>
+<div class="preview-color" style="background-color:#f2777a"></div>
+<div class="preview-color" style="background-color:#99cc99"></div>
+<div class="preview-color" style="background-color:#ffcc66"></div>
+<div class="preview-color" style="background-color:#6699cc"></div>
+<div class="preview-color" style="background-color:#cc99cc"></div>
+<div class="preview-color" style="background-color:#66cccc"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#f2f0ec"></div>
+<div class="preview-color" style="background-color:#747369"></div>
+<div class="preview-color" style="background-color:#f2777a"></div>
+<div class="preview-color" style="background-color:#99cc99"></div>
+<div class="preview-color" style="background-color:#ffcc66"></div>
+<div class="preview-color" style="background-color:#6699cc"></div>
+<div class="preview-color" style="background-color:#cc99cc"></div>
+<div class="preview-color" style="background-color:#66cccc"></div>
+</div>
+</div>
+<h3 id="base16-embers-dark">Base16 Embers Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#A39A90"></div>
+<div class="preview-color" style="background-color:#16130F"></div>
+<div class="preview-color" style="background-color:#826D57"></div>
+<div class="preview-color" style="background-color:#57826D"></div>
+<div class="preview-color" style="background-color:#6D8257"></div>
+<div class="preview-color" style="background-color:#6D5782"></div>
+<div class="preview-color" style="background-color:#82576D"></div>
+<div class="preview-color" style="background-color:#576D82"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#16130F"></div>
+<div class="preview-color" style="background-color:#5A5047"></div>
+<div class="preview-color" style="background-color:#826D57"></div>
+<div class="preview-color" style="background-color:#57826D"></div>
+<div class="preview-color" style="background-color:#6D8257"></div>
+<div class="preview-color" style="background-color:#6D5782"></div>
+<div class="preview-color" style="background-color:#82576D"></div>
+<div class="preview-color" style="background-color:#576D82"></div>
+</div>
+</div>
+<h3 id="base16-embers-light">Base16 Embers Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#433B32"></div>
+<div class="preview-color" style="background-color:#16130F"></div>
+<div class="preview-color" style="background-color:#826D57"></div>
+<div class="preview-color" style="background-color:#57826D"></div>
+<div class="preview-color" style="background-color:#6D8257"></div>
+<div class="preview-color" style="background-color:#6D5782"></div>
+<div class="preview-color" style="background-color:#82576D"></div>
+<div class="preview-color" style="background-color:#576D82"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#DBD6D1"></div>
+<div class="preview-color" style="background-color:#5A5047"></div>
+<div class="preview-color" style="background-color:#826D57"></div>
+<div class="preview-color" style="background-color:#57826D"></div>
+<div class="preview-color" style="background-color:#6D8257"></div>
+<div class="preview-color" style="background-color:#6D5782"></div>
+<div class="preview-color" style="background-color:#82576D"></div>
+<div class="preview-color" style="background-color:#576D82"></div>
+</div>
+</div>
+<h3 id="base16-flat-dark">Base16 Flat Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#e0e0e0"></div>
+<div class="preview-color" style="background-color:#2C3E50"></div>
+<div class="preview-color" style="background-color:#E74C3C"></div>
+<div class="preview-color" style="background-color:#2ECC71"></div>
+<div class="preview-color" style="background-color:#F1C40F"></div>
+<div class="preview-color" style="background-color:#3498DB"></div>
+<div class="preview-color" style="background-color:#9B59B6"></div>
+<div class="preview-color" style="background-color:#1ABC9C"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#2C3E50"></div>
+<div class="preview-color" style="background-color:#95A5A6"></div>
+<div class="preview-color" style="background-color:#E74C3C"></div>
+<div class="preview-color" style="background-color:#2ECC71"></div>
+<div class="preview-color" style="background-color:#F1C40F"></div>
+<div class="preview-color" style="background-color:#3498DB"></div>
+<div class="preview-color" style="background-color:#9B59B6"></div>
+<div class="preview-color" style="background-color:#1ABC9C"></div>
+</div>
+</div>
+<h3 id="base16-flat-light">Base16 Flat Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#7F8C8D"></div>
+<div class="preview-color" style="background-color:#2C3E50"></div>
+<div class="preview-color" style="background-color:#E74C3C"></div>
+<div class="preview-color" style="background-color:#2ECC71"></div>
+<div class="preview-color" style="background-color:#F1C40F"></div>
+<div class="preview-color" style="background-color:#3498DB"></div>
+<div class="preview-color" style="background-color:#9B59B6"></div>
+<div class="preview-color" style="background-color:#1ABC9C"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#ECF0F1"></div>
+<div class="preview-color" style="background-color:#95A5A6"></div>
+<div class="preview-color" style="background-color:#E74C3C"></div>
+<div class="preview-color" style="background-color:#2ECC71"></div>
+<div class="preview-color" style="background-color:#F1C40F"></div>
+<div class="preview-color" style="background-color:#3498DB"></div>
+<div class="preview-color" style="background-color:#9B59B6"></div>
+<div class="preview-color" style="background-color:#1ABC9C"></div>
+</div>
+</div>
+<h3 id="base16-google-dark">Base16 Google Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#c5c8c6"></div>
+<div class="preview-color" style="background-color:#1d1f21"></div>
+<div class="preview-color" style="background-color:#CC342B"></div>
+<div class="preview-color" style="background-color:#198844"></div>
+<div class="preview-color" style="background-color:#FBA922"></div>
+<div class="preview-color" style="background-color:#3971ED"></div>
+<div class="preview-color" style="background-color:#A36AC7"></div>
+<div class="preview-color" style="background-color:#3971ED"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#1d1f21"></div>
+<div class="preview-color" style="background-color:#969896"></div>
+<div class="preview-color" style="background-color:#CC342B"></div>
+<div class="preview-color" style="background-color:#198844"></div>
+<div class="preview-color" style="background-color:#FBA922"></div>
+<div class="preview-color" style="background-color:#3971ED"></div>
+<div class="preview-color" style="background-color:#A36AC7"></div>
+<div class="preview-color" style="background-color:#3971ED"></div>
+</div>
+</div>
+<h3 id="base16-google-light">Base16 Google Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#373b41"></div>
+<div class="preview-color" style="background-color:#1d1f21"></div>
+<div class="preview-color" style="background-color:#CC342B"></div>
+<div class="preview-color" style="background-color:#198844"></div>
+<div class="preview-color" style="background-color:#FBA922"></div>
+<div class="preview-color" style="background-color:#3971ED"></div>
+<div class="preview-color" style="background-color:#A36AC7"></div>
+<div class="preview-color" style="background-color:#3971ED"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#ffffff"></div>
+<div class="preview-color" style="background-color:#969896"></div>
+<div class="preview-color" style="background-color:#CC342B"></div>
+<div class="preview-color" style="background-color:#198844"></div>
+<div class="preview-color" style="background-color:#FBA922"></div>
+<div class="preview-color" style="background-color:#3971ED"></div>
+<div class="preview-color" style="background-color:#A36AC7"></div>
+<div class="preview-color" style="background-color:#3971ED"></div>
+</div>
+</div>
+<h3 id="base16-grayscale-dark">Base16 Grayscale Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#b9b9b9"></div>
+<div class="preview-color" style="background-color:#101010"></div>
+<div class="preview-color" style="background-color:#7c7c7c"></div>
+<div class="preview-color" style="background-color:#8e8e8e"></div>
+<div class="preview-color" style="background-color:#a0a0a0"></div>
+<div class="preview-color" style="background-color:#686868"></div>
+<div class="preview-color" style="background-color:#747474"></div>
+<div class="preview-color" style="background-color:#868686"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#101010"></div>
+<div class="preview-color" style="background-color:#525252"></div>
+<div class="preview-color" style="background-color:#7c7c7c"></div>
+<div class="preview-color" style="background-color:#8e8e8e"></div>
+<div class="preview-color" style="background-color:#a0a0a0"></div>
+<div class="preview-color" style="background-color:#686868"></div>
+<div class="preview-color" style="background-color:#747474"></div>
+<div class="preview-color" style="background-color:#868686"></div>
+</div>
+</div>
+<h3 id="base16-grayscale-light">Base16 Grayscale Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#464646"></div>
+<div class="preview-color" style="background-color:#101010"></div>
+<div class="preview-color" style="background-color:#7c7c7c"></div>
+<div class="preview-color" style="background-color:#8e8e8e"></div>
+<div class="preview-color" style="background-color:#a0a0a0"></div>
+<div class="preview-color" style="background-color:#686868"></div>
+<div class="preview-color" style="background-color:#747474"></div>
+<div class="preview-color" style="background-color:#868686"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#f7f7f7"></div>
+<div class="preview-color" style="background-color:#525252"></div>
+<div class="preview-color" style="background-color:#7c7c7c"></div>
+<div class="preview-color" style="background-color:#8e8e8e"></div>
+<div class="preview-color" style="background-color:#a0a0a0"></div>
+<div class="preview-color" style="background-color:#686868"></div>
+<div class="preview-color" style="background-color:#747474"></div>
+<div class="preview-color" style="background-color:#868686"></div>
+</div>
+</div>
+<h3 id="base16-greenscreen-dark">Base16 Greenscreen Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#00bb00"></div>
+<div class="preview-color" style="background-color:#001100"></div>
+<div class="preview-color" style="background-color:#007700"></div>
+<div class="preview-color" style="background-color:#00bb00"></div>
+<div class="preview-color" style="background-color:#007700"></div>
+<div class="preview-color" style="background-color:#009900"></div>
+<div class="preview-color" style="background-color:#00bb00"></div>
+<div class="preview-color" style="background-color:#005500"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#001100"></div>
+<div class="preview-color" style="background-color:#007700"></div>
+<div class="preview-color" style="background-color:#007700"></div>
+<div class="preview-color" style="background-color:#00bb00"></div>
+<div class="preview-color" style="background-color:#007700"></div>
+<div class="preview-color" style="background-color:#009900"></div>
+<div class="preview-color" style="background-color:#00bb00"></div>
+<div class="preview-color" style="background-color:#005500"></div>
+</div>
+</div>
+<h3 id="base16-greenscreen-light">Base16 Greenscreen Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#005500"></div>
+<div class="preview-color" style="background-color:#001100"></div>
+<div class="preview-color" style="background-color:#007700"></div>
+<div class="preview-color" style="background-color:#00bb00"></div>
+<div class="preview-color" style="background-color:#007700"></div>
+<div class="preview-color" style="background-color:#009900"></div>
+<div class="preview-color" style="background-color:#00bb00"></div>
+<div class="preview-color" style="background-color:#005500"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#00ff00"></div>
+<div class="preview-color" style="background-color:#007700"></div>
+<div class="preview-color" style="background-color:#007700"></div>
+<div class="preview-color" style="background-color:#00bb00"></div>
+<div class="preview-color" style="background-color:#007700"></div>
+<div class="preview-color" style="background-color:#009900"></div>
+<div class="preview-color" style="background-color:#00bb00"></div>
+<div class="preview-color" style="background-color:#005500"></div>
+</div>
+</div>
+<h3 id="base16-harmonic16-dark">Base16 Harmonic16 Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#cbd6e2"></div>
+<div class="preview-color" style="background-color:#0b1c2c"></div>
+<div class="preview-color" style="background-color:#bf8b56"></div>
+<div class="preview-color" style="background-color:#56bf8b"></div>
+<div class="preview-color" style="background-color:#8bbf56"></div>
+<div class="preview-color" style="background-color:#8b56bf"></div>
+<div class="preview-color" style="background-color:#bf568b"></div>
+<div class="preview-color" style="background-color:#568bbf"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#0b1c2c"></div>
+<div class="preview-color" style="background-color:#627e99"></div>
+<div class="preview-color" style="background-color:#bf8b56"></div>
+<div class="preview-color" style="background-color:#56bf8b"></div>
+<div class="preview-color" style="background-color:#8bbf56"></div>
+<div class="preview-color" style="background-color:#8b56bf"></div>
+<div class="preview-color" style="background-color:#bf568b"></div>
+<div class="preview-color" style="background-color:#568bbf"></div>
+</div>
+</div>
+<h3 id="base16-harmonic16-light">Base16 Harmonic16 Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#405c79"></div>
+<div class="preview-color" style="background-color:#0b1c2c"></div>
+<div class="preview-color" style="background-color:#bf8b56"></div>
+<div class="preview-color" style="background-color:#56bf8b"></div>
+<div class="preview-color" style="background-color:#8bbf56"></div>
+<div class="preview-color" style="background-color:#8b56bf"></div>
+<div class="preview-color" style="background-color:#bf568b"></div>
+<div class="preview-color" style="background-color:#568bbf"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#f7f9fb"></div>
+<div class="preview-color" style="background-color:#627e99"></div>
+<div class="preview-color" style="background-color:#bf8b56"></div>
+<div class="preview-color" style="background-color:#56bf8b"></div>
+<div class="preview-color" style="background-color:#8bbf56"></div>
+<div class="preview-color" style="background-color:#8b56bf"></div>
+<div class="preview-color" style="background-color:#bf568b"></div>
+<div class="preview-color" style="background-color:#568bbf"></div>
+</div>
+</div>
+<h3 id="base16-isotope-dark">Base16 Isotope Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#d0d0d0"></div>
+<div class="preview-color" style="background-color:#000000"></div>
+<div class="preview-color" style="background-color:#ff0000"></div>
+<div class="preview-color" style="background-color:#33ff00"></div>
+<div class="preview-color" style="background-color:#ff0099"></div>
+<div class="preview-color" style="background-color:#0066ff"></div>
+<div class="preview-color" style="background-color:#cc00ff"></div>
+<div class="preview-color" style="background-color:#00ffff"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#000000"></div>
+<div class="preview-color" style="background-color:#808080"></div>
+<div class="preview-color" style="background-color:#ff0000"></div>
+<div class="preview-color" style="background-color:#33ff00"></div>
+<div class="preview-color" style="background-color:#ff0099"></div>
+<div class="preview-color" style="background-color:#0066ff"></div>
+<div class="preview-color" style="background-color:#cc00ff"></div>
+<div class="preview-color" style="background-color:#00ffff"></div>
+</div>
+</div>
+<h3 id="base16-isotope-light">Base16 Isotope Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#606060"></div>
+<div class="preview-color" style="background-color:#000000"></div>
+<div class="preview-color" style="background-color:#ff0000"></div>
+<div class="preview-color" style="background-color:#33ff00"></div>
+<div class="preview-color" style="background-color:#ff0099"></div>
+<div class="preview-color" style="background-color:#0066ff"></div>
+<div class="preview-color" style="background-color:#cc00ff"></div>
+<div class="preview-color" style="background-color:#00ffff"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#ffffff"></div>
+<div class="preview-color" style="background-color:#808080"></div>
+<div class="preview-color" style="background-color:#ff0000"></div>
+<div class="preview-color" style="background-color:#33ff00"></div>
+<div class="preview-color" style="background-color:#ff0099"></div>
+<div class="preview-color" style="background-color:#0066ff"></div>
+<div class="preview-color" style="background-color:#cc00ff"></div>
+<div class="preview-color" style="background-color:#00ffff"></div>
+</div>
+</div>
+<h3 id="base16-londontube-dark">Base16 Londontube Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#d9d8d8"></div>
+<div class="preview-color" style="background-color:#231f20"></div>
+<div class="preview-color" style="background-color:#ee2e24"></div>
+<div class="preview-color" style="background-color:#00853e"></div>
+<div class="preview-color" style="background-color:#ffd204"></div>
+<div class="preview-color" style="background-color:#009ddc"></div>
+<div class="preview-color" style="background-color:#98005d"></div>
+<div class="preview-color" style="background-color:#85cebc"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#231f20"></div>
+<div class="preview-color" style="background-color:#737171"></div>
+<div class="preview-color" style="background-color:#ee2e24"></div>
+<div class="preview-color" style="background-color:#00853e"></div>
+<div class="preview-color" style="background-color:#ffd204"></div>
+<div class="preview-color" style="background-color:#009ddc"></div>
+<div class="preview-color" style="background-color:#98005d"></div>
+<div class="preview-color" style="background-color:#85cebc"></div>
+</div>
+</div>
+<h3 id="base16-londontube-light">Base16 Londontube Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#5a5758"></div>
+<div class="preview-color" style="background-color:#231f20"></div>
+<div class="preview-color" style="background-color:#ee2e24"></div>
+<div class="preview-color" style="background-color:#00853e"></div>
+<div class="preview-color" style="background-color:#ffd204"></div>
+<div class="preview-color" style="background-color:#009ddc"></div>
+<div class="preview-color" style="background-color:#98005d"></div>
+<div class="preview-color" style="background-color:#85cebc"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#ffffff"></div>
+<div class="preview-color" style="background-color:#737171"></div>
+<div class="preview-color" style="background-color:#ee2e24"></div>
+<div class="preview-color" style="background-color:#00853e"></div>
+<div class="preview-color" style="background-color:#ffd204"></div>
+<div class="preview-color" style="background-color:#009ddc"></div>
+<div class="preview-color" style="background-color:#98005d"></div>
+<div class="preview-color" style="background-color:#85cebc"></div>
+</div>
+</div>
+<h3 id="base16-marrakesh-dark">Base16 Marrakesh Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#948e48"></div>
+<div class="preview-color" style="background-color:#201602"></div>
+<div class="preview-color" style="background-color:#c35359"></div>
+<div class="preview-color" style="background-color:#18974e"></div>
+<div class="preview-color" style="background-color:#a88339"></div>
+<div class="preview-color" style="background-color:#477ca1"></div>
+<div class="preview-color" style="background-color:#8868b3"></div>
+<div class="preview-color" style="background-color:#75a738"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#201602"></div>
+<div class="preview-color" style="background-color:#6c6823"></div>
+<div class="preview-color" style="background-color:#c35359"></div>
+<div class="preview-color" style="background-color:#18974e"></div>
+<div class="preview-color" style="background-color:#a88339"></div>
+<div class="preview-color" style="background-color:#477ca1"></div>
+<div class="preview-color" style="background-color:#8868b3"></div>
+<div class="preview-color" style="background-color:#75a738"></div>
+</div>
+</div>
+<h3 id="base16-marrakesh-light">Base16 Marrakesh Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#5f5b17"></div>
+<div class="preview-color" style="background-color:#201602"></div>
+<div class="preview-color" style="background-color:#c35359"></div>
+<div class="preview-color" style="background-color:#18974e"></div>
+<div class="preview-color" style="background-color:#a88339"></div>
+<div class="preview-color" style="background-color:#477ca1"></div>
+<div class="preview-color" style="background-color:#8868b3"></div>
+<div class="preview-color" style="background-color:#75a738"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#faf0a5"></div>
+<div class="preview-color" style="background-color:#6c6823"></div>
+<div class="preview-color" style="background-color:#c35359"></div>
+<div class="preview-color" style="background-color:#18974e"></div>
+<div class="preview-color" style="background-color:#a88339"></div>
+<div class="preview-color" style="background-color:#477ca1"></div>
+<div class="preview-color" style="background-color:#8868b3"></div>
+<div class="preview-color" style="background-color:#75a738"></div>
+</div>
+</div>
+<h3 id="base16-mocha-dark">Base16 Mocha Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#d0c8c6"></div>
+<div class="preview-color" style="background-color:#3B3228"></div>
+<div class="preview-color" style="background-color:#cb6077"></div>
+<div class="preview-color" style="background-color:#beb55b"></div>
+<div class="preview-color" style="background-color:#f4bc87"></div>
+<div class="preview-color" style="background-color:#8ab3b5"></div>
+<div class="preview-color" style="background-color:#a89bb9"></div>
+<div class="preview-color" style="background-color:#7bbda4"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#3B3228"></div>
+<div class="preview-color" style="background-color:#7e705a"></div>
+<div class="preview-color" style="background-color:#cb6077"></div>
+<div class="preview-color" style="background-color:#beb55b"></div>
+<div class="preview-color" style="background-color:#f4bc87"></div>
+<div class="preview-color" style="background-color:#8ab3b5"></div>
+<div class="preview-color" style="background-color:#a89bb9"></div>
+<div class="preview-color" style="background-color:#7bbda4"></div>
+</div>
+</div>
+<h3 id="base16-mocha-light">Base16 Mocha Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#645240"></div>
+<div class="preview-color" style="background-color:#3B3228"></div>
+<div class="preview-color" style="background-color:#cb6077"></div>
+<div class="preview-color" style="background-color:#beb55b"></div>
+<div class="preview-color" style="background-color:#f4bc87"></div>
+<div class="preview-color" style="background-color:#8ab3b5"></div>
+<div class="preview-color" style="background-color:#a89bb9"></div>
+<div class="preview-color" style="background-color:#7bbda4"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#f5eeeb"></div>
+<div class="preview-color" style="background-color:#7e705a"></div>
+<div class="preview-color" style="background-color:#cb6077"></div>
+<div class="preview-color" style="background-color:#beb55b"></div>
+<div class="preview-color" style="background-color:#f4bc87"></div>
+<div class="preview-color" style="background-color:#8ab3b5"></div>
+<div class="preview-color" style="background-color:#a89bb9"></div>
+<div class="preview-color" style="background-color:#7bbda4"></div>
+</div>
+</div>
+<h3 id="base16-monokai-dark">Base16 Monokai Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#f8f8f2"></div>
+<div class="preview-color" style="background-color:#272822"></div>
+<div class="preview-color" style="background-color:#f92672"></div>
+<div class="preview-color" style="background-color:#a6e22e"></div>
+<div class="preview-color" style="background-color:#f4bf75"></div>
+<div class="preview-color" style="background-color:#66d9ef"></div>
+<div class="preview-color" style="background-color:#ae81ff"></div>
+<div class="preview-color" style="background-color:#a1efe4"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#272822"></div>
+<div class="preview-color" style="background-color:#75715e"></div>
+<div class="preview-color" style="background-color:#f92672"></div>
+<div class="preview-color" style="background-color:#a6e22e"></div>
+<div class="preview-color" style="background-color:#f4bf75"></div>
+<div class="preview-color" style="background-color:#66d9ef"></div>
+<div class="preview-color" style="background-color:#ae81ff"></div>
+<div class="preview-color" style="background-color:#a1efe4"></div>
+</div>
+</div>
+<h3 id="base16-monokai-light">Base16 Monokai Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#49483e"></div>
+<div class="preview-color" style="background-color:#272822"></div>
+<div class="preview-color" style="background-color:#f92672"></div>
+<div class="preview-color" style="background-color:#a6e22e"></div>
+<div class="preview-color" style="background-color:#f4bf75"></div>
+<div class="preview-color" style="background-color:#66d9ef"></div>
+<div class="preview-color" style="background-color:#ae81ff"></div>
+<div class="preview-color" style="background-color:#a1efe4"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#f9f8f5"></div>
+<div class="preview-color" style="background-color:#75715e"></div>
+<div class="preview-color" style="background-color:#f92672"></div>
+<div class="preview-color" style="background-color:#a6e22e"></div>
+<div class="preview-color" style="background-color:#f4bf75"></div>
+<div class="preview-color" style="background-color:#66d9ef"></div>
+<div class="preview-color" style="background-color:#ae81ff"></div>
+<div class="preview-color" style="background-color:#a1efe4"></div>
+</div>
+</div>
+<h3 id="base16-ocean-dark">Base16 Ocean Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#c0c5ce"></div>
+<div class="preview-color" style="background-color:#2b303b"></div>
+<div class="preview-color" style="background-color:#bf616a"></div>
+<div class="preview-color" style="background-color:#a3be8c"></div>
+<div class="preview-color" style="background-color:#ebcb8b"></div>
+<div class="preview-color" style="background-color:#8fa1b3"></div>
+<div class="preview-color" style="background-color:#b48ead"></div>
+<div class="preview-color" style="background-color:#96b5b4"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#2b303b"></div>
+<div class="preview-color" style="background-color:#65737e"></div>
+<div class="preview-color" style="background-color:#bf616a"></div>
+<div class="preview-color" style="background-color:#a3be8c"></div>
+<div class="preview-color" style="background-color:#ebcb8b"></div>
+<div class="preview-color" style="background-color:#8fa1b3"></div>
+<div class="preview-color" style="background-color:#b48ead"></div>
+<div class="preview-color" style="background-color:#96b5b4"></div>
+</div>
+</div>
+<h3 id="base16-ocean-light">Base16 Ocean Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#4f5b66"></div>
+<div class="preview-color" style="background-color:#2b303b"></div>
+<div class="preview-color" style="background-color:#bf616a"></div>
+<div class="preview-color" style="background-color:#a3be8c"></div>
+<div class="preview-color" style="background-color:#ebcb8b"></div>
+<div class="preview-color" style="background-color:#8fa1b3"></div>
+<div class="preview-color" style="background-color:#b48ead"></div>
+<div class="preview-color" style="background-color:#96b5b4"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#eff1f5"></div>
+<div class="preview-color" style="background-color:#65737e"></div>
+<div class="preview-color" style="background-color:#bf616a"></div>
+<div class="preview-color" style="background-color:#a3be8c"></div>
+<div class="preview-color" style="background-color:#ebcb8b"></div>
+<div class="preview-color" style="background-color:#8fa1b3"></div>
+<div class="preview-color" style="background-color:#b48ead"></div>
+<div class="preview-color" style="background-color:#96b5b4"></div>
+</div>
+</div>
+<h3 id="base16-paraiso-dark">Base16 Paraiso Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#a39e9b"></div>
+<div class="preview-color" style="background-color:#2f1e2e"></div>
+<div class="preview-color" style="background-color:#ef6155"></div>
+<div class="preview-color" style="background-color:#48b685"></div>
+<div class="preview-color" style="background-color:#fec418"></div>
+<div class="preview-color" style="background-color:#06b6ef"></div>
+<div class="preview-color" style="background-color:#815ba4"></div>
+<div class="preview-color" style="background-color:#5bc4bf"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#2f1e2e"></div>
+<div class="preview-color" style="background-color:#776e71"></div>
+<div class="preview-color" style="background-color:#ef6155"></div>
+<div class="preview-color" style="background-color:#48b685"></div>
+<div class="preview-color" style="background-color:#fec418"></div>
+<div class="preview-color" style="background-color:#06b6ef"></div>
+<div class="preview-color" style="background-color:#815ba4"></div>
+<div class="preview-color" style="background-color:#5bc4bf"></div>
+</div>
+</div>
+<h3 id="base16-paraiso-light">Base16 Paraiso Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#4f424c"></div>
+<div class="preview-color" style="background-color:#2f1e2e"></div>
+<div class="preview-color" style="background-color:#ef6155"></div>
+<div class="preview-color" style="background-color:#48b685"></div>
+<div class="preview-color" style="background-color:#fec418"></div>
+<div class="preview-color" style="background-color:#06b6ef"></div>
+<div class="preview-color" style="background-color:#815ba4"></div>
+<div class="preview-color" style="background-color:#5bc4bf"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#e7e9db"></div>
+<div class="preview-color" style="background-color:#776e71"></div>
+<div class="preview-color" style="background-color:#ef6155"></div>
+<div class="preview-color" style="background-color:#48b685"></div>
+<div class="preview-color" style="background-color:#fec418"></div>
+<div class="preview-color" style="background-color:#06b6ef"></div>
+<div class="preview-color" style="background-color:#815ba4"></div>
+<div class="preview-color" style="background-color:#5bc4bf"></div>
+</div>
+</div>
+<h3 id="base16-railscasts-dark">Base16 Railscasts Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#e6e1dc"></div>
+<div class="preview-color" style="background-color:#2b2b2b"></div>
+<div class="preview-color" style="background-color:#da4939"></div>
+<div class="preview-color" style="background-color:#a5c261"></div>
+<div class="preview-color" style="background-color:#ffc66d"></div>
+<div class="preview-color" style="background-color:#6d9cbe"></div>
+<div class="preview-color" style="background-color:#b6b3eb"></div>
+<div class="preview-color" style="background-color:#519f50"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#2b2b2b"></div>
+<div class="preview-color" style="background-color:#5a647e"></div>
+<div class="preview-color" style="background-color:#da4939"></div>
+<div class="preview-color" style="background-color:#a5c261"></div>
+<div class="preview-color" style="background-color:#ffc66d"></div>
+<div class="preview-color" style="background-color:#6d9cbe"></div>
+<div class="preview-color" style="background-color:#b6b3eb"></div>
+<div class="preview-color" style="background-color:#519f50"></div>
+</div>
+</div>
+<h3 id="base16-railscasts-light">Base16 Railscasts Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#3a4055"></div>
+<div class="preview-color" style="background-color:#2b2b2b"></div>
+<div class="preview-color" style="background-color:#da4939"></div>
+<div class="preview-color" style="background-color:#a5c261"></div>
+<div class="preview-color" style="background-color:#ffc66d"></div>
+<div class="preview-color" style="background-color:#6d9cbe"></div>
+<div class="preview-color" style="background-color:#b6b3eb"></div>
+<div class="preview-color" style="background-color:#519f50"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#f9f7f3"></div>
+<div class="preview-color" style="background-color:#5a647e"></div>
+<div class="preview-color" style="background-color:#da4939"></div>
+<div class="preview-color" style="background-color:#a5c261"></div>
+<div class="preview-color" style="background-color:#ffc66d"></div>
+<div class="preview-color" style="background-color:#6d9cbe"></div>
+<div class="preview-color" style="background-color:#b6b3eb"></div>
+<div class="preview-color" style="background-color:#519f50"></div>
+</div>
+</div>
+<h3 id="base16-shapeshifter-dark">Base16 Shapeshifter Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#ababab"></div>
+<div class="preview-color" style="background-color:#000000"></div>
+<div class="preview-color" style="background-color:#e92f2f"></div>
+<div class="preview-color" style="background-color:#0ed839"></div>
+<div class="preview-color" style="background-color:#dddd13"></div>
+<div class="preview-color" style="background-color:#3b48e3"></div>
+<div class="preview-color" style="background-color:#f996e2"></div>
+<div class="preview-color" style="background-color:#23edda"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#000000"></div>
+<div class="preview-color" style="background-color:#343434"></div>
+<div class="preview-color" style="background-color:#e92f2f"></div>
+<div class="preview-color" style="background-color:#0ed839"></div>
+<div class="preview-color" style="background-color:#dddd13"></div>
+<div class="preview-color" style="background-color:#3b48e3"></div>
+<div class="preview-color" style="background-color:#f996e2"></div>
+<div class="preview-color" style="background-color:#23edda"></div>
+</div>
+</div>
+<h3 id="base16-shapeshifter-light">Base16 Shapeshifter Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#102015"></div>
+<div class="preview-color" style="background-color:#000000"></div>
+<div class="preview-color" style="background-color:#e92f2f"></div>
+<div class="preview-color" style="background-color:#0ed839"></div>
+<div class="preview-color" style="background-color:#dddd13"></div>
+<div class="preview-color" style="background-color:#3b48e3"></div>
+<div class="preview-color" style="background-color:#f996e2"></div>
+<div class="preview-color" style="background-color:#23edda"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#f9f9f9"></div>
+<div class="preview-color" style="background-color:#343434"></div>
+<div class="preview-color" style="background-color:#e92f2f"></div>
+<div class="preview-color" style="background-color:#0ed839"></div>
+<div class="preview-color" style="background-color:#dddd13"></div>
+<div class="preview-color" style="background-color:#3b48e3"></div>
+<div class="preview-color" style="background-color:#f996e2"></div>
+<div class="preview-color" style="background-color:#23edda"></div>
+</div>
+</div>
+<h3 id="base16-solarized-dark">Base16 Solarized Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#93a1a1"></div>
+<div class="preview-color" style="background-color:#002b36"></div>
+<div class="preview-color" style="background-color:#dc322f"></div>
+<div class="preview-color" style="background-color:#859900"></div>
+<div class="preview-color" style="background-color:#b58900"></div>
+<div class="preview-color" style="background-color:#268bd2"></div>
+<div class="preview-color" style="background-color:#6c71c4"></div>
+<div class="preview-color" style="background-color:#2aa198"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#002b36"></div>
+<div class="preview-color" style="background-color:#657b83"></div>
+<div class="preview-color" style="background-color:#dc322f"></div>
+<div class="preview-color" style="background-color:#859900"></div>
+<div class="preview-color" style="background-color:#b58900"></div>
+<div class="preview-color" style="background-color:#268bd2"></div>
+<div class="preview-color" style="background-color:#6c71c4"></div>
+<div class="preview-color" style="background-color:#2aa198"></div>
+</div>
+</div>
+<h3 id="base16-solarized-light">Base16 Solarized Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#586e75"></div>
+<div class="preview-color" style="background-color:#002b36"></div>
+<div class="preview-color" style="background-color:#dc322f"></div>
+<div class="preview-color" style="background-color:#859900"></div>
+<div class="preview-color" style="background-color:#b58900"></div>
+<div class="preview-color" style="background-color:#268bd2"></div>
+<div class="preview-color" style="background-color:#6c71c4"></div>
+<div class="preview-color" style="background-color:#2aa198"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#fdf6e3"></div>
+<div class="preview-color" style="background-color:#657b83"></div>
+<div class="preview-color" style="background-color:#cb4b16"></div>
+<div class="preview-color" style="background-color:#073642"></div>
+<div class="preview-color" style="background-color:#586e75"></div>
+<div class="preview-color" style="background-color:#839496"></div>
+<div class="preview-color" style="background-color:#eee8d5"></div>
+<div class="preview-color" style="background-color:#d33682"></div>
+</div>
+</div>
+<h3 id="base16-summerfruit-dark">Base16 Summerfruit Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#D0D0D0"></div>
+<div class="preview-color" style="background-color:#151515"></div>
+<div class="preview-color" style="background-color:#FF0086"></div>
+<div class="preview-color" style="background-color:#00C918"></div>
+<div class="preview-color" style="background-color:#ABA800"></div>
+<div class="preview-color" style="background-color:#3777E6"></div>
+<div class="preview-color" style="background-color:#AD00A1"></div>
+<div class="preview-color" style="background-color:#1faaaa"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#151515"></div>
+<div class="preview-color" style="background-color:#505050"></div>
+<div class="preview-color" style="background-color:#FF0086"></div>
+<div class="preview-color" style="background-color:#00C918"></div>
+<div class="preview-color" style="background-color:#ABA800"></div>
+<div class="preview-color" style="background-color:#3777E6"></div>
+<div class="preview-color" style="background-color:#AD00A1"></div>
+<div class="preview-color" style="background-color:#1faaaa"></div>
+</div>
+</div>
+<h3 id="base16-summerfruit-light">Base16 Summerfruit Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#303030"></div>
+<div class="preview-color" style="background-color:#151515"></div>
+<div class="preview-color" style="background-color:#FF0086"></div>
+<div class="preview-color" style="background-color:#00C918"></div>
+<div class="preview-color" style="background-color:#ABA800"></div>
+<div class="preview-color" style="background-color:#3777E6"></div>
+<div class="preview-color" style="background-color:#AD00A1"></div>
+<div class="preview-color" style="background-color:#1faaaa"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#FFFFFF"></div>
+<div class="preview-color" style="background-color:#505050"></div>
+<div class="preview-color" style="background-color:#FF0086"></div>
+<div class="preview-color" style="background-color:#00C918"></div>
+<div class="preview-color" style="background-color:#ABA800"></div>
+<div class="preview-color" style="background-color:#3777E6"></div>
+<div class="preview-color" style="background-color:#AD00A1"></div>
+<div class="preview-color" style="background-color:#1faaaa"></div>
+</div>
+</div>
+<h3 id="base16-tomorrow-dark">Base16 Tomorrow Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#c5c8c6"></div>
+<div class="preview-color" style="background-color:#1d1f21"></div>
+<div class="preview-color" style="background-color:#cc6666"></div>
+<div class="preview-color" style="background-color:#b5bd68"></div>
+<div class="preview-color" style="background-color:#f0c674"></div>
+<div class="preview-color" style="background-color:#81a2be"></div>
+<div class="preview-color" style="background-color:#b294bb"></div>
+<div class="preview-color" style="background-color:#8abeb7"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#1d1f21"></div>
+<div class="preview-color" style="background-color:#969896"></div>
+<div class="preview-color" style="background-color:#cc6666"></div>
+<div class="preview-color" style="background-color:#b5bd68"></div>
+<div class="preview-color" style="background-color:#f0c674"></div>
+<div class="preview-color" style="background-color:#81a2be"></div>
+<div class="preview-color" style="background-color:#b294bb"></div>
+<div class="preview-color" style="background-color:#8abeb7"></div>
+</div>
+</div>
+<h3 id="base16-tomorrow-light">Base16 Tomorrow Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#373b41"></div>
+<div class="preview-color" style="background-color:#1d1f21"></div>
+<div class="preview-color" style="background-color:#cc6666"></div>
+<div class="preview-color" style="background-color:#b5bd68"></div>
+<div class="preview-color" style="background-color:#f0c674"></div>
+<div class="preview-color" style="background-color:#81a2be"></div>
+<div class="preview-color" style="background-color:#b294bb"></div>
+<div class="preview-color" style="background-color:#8abeb7"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#ffffff"></div>
+<div class="preview-color" style="background-color:#969896"></div>
+<div class="preview-color" style="background-color:#cc6666"></div>
+<div class="preview-color" style="background-color:#b5bd68"></div>
+<div class="preview-color" style="background-color:#f0c674"></div>
+<div class="preview-color" style="background-color:#81a2be"></div>
+<div class="preview-color" style="background-color:#b294bb"></div>
+<div class="preview-color" style="background-color:#8abeb7"></div>
+</div>
+</div>
+<h3 id="base16-twilight-dark">Base16 Twilight Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#a7a7a7"></div>
+<div class="preview-color" style="background-color:#1e1e1e"></div>
+<div class="preview-color" style="background-color:#cf6a4c"></div>
+<div class="preview-color" style="background-color:#8f9d6a"></div>
+<div class="preview-color" style="background-color:#f9ee98"></div>
+<div class="preview-color" style="background-color:#7587a6"></div>
+<div class="preview-color" style="background-color:#9b859d"></div>
+<div class="preview-color" style="background-color:#afc4db"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#1e1e1e"></div>
+<div class="preview-color" style="background-color:#5f5a60"></div>
+<div class="preview-color" style="background-color:#cf6a4c"></div>
+<div class="preview-color" style="background-color:#8f9d6a"></div>
+<div class="preview-color" style="background-color:#f9ee98"></div>
+<div class="preview-color" style="background-color:#7587a6"></div>
+<div class="preview-color" style="background-color:#9b859d"></div>
+<div class="preview-color" style="background-color:#afc4db"></div>
+</div>
+</div>
+<h3 id="base16-twilight-light">Base16 Twilight Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#464b50"></div>
+<div class="preview-color" style="background-color:#1e1e1e"></div>
+<div class="preview-color" style="background-color:#cf6a4c"></div>
+<div class="preview-color" style="background-color:#8f9d6a"></div>
+<div class="preview-color" style="background-color:#f9ee98"></div>
+<div class="preview-color" style="background-color:#7587a6"></div>
+<div class="preview-color" style="background-color:#9b859d"></div>
+<div class="preview-color" style="background-color:#afc4db"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#ffffff"></div>
+<div class="preview-color" style="background-color:#5f5a60"></div>
+<div class="preview-color" style="background-color:#cf6a4c"></div>
+<div class="preview-color" style="background-color:#8f9d6a"></div>
+<div class="preview-color" style="background-color:#f9ee98"></div>
+<div class="preview-color" style="background-color:#7587a6"></div>
+<div class="preview-color" style="background-color:#9b859d"></div>
+<div class="preview-color" style="background-color:#afc4db"></div>
+</div>
+</div>
+<h3 id="dracula">Dracula</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#f8f8f2"></div>
+<div class="preview-color" style="background-color:#000000"></div>
+<div class="preview-color" style="background-color:#ff5555"></div>
+<div class="preview-color" style="background-color:#50fa7b"></div>
+<div class="preview-color" style="background-color:#f1fa8c"></div>
+<div class="preview-color" style="background-color:#caa9fa"></div>
+<div class="preview-color" style="background-color:#ff79c6"></div>
+<div class="preview-color" style="background-color:#8be9fd"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#282a36"></div>
+<div class="preview-color" style="background-color:#4d4d4d"></div>
+<div class="preview-color" style="background-color:#ff6e67"></div>
+<div class="preview-color" style="background-color:#5af78e"></div>
+<div class="preview-color" style="background-color:#f4f99d"></div>
+<div class="preview-color" style="background-color:#caa9fa"></div>
+<div class="preview-color" style="background-color:#ff92d0"></div>
+<div class="preview-color" style="background-color:#9aedfe"></div>
+</div>
+</div>
+<h3 id="gnometerm">Gnometerm</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:none"></div>
+<div class="preview-color" style="background-color:#000000"></div>
+<div class="preview-color" style="background-color:#cc0000"></div>
+<div class="preview-color" style="background-color:#4e9a06"></div>
+<div class="preview-color" style="background-color:#c4a000"></div>
+<div class="preview-color" style="background-color:#3465a4"></div>
+<div class="preview-color" style="background-color:#75507b"></div>
+<div class="preview-color" style="background-color:#06989a"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:none"></div>
+<div class="preview-color" style="background-color:#555753"></div>
+<div class="preview-color" style="background-color:#ef2929"></div>
+<div class="preview-color" style="background-color:#8ae234"></div>
+<div class="preview-color" style="background-color:#fce94f"></div>
+<div class="preview-color" style="background-color:#729fcf"></div>
+<div class="preview-color" style="background-color:#ad7fa8"></div>
+<div class="preview-color" style="background-color:#34e2e2"></div>
+</div>
+</div>
+<h3 id="gotham">Gotham</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#98d1ce"></div>
+<div class="preview-color" style="background-color:#0a0f14"></div>
+<div class="preview-color" style="background-color:#c33027"></div>
+<div class="preview-color" style="background-color:#26a98b"></div>
+<div class="preview-color" style="background-color:#edb54b"></div>
+<div class="preview-color" style="background-color:#195465"></div>
+<div class="preview-color" style="background-color:#4e5165"></div>
+<div class="preview-color" style="background-color:#33859d"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#0a0f14"></div>
+<div class="preview-color" style="background-color:#10151b"></div>
+<div class="preview-color" style="background-color:#d26939"></div>
+<div class="preview-color" style="background-color:#081f2d"></div>
+<div class="preview-color" style="background-color:#245361"></div>
+<div class="preview-color" style="background-color:#093748"></div>
+<div class="preview-color" style="background-color:#888ba5"></div>
+<div class="preview-color" style="background-color:#599caa"></div>
+</div>
+</div>
+<h3 id="gruvbox-dark">Gruvbox Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#ebdbb2"></div>
+<div class="preview-color" style="background-color:#282828"></div>
+<div class="preview-color" style="background-color:#cc241d"></div>
+<div class="preview-color" style="background-color:#98971a"></div>
+<div class="preview-color" style="background-color:#d79921"></div>
+<div class="preview-color" style="background-color:#458588"></div>
+<div class="preview-color" style="background-color:#b16286"></div>
+<div class="preview-color" style="background-color:#689d6a"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#1d2021"></div>
+<div class="preview-color" style="background-color:#928374"></div>
+<div class="preview-color" style="background-color:#fb4934"></div>
+<div class="preview-color" style="background-color:#b8bb26"></div>
+<div class="preview-color" style="background-color:#fabd2f"></div>
+<div class="preview-color" style="background-color:#83a598"></div>
+<div class="preview-color" style="background-color:#d3869b"></div>
+<div class="preview-color" style="background-color:#8ec07c"></div>
+</div>
+</div>
+<h3 id="gruvbox-light">Gruvbox Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#3c3836"></div>
+<div class="preview-color" style="background-color:#fdf4c1"></div>
+<div class="preview-color" style="background-color:#cc241d"></div>
+<div class="preview-color" style="background-color:#98971a"></div>
+<div class="preview-color" style="background-color:#d79921"></div>
+<div class="preview-color" style="background-color:#458588"></div>
+<div class="preview-color" style="background-color:#b16286"></div>
+<div class="preview-color" style="background-color:#689d6a"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#f9f5d7"></div>
+<div class="preview-color" style="background-color:#928374"></div>
+<div class="preview-color" style="background-color:#9d0006"></div>
+<div class="preview-color" style="background-color:#79740e"></div>
+<div class="preview-color" style="background-color:#b57614"></div>
+<div class="preview-color" style="background-color:#076678"></div>
+<div class="preview-color" style="background-color:#8f3f71"></div>
+<div class="preview-color" style="background-color:#427b58"></div>
+</div>
+</div>
+<h3 id="material">Material</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#eceff1"></div>
+<div class="preview-color" style="background-color:#263238"></div>
+<div class="preview-color" style="background-color:#ff9800"></div>
+<div class="preview-color" style="background-color:#8bc34a"></div>
+<div class="preview-color" style="background-color:#ffc107"></div>
+<div class="preview-color" style="background-color:#03a9f4"></div>
+<div class="preview-color" style="background-color:#e91e63"></div>
+<div class="preview-color" style="background-color:#009688"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#263238"></div>
+<div class="preview-color" style="background-color:#37474f"></div>
+<div class="preview-color" style="background-color:#ffa74d"></div>
+<div class="preview-color" style="background-color:#9ccc65"></div>
+<div class="preview-color" style="background-color:#ffa000"></div>
+<div class="preview-color" style="background-color:#81d4fa"></div>
+<div class="preview-color" style="background-color:#ad1457"></div>
+<div class="preview-color" style="background-color:#26a69a"></div>
+</div>
+</div>
+<h3 id="nancy">Nancy</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#fff"></div>
+<div class="preview-color" style="background-color:#1b1d1e"></div>
+<div class="preview-color" style="background-color:#f92672"></div>
+<div class="preview-color" style="background-color:#82b414"></div>
+<div class="preview-color" style="background-color:#fd971f"></div>
+<div class="preview-color" style="background-color:#4e82aa"></div>
+<div class="preview-color" style="background-color:#8c54fe"></div>
+<div class="preview-color" style="background-color:#465457"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#010101"></div>
+<div class="preview-color" style="background-color:#505354"></div>
+<div class="preview-color" style="background-color:#ff5995"></div>
+<div class="preview-color" style="background-color:#b6e354"></div>
+<div class="preview-color" style="background-color:#feed6c"></div>
+<div class="preview-color" style="background-color:#0c73c2"></div>
+<div class="preview-color" style="background-color:#9e6ffe"></div>
+<div class="preview-color" style="background-color:#899ca1"></div>
+</div>
+</div>
+<h3 id="neon">Neon</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#F8F8F8"></div>
+<div class="preview-color" style="background-color:#171717"></div>
+<div class="preview-color" style="background-color:#D81765"></div>
+<div class="preview-color" style="background-color:#97D01A"></div>
+<div class="preview-color" style="background-color:#FFA800"></div>
+<div class="preview-color" style="background-color:#16B1FB"></div>
+<div class="preview-color" style="background-color:#FF2491"></div>
+<div class="preview-color" style="background-color:#0FDCB6"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#171717"></div>
+<div class="preview-color" style="background-color:#38252C"></div>
+<div class="preview-color" style="background-color:#FF0000"></div>
+<div class="preview-color" style="background-color:#76B639"></div>
+<div class="preview-color" style="background-color:#E1A126"></div>
+<div class="preview-color" style="background-color:#289CD5"></div>
+<div class="preview-color" style="background-color:#FF2491"></div>
+<div class="preview-color" style="background-color:#0A9B81"></div>
+</div>
+</div>
+<h3 id="rydgel">Rydgel</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:none"></div>
+<div class="preview-color" style="background-color:#303430"></div>
+<div class="preview-color" style="background-color:#bf7979"></div>
+<div class="preview-color" style="background-color:#97b26b"></div>
+<div class="preview-color" style="background-color:#cdcdc1"></div>
+<div class="preview-color" style="background-color:#86a2be"></div>
+<div class="preview-color" style="background-color:#d9b798"></div>
+<div class="preview-color" style="background-color:#a1b5cd"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:none"></div>
+<div class="preview-color" style="background-color:#cdb5cd"></div>
+<div class="preview-color" style="background-color:#f4a45f"></div>
+<div class="preview-color" style="background-color:#c5f779"></div>
+<div class="preview-color" style="background-color:#ffffed"></div>
+<div class="preview-color" style="background-color:#98afd9"></div>
+<div class="preview-color" style="background-color:#d7d998"></div>
+<div class="preview-color" style="background-color:#a1b5cd"></div>
+</div>
+</div>
+<h3 id="solarized-dark">Solarized Dark</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#839496"></div>
+<div class="preview-color" style="background-color:#073642"></div>
+<div class="preview-color" style="background-color:#dc322f"></div>
+<div class="preview-color" style="background-color:#859900"></div>
+<div class="preview-color" style="background-color:#b58900"></div>
+<div class="preview-color" style="background-color:#268bd2"></div>
+<div class="preview-color" style="background-color:#d33682"></div>
+<div class="preview-color" style="background-color:#2aa198"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#002b36"></div>
+<div class="preview-color" style="background-color:#002b36"></div>
+<div class="preview-color" style="background-color:#cb4b16"></div>
+<div class="preview-color" style="background-color:#586e75"></div>
+<div class="preview-color" style="background-color:#657b83"></div>
+<div class="preview-color" style="background-color:#839496"></div>
+<div class="preview-color" style="background-color:#6c71c4"></div>
+<div class="preview-color" style="background-color:#93a1a1"></div>
+</div>
+</div>
+<h3 id="solarized-light">Solarized Light</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#657b83"></div>
+<div class="preview-color" style="background-color:#073642"></div>
+<div class="preview-color" style="background-color:#dc322f"></div>
+<div class="preview-color" style="background-color:#859900"></div>
+<div class="preview-color" style="background-color:#b58900"></div>
+<div class="preview-color" style="background-color:#268bd2"></div>
+<div class="preview-color" style="background-color:#d33682"></div>
+<div class="preview-color" style="background-color:#2aa198"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#fdf6e3"></div>
+<div class="preview-color" style="background-color:#002b36"></div>
+<div class="preview-color" style="background-color:#cb4b16"></div>
+<div class="preview-color" style="background-color:#586e75"></div>
+<div class="preview-color" style="background-color:#657b83"></div>
+<div class="preview-color" style="background-color:#839496"></div>
+<div class="preview-color" style="background-color:#6c71c4"></div>
+<div class="preview-color" style="background-color:#93a1a1"></div>
+</div>
+</div>
+<h3 id="tomorrow-night">Tomorrow Night</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#c5c8c6"></div>
+<div class="preview-color" style="background-color:#1d1f21"></div>
+<div class="preview-color" style="background-color:#cc6666"></div>
+<div class="preview-color" style="background-color:#b5bd68"></div>
+<div class="preview-color" style="background-color:#f0c674"></div>
+<div class="preview-color" style="background-color:#81a2be"></div>
+<div class="preview-color" style="background-color:#b294bb"></div>
+<div class="preview-color" style="background-color:#8abeb7"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#1d1f21"></div>
+<div class="preview-color" style="background-color:#cc6666"></div>
+<div class="preview-color" style="background-color:#969896"></div>
+<div class="preview-color" style="background-color:#b5bd68"></div>
+<div class="preview-color" style="background-color:#f0c674"></div>
+<div class="preview-color" style="background-color:#81a2be"></div>
+<div class="preview-color" style="background-color:#b294bb"></div>
+<div class="preview-color" style="background-color:#8abeb7"></div>
+</div>
+</div>
+<h3 id="zenburn">Zenburn</h3>
+<div class="preview-color-block">
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#ffffff"></div>
+<div class="preview-color" style="background-color:#000000"></div>
+<div class="preview-color" style="background-color:#9e1828"></div>
+<div class="preview-color" style="background-color:#aece92"></div>
+<div class="preview-color" style="background-color:#968a38"></div>
+<div class="preview-color" style="background-color:#414171"></div>
+<div class="preview-color" style="background-color:#963c59"></div>
+<div class="preview-color" style="background-color:#418179"></div>
+</div>
+<div class="preview-color-row">
+<div class="preview-color" style="background-color:#000010"></div>
+<div class="preview-color" style="background-color:#666666"></div>
+<div class="preview-color" style="background-color:#cf6171"></div>
+<div class="preview-color" style="background-color:#c5f779"></div>
+<div class="preview-color" style="background-color:#fff796"></div>
+<div class="preview-color" style="background-color:#4186be"></div>
+<div class="preview-color" style="background-color:#cf9ebe"></div>
+<div class="preview-color" style="background-color:#71bebe"></div>
+</div>
+</div>

--- a/add-on-styling.md
+++ b/add-on-styling.md
@@ -6,6 +6,7 @@ title: Termux:Styling add-on
 This add-on provides color schemes and fonts to customize the appearance of the Termux terminal.
 
 - [See more and install from Google Play](https://play.google.com/store/apps/details?id=com.termux.styling)
+- [Preview of available color schemes](add-on-styling-color-preview.html)
 
 ![Screenshot](https://lh3.googleusercontent.com/fns10rc005k3f3orbAcirMlquJU-mrFUt_6_gZHM7N0RUke4HPIGCeK_COAyaWYIq-ya=h310-rw)
 ![Screenshot](https://lh3.googleusercontent.com/gDJt1ji27uDHrX58wwhPhXPGqBu6RFtEMR2b3OThqP-_wVa9gIrYYKXiW9TGY2YQ9xM=h310-rw)


### PR DESCRIPTION
Since the last update added so many new color schemes, I decided to create this helpful preview page.

![screenshot_20160801-160027](https://cloud.githubusercontent.com/assets/7983745/17296921/bae9fc66-5803-11e6-8e4b-35c3ebcb1b7c.png)

I created a script to parse the color schemes directly to the markdown file.
https://github.com/Neo-Oli/termux-styling-preview