### PR TITLE
Add code example previews and navigation for color preview page

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -202,15 +202,30 @@ pre {
         }
     }
 }
-.preview-color{
-	float:left;
-	padding-top:12.5%;
-	width:12.5%;
+/*
+ * Color Previews
+ */
+.preview-color {
+  float: left;
+  padding-top: calc(100% / 8);
+  width: calc(100% / 8); 
+  border-left: 1px solid white;
+  border-bottom: 1px solid white;
+  box-sizing: border-box;
 }
-.preview-color-row{
-	overflow:auto;
-	width:100%;
+.preview-color-row {
+  overflow: auto;
+  width: 100%; }
+
+.preview-color-block {
+  max-width: 300px;
+  margin: 0 auto;
 }
-.preview-color-block{
-	margin-bottom:15px;
+.codeexample{
+  max-width: 300px;
+  margin:0 auto;
+	*{
+		font-size: 8px;
+		line-height:8px;
+	}
 }

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -225,7 +225,7 @@ pre {
   max-width: 300px;
   margin:0 auto;
 	*{
-		font-size: 8px;
-		line-height:8px;
+		font-size: 9px;
+		line-height: 9px;
 	}
 }

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -226,6 +226,6 @@ pre {
   margin:0 auto;
 	*{
 		font-size: 9px;
-		line-height: 9px;
+		line-height: 11px;
 	}
 }

--- a/add-on-styling-color-preview.md
+++ b/add-on-styling-color-preview.md
@@ -2,1912 +2,2496 @@
 layout: page
 title: Preview of color schemes
 ---
-<h3 id="base16-3024-dark">Base16 3024 Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#a5a2a2"></div>
-<div class="preview-color" style="background-color:#090300"></div>
-<div class="preview-color" style="background-color:#db2d20"></div>
-<div class="preview-color" style="background-color:#01a252"></div>
-<div class="preview-color" style="background-color:#fded02"></div>
-<div class="preview-color" style="background-color:#01a0e4"></div>
-<div class="preview-color" style="background-color:#a16a94"></div>
-<div class="preview-color" style="background-color:#b5e4f4"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#090300"></div>
-<div class="preview-color" style="background-color:#5c5855"></div>
-<div class="preview-color" style="background-color:#db2d20"></div>
-<div class="preview-color" style="background-color:#01a252"></div>
-<div class="preview-color" style="background-color:#fded02"></div>
-<div class="preview-color" style="background-color:#01a0e4"></div>
-<div class="preview-color" style="background-color:#a16a94"></div>
-<div class="preview-color" style="background-color:#b5e4f4"></div>
-</div>
-</div>
-<h3 id="base16-3024-light">Base16 3024 Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#4a4543"></div>
-<div class="preview-color" style="background-color:#090300"></div>
-<div class="preview-color" style="background-color:#db2d20"></div>
-<div class="preview-color" style="background-color:#01a252"></div>
-<div class="preview-color" style="background-color:#fded02"></div>
-<div class="preview-color" style="background-color:#01a0e4"></div>
-<div class="preview-color" style="background-color:#a16a94"></div>
-<div class="preview-color" style="background-color:#b5e4f4"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#f7f7f7"></div>
-<div class="preview-color" style="background-color:#5c5855"></div>
-<div class="preview-color" style="background-color:#db2d20"></div>
-<div class="preview-color" style="background-color:#01a252"></div>
-<div class="preview-color" style="background-color:#fded02"></div>
-<div class="preview-color" style="background-color:#01a0e4"></div>
-<div class="preview-color" style="background-color:#a16a94"></div>
-<div class="preview-color" style="background-color:#b5e4f4"></div>
-</div>
-</div>
-<h3 id="base16-apathy-dark">Base16 Apathy Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#81B5AC"></div>
-<div class="preview-color" style="background-color:#031A16"></div>
-<div class="preview-color" style="background-color:#3E9688"></div>
-<div class="preview-color" style="background-color:#883E96"></div>
-<div class="preview-color" style="background-color:#3E4C96"></div>
-<div class="preview-color" style="background-color:#96883E"></div>
-<div class="preview-color" style="background-color:#4C963E"></div>
-<div class="preview-color" style="background-color:#963E4C"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#031A16"></div>
-<div class="preview-color" style="background-color:#2B685E"></div>
-<div class="preview-color" style="background-color:#3E9688"></div>
-<div class="preview-color" style="background-color:#883E96"></div>
-<div class="preview-color" style="background-color:#3E4C96"></div>
-<div class="preview-color" style="background-color:#96883E"></div>
-<div class="preview-color" style="background-color:#4C963E"></div>
-<div class="preview-color" style="background-color:#963E4C"></div>
-</div>
-</div>
-<h3 id="base16-apathy-light">Base16 Apathy Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#184E45"></div>
-<div class="preview-color" style="background-color:#031A16"></div>
-<div class="preview-color" style="background-color:#3E9688"></div>
-<div class="preview-color" style="background-color:#883E96"></div>
-<div class="preview-color" style="background-color:#3E4C96"></div>
-<div class="preview-color" style="background-color:#96883E"></div>
-<div class="preview-color" style="background-color:#4C963E"></div>
-<div class="preview-color" style="background-color:#963E4C"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#D2E7E4"></div>
-<div class="preview-color" style="background-color:#2B685E"></div>
-<div class="preview-color" style="background-color:#3E9688"></div>
-<div class="preview-color" style="background-color:#883E96"></div>
-<div class="preview-color" style="background-color:#3E4C96"></div>
-<div class="preview-color" style="background-color:#96883E"></div>
-<div class="preview-color" style="background-color:#4C963E"></div>
-<div class="preview-color" style="background-color:#963E4C"></div>
-</div>
-</div>
-<h3 id="base16-ashes-dark">Base16 Ashes Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#C7CCD1"></div>
-<div class="preview-color" style="background-color:#1C2023"></div>
-<div class="preview-color" style="background-color:#C7AE95"></div>
-<div class="preview-color" style="background-color:#95C7AE"></div>
-<div class="preview-color" style="background-color:#AEC795"></div>
-<div class="preview-color" style="background-color:#AE95C7"></div>
-<div class="preview-color" style="background-color:#C795AE"></div>
-<div class="preview-color" style="background-color:#95AEC7"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#1C2023"></div>
-<div class="preview-color" style="background-color:#747C84"></div>
-<div class="preview-color" style="background-color:#C7AE95"></div>
-<div class="preview-color" style="background-color:#95C7AE"></div>
-<div class="preview-color" style="background-color:#AEC795"></div>
-<div class="preview-color" style="background-color:#AE95C7"></div>
-<div class="preview-color" style="background-color:#C795AE"></div>
-<div class="preview-color" style="background-color:#95AEC7"></div>
-</div>
-</div>
-<h3 id="base16-ashes-light">Base16 Ashes Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#565E65"></div>
-<div class="preview-color" style="background-color:#1C2023"></div>
-<div class="preview-color" style="background-color:#C7AE95"></div>
-<div class="preview-color" style="background-color:#95C7AE"></div>
-<div class="preview-color" style="background-color:#AEC795"></div>
-<div class="preview-color" style="background-color:#AE95C7"></div>
-<div class="preview-color" style="background-color:#C795AE"></div>
-<div class="preview-color" style="background-color:#95AEC7"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#F3F4F5"></div>
-<div class="preview-color" style="background-color:#747C84"></div>
-<div class="preview-color" style="background-color:#C7AE95"></div>
-<div class="preview-color" style="background-color:#95C7AE"></div>
-<div class="preview-color" style="background-color:#AEC795"></div>
-<div class="preview-color" style="background-color:#AE95C7"></div>
-<div class="preview-color" style="background-color:#C795AE"></div>
-<div class="preview-color" style="background-color:#95AEC7"></div>
-</div>
-</div>
-<h3 id="base16-atelierdune-dark">Base16 Atelierdune Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#a6a28c"></div>
-<div class="preview-color" style="background-color:#20201d"></div>
-<div class="preview-color" style="background-color:#d73737"></div>
-<div class="preview-color" style="background-color:#60ac39"></div>
-<div class="preview-color" style="background-color:#cfb017"></div>
-<div class="preview-color" style="background-color:#6684e1"></div>
-<div class="preview-color" style="background-color:#b854d4"></div>
-<div class="preview-color" style="background-color:#1fad83"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#20201d"></div>
-<div class="preview-color" style="background-color:#7d7a68"></div>
-<div class="preview-color" style="background-color:#d73737"></div>
-<div class="preview-color" style="background-color:#60ac39"></div>
-<div class="preview-color" style="background-color:#cfb017"></div>
-<div class="preview-color" style="background-color:#6684e1"></div>
-<div class="preview-color" style="background-color:#b854d4"></div>
-<div class="preview-color" style="background-color:#1fad83"></div>
-</div>
-</div>
-<h3 id="base16-atelierdune-light">Base16 Atelierdune Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#6e6b5e"></div>
-<div class="preview-color" style="background-color:#20201d"></div>
-<div class="preview-color" style="background-color:#d73737"></div>
-<div class="preview-color" style="background-color:#60ac39"></div>
-<div class="preview-color" style="background-color:#cfb017"></div>
-<div class="preview-color" style="background-color:#6684e1"></div>
-<div class="preview-color" style="background-color:#b854d4"></div>
-<div class="preview-color" style="background-color:#1fad83"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#fefbec"></div>
-<div class="preview-color" style="background-color:#7d7a68"></div>
-<div class="preview-color" style="background-color:#d73737"></div>
-<div class="preview-color" style="background-color:#60ac39"></div>
-<div class="preview-color" style="background-color:#cfb017"></div>
-<div class="preview-color" style="background-color:#6684e1"></div>
-<div class="preview-color" style="background-color:#b854d4"></div>
-<div class="preview-color" style="background-color:#1fad83"></div>
-</div>
-</div>
-<h3 id="base16-atelierforest-dark">Base16 Atelierforest Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#a8a19f"></div>
-<div class="preview-color" style="background-color:#1b1918"></div>
-<div class="preview-color" style="background-color:#f22c40"></div>
-<div class="preview-color" style="background-color:#5ab738"></div>
-<div class="preview-color" style="background-color:#d5911a"></div>
-<div class="preview-color" style="background-color:#407ee7"></div>
-<div class="preview-color" style="background-color:#6666ea"></div>
-<div class="preview-color" style="background-color:#00ad9c"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#1b1918"></div>
-<div class="preview-color" style="background-color:#766e6b"></div>
-<div class="preview-color" style="background-color:#f22c40"></div>
-<div class="preview-color" style="background-color:#5ab738"></div>
-<div class="preview-color" style="background-color:#d5911a"></div>
-<div class="preview-color" style="background-color:#407ee7"></div>
-<div class="preview-color" style="background-color:#6666ea"></div>
-<div class="preview-color" style="background-color:#00ad9c"></div>
-</div>
-</div>
-<h3 id="base16-atelierforest-light">Base16 Atelierforest Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#68615e"></div>
-<div class="preview-color" style="background-color:#1b1918"></div>
-<div class="preview-color" style="background-color:#f22c40"></div>
-<div class="preview-color" style="background-color:#5ab738"></div>
-<div class="preview-color" style="background-color:#d5911a"></div>
-<div class="preview-color" style="background-color:#407ee7"></div>
-<div class="preview-color" style="background-color:#6666ea"></div>
-<div class="preview-color" style="background-color:#00ad9c"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#f1efee"></div>
-<div class="preview-color" style="background-color:#766e6b"></div>
-<div class="preview-color" style="background-color:#f22c40"></div>
-<div class="preview-color" style="background-color:#5ab738"></div>
-<div class="preview-color" style="background-color:#d5911a"></div>
-<div class="preview-color" style="background-color:#407ee7"></div>
-<div class="preview-color" style="background-color:#6666ea"></div>
-<div class="preview-color" style="background-color:#00ad9c"></div>
-</div>
-</div>
-<h3 id="base16-atelierheath-dark">Base16 Atelierheath Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#ab9bab"></div>
-<div class="preview-color" style="background-color:#1b181b"></div>
-<div class="preview-color" style="background-color:#ca402b"></div>
-<div class="preview-color" style="background-color:#379a37"></div>
-<div class="preview-color" style="background-color:#bb8a35"></div>
-<div class="preview-color" style="background-color:#516aec"></div>
-<div class="preview-color" style="background-color:#7b59c0"></div>
-<div class="preview-color" style="background-color:#159393"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#1b181b"></div>
-<div class="preview-color" style="background-color:#776977"></div>
-<div class="preview-color" style="background-color:#ca402b"></div>
-<div class="preview-color" style="background-color:#379a37"></div>
-<div class="preview-color" style="background-color:#bb8a35"></div>
-<div class="preview-color" style="background-color:#516aec"></div>
-<div class="preview-color" style="background-color:#7b59c0"></div>
-<div class="preview-color" style="background-color:#159393"></div>
-</div>
-</div>
-<h3 id="base16-atelierheath-light">Base16 Atelierheath Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#695d69"></div>
-<div class="preview-color" style="background-color:#1b181b"></div>
-<div class="preview-color" style="background-color:#ca402b"></div>
-<div class="preview-color" style="background-color:#379a37"></div>
-<div class="preview-color" style="background-color:#bb8a35"></div>
-<div class="preview-color" style="background-color:#516aec"></div>
-<div class="preview-color" style="background-color:#7b59c0"></div>
-<div class="preview-color" style="background-color:#159393"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#f7f3f7"></div>
-<div class="preview-color" style="background-color:#776977"></div>
-<div class="preview-color" style="background-color:#ca402b"></div>
-<div class="preview-color" style="background-color:#379a37"></div>
-<div class="preview-color" style="background-color:#bb8a35"></div>
-<div class="preview-color" style="background-color:#516aec"></div>
-<div class="preview-color" style="background-color:#7b59c0"></div>
-<div class="preview-color" style="background-color:#159393"></div>
-</div>
-</div>
-<h3 id="base16-atelierlakeside-dark">Base16 Atelierlakeside Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#7ea2b4"></div>
-<div class="preview-color" style="background-color:#161b1d"></div>
-<div class="preview-color" style="background-color:#d22d72"></div>
-<div class="preview-color" style="background-color:#568c3b"></div>
-<div class="preview-color" style="background-color:#8a8a0f"></div>
-<div class="preview-color" style="background-color:#257fad"></div>
-<div class="preview-color" style="background-color:#5d5db1"></div>
-<div class="preview-color" style="background-color:#2d8f6f"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#161b1d"></div>
-<div class="preview-color" style="background-color:#5a7b8c"></div>
-<div class="preview-color" style="background-color:#d22d72"></div>
-<div class="preview-color" style="background-color:#568c3b"></div>
-<div class="preview-color" style="background-color:#8a8a0f"></div>
-<div class="preview-color" style="background-color:#257fad"></div>
-<div class="preview-color" style="background-color:#5d5db1"></div>
-<div class="preview-color" style="background-color:#2d8f6f"></div>
-</div>
-</div>
-<h3 id="base16-atelierlakeside-light">Base16 Atelierlakeside Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#516d7b"></div>
-<div class="preview-color" style="background-color:#161b1d"></div>
-<div class="preview-color" style="background-color:#d22d72"></div>
-<div class="preview-color" style="background-color:#568c3b"></div>
-<div class="preview-color" style="background-color:#8a8a0f"></div>
-<div class="preview-color" style="background-color:#257fad"></div>
-<div class="preview-color" style="background-color:#5d5db1"></div>
-<div class="preview-color" style="background-color:#2d8f6f"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#ebf8ff"></div>
-<div class="preview-color" style="background-color:#5a7b8c"></div>
-<div class="preview-color" style="background-color:#d22d72"></div>
-<div class="preview-color" style="background-color:#568c3b"></div>
-<div class="preview-color" style="background-color:#8a8a0f"></div>
-<div class="preview-color" style="background-color:#257fad"></div>
-<div class="preview-color" style="background-color:#5d5db1"></div>
-<div class="preview-color" style="background-color:#2d8f6f"></div>
-</div>
-</div>
-<h3 id="base16-atelierseaside-dark">Base16 Atelierseaside Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#8ca68c"></div>
-<div class="preview-color" style="background-color:#131513"></div>
-<div class="preview-color" style="background-color:#e6193c"></div>
-<div class="preview-color" style="background-color:#29a329"></div>
-<div class="preview-color" style="background-color:#c3c322"></div>
-<div class="preview-color" style="background-color:#3d62f5"></div>
-<div class="preview-color" style="background-color:#ad2bee"></div>
-<div class="preview-color" style="background-color:#1999b3"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#131513"></div>
-<div class="preview-color" style="background-color:#687d68"></div>
-<div class="preview-color" style="background-color:#e6193c"></div>
-<div class="preview-color" style="background-color:#29a329"></div>
-<div class="preview-color" style="background-color:#c3c322"></div>
-<div class="preview-color" style="background-color:#3d62f5"></div>
-<div class="preview-color" style="background-color:#ad2bee"></div>
-<div class="preview-color" style="background-color:#1999b3"></div>
-</div>
-</div>
-<h3 id="base16-atelierseaside-light">Base16 Atelierseaside Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#5e6e5e"></div>
-<div class="preview-color" style="background-color:#131513"></div>
-<div class="preview-color" style="background-color:#e6193c"></div>
-<div class="preview-color" style="background-color:#29a329"></div>
-<div class="preview-color" style="background-color:#c3c322"></div>
-<div class="preview-color" style="background-color:#3d62f5"></div>
-<div class="preview-color" style="background-color:#ad2bee"></div>
-<div class="preview-color" style="background-color:#1999b3"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#f0fff0"></div>
-<div class="preview-color" style="background-color:#687d68"></div>
-<div class="preview-color" style="background-color:#e6193c"></div>
-<div class="preview-color" style="background-color:#29a329"></div>
-<div class="preview-color" style="background-color:#c3c322"></div>
-<div class="preview-color" style="background-color:#3d62f5"></div>
-<div class="preview-color" style="background-color:#ad2bee"></div>
-<div class="preview-color" style="background-color:#1999b3"></div>
-</div>
-</div>
-<h3 id="base16-bespin-dark">Base16 Bespin Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#8a8986"></div>
-<div class="preview-color" style="background-color:#28211c"></div>
-<div class="preview-color" style="background-color:#cf6a4c"></div>
-<div class="preview-color" style="background-color:#54be0d"></div>
-<div class="preview-color" style="background-color:#f9ee98"></div>
-<div class="preview-color" style="background-color:#5ea6ea"></div>
-<div class="preview-color" style="background-color:#9b859d"></div>
-<div class="preview-color" style="background-color:#afc4db"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#28211c"></div>
-<div class="preview-color" style="background-color:#666666"></div>
-<div class="preview-color" style="background-color:#cf6a4c"></div>
-<div class="preview-color" style="background-color:#54be0d"></div>
-<div class="preview-color" style="background-color:#f9ee98"></div>
-<div class="preview-color" style="background-color:#5ea6ea"></div>
-<div class="preview-color" style="background-color:#9b859d"></div>
-<div class="preview-color" style="background-color:#afc4db"></div>
-</div>
-</div>
-<h3 id="base16-bespin-light">Base16 Bespin Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#5e5d5c"></div>
-<div class="preview-color" style="background-color:#28211c"></div>
-<div class="preview-color" style="background-color:#cf6a4c"></div>
-<div class="preview-color" style="background-color:#54be0d"></div>
-<div class="preview-color" style="background-color:#f9ee98"></div>
-<div class="preview-color" style="background-color:#5ea6ea"></div>
-<div class="preview-color" style="background-color:#9b859d"></div>
-<div class="preview-color" style="background-color:#afc4db"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#baae9e"></div>
-<div class="preview-color" style="background-color:#666666"></div>
-<div class="preview-color" style="background-color:#cf6a4c"></div>
-<div class="preview-color" style="background-color:#54be0d"></div>
-<div class="preview-color" style="background-color:#f9ee98"></div>
-<div class="preview-color" style="background-color:#5ea6ea"></div>
-<div class="preview-color" style="background-color:#9b859d"></div>
-<div class="preview-color" style="background-color:#afc4db"></div>
-</div>
-</div>
-<h3 id="base16-brewer-dark">Base16 Brewer Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#b7b8b9"></div>
-<div class="preview-color" style="background-color:#0c0d0e"></div>
-<div class="preview-color" style="background-color:#e31a1c"></div>
-<div class="preview-color" style="background-color:#31a354"></div>
-<div class="preview-color" style="background-color:#dca060"></div>
-<div class="preview-color" style="background-color:#3182bd"></div>
-<div class="preview-color" style="background-color:#756bb1"></div>
-<div class="preview-color" style="background-color:#80b1d3"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#0c0d0e"></div>
-<div class="preview-color" style="background-color:#737475"></div>
-<div class="preview-color" style="background-color:#e31a1c"></div>
-<div class="preview-color" style="background-color:#31a354"></div>
-<div class="preview-color" style="background-color:#dca060"></div>
-<div class="preview-color" style="background-color:#3182bd"></div>
-<div class="preview-color" style="background-color:#756bb1"></div>
-<div class="preview-color" style="background-color:#80b1d3"></div>
-</div>
-</div>
-<h3 id="base16-brewer-light">Base16 Brewer Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#515253"></div>
-<div class="preview-color" style="background-color:#0c0d0e"></div>
-<div class="preview-color" style="background-color:#e31a1c"></div>
-<div class="preview-color" style="background-color:#31a354"></div>
-<div class="preview-color" style="background-color:#dca060"></div>
-<div class="preview-color" style="background-color:#3182bd"></div>
-<div class="preview-color" style="background-color:#756bb1"></div>
-<div class="preview-color" style="background-color:#80b1d3"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#fcfdfe"></div>
-<div class="preview-color" style="background-color:#737475"></div>
-<div class="preview-color" style="background-color:#e31a1c"></div>
-<div class="preview-color" style="background-color:#31a354"></div>
-<div class="preview-color" style="background-color:#dca060"></div>
-<div class="preview-color" style="background-color:#3182bd"></div>
-<div class="preview-color" style="background-color:#756bb1"></div>
-<div class="preview-color" style="background-color:#80b1d3"></div>
-</div>
-</div>
-<h3 id="base16-bright-dark">Base16 Bright Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#e0e0e0"></div>
-<div class="preview-color" style="background-color:#000000"></div>
-<div class="preview-color" style="background-color:#fb0120"></div>
-<div class="preview-color" style="background-color:#a1c659"></div>
-<div class="preview-color" style="background-color:#fda331"></div>
-<div class="preview-color" style="background-color:#6fb3d2"></div>
-<div class="preview-color" style="background-color:#d381c3"></div>
-<div class="preview-color" style="background-color:#76c7b7"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#000000"></div>
-<div class="preview-color" style="background-color:#b0b0b0"></div>
-<div class="preview-color" style="background-color:#fb0120"></div>
-<div class="preview-color" style="background-color:#a1c659"></div>
-<div class="preview-color" style="background-color:#fda331"></div>
-<div class="preview-color" style="background-color:#6fb3d2"></div>
-<div class="preview-color" style="background-color:#d381c3"></div>
-<div class="preview-color" style="background-color:#76c7b7"></div>
-</div>
-</div>
-<h3 id="base16-bright-light">Base16 Bright Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#505050"></div>
-<div class="preview-color" style="background-color:#000000"></div>
-<div class="preview-color" style="background-color:#fb0120"></div>
-<div class="preview-color" style="background-color:#a1c659"></div>
-<div class="preview-color" style="background-color:#fda331"></div>
-<div class="preview-color" style="background-color:#6fb3d2"></div>
-<div class="preview-color" style="background-color:#d381c3"></div>
-<div class="preview-color" style="background-color:#76c7b7"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#ffffff"></div>
-<div class="preview-color" style="background-color:#b0b0b0"></div>
-<div class="preview-color" style="background-color:#fb0120"></div>
-<div class="preview-color" style="background-color:#a1c659"></div>
-<div class="preview-color" style="background-color:#fda331"></div>
-<div class="preview-color" style="background-color:#6fb3d2"></div>
-<div class="preview-color" style="background-color:#d381c3"></div>
-<div class="preview-color" style="background-color:#76c7b7"></div>
-</div>
-</div>
-<h3 id="base16-chalk-dark">Base16 Chalk Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#d0d0d0"></div>
-<div class="preview-color" style="background-color:#151515"></div>
-<div class="preview-color" style="background-color:#fb9fb1"></div>
-<div class="preview-color" style="background-color:#acc267"></div>
-<div class="preview-color" style="background-color:#ddb26f"></div>
-<div class="preview-color" style="background-color:#6fc2ef"></div>
-<div class="preview-color" style="background-color:#e1a3ee"></div>
-<div class="preview-color" style="background-color:#12cfc0"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#151515"></div>
-<div class="preview-color" style="background-color:#505050"></div>
-<div class="preview-color" style="background-color:#fb9fb1"></div>
-<div class="preview-color" style="background-color:#acc267"></div>
-<div class="preview-color" style="background-color:#ddb26f"></div>
-<div class="preview-color" style="background-color:#6fc2ef"></div>
-<div class="preview-color" style="background-color:#e1a3ee"></div>
-<div class="preview-color" style="background-color:#12cfc0"></div>
-</div>
-</div>
-<h3 id="base16-chalk-light">Base16 Chalk Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#303030"></div>
-<div class="preview-color" style="background-color:#151515"></div>
-<div class="preview-color" style="background-color:#fb9fb1"></div>
-<div class="preview-color" style="background-color:#acc267"></div>
-<div class="preview-color" style="background-color:#ddb26f"></div>
-<div class="preview-color" style="background-color:#6fc2ef"></div>
-<div class="preview-color" style="background-color:#e1a3ee"></div>
-<div class="preview-color" style="background-color:#12cfc0"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#f5f5f5"></div>
-<div class="preview-color" style="background-color:#505050"></div>
-<div class="preview-color" style="background-color:#fb9fb1"></div>
-<div class="preview-color" style="background-color:#acc267"></div>
-<div class="preview-color" style="background-color:#ddb26f"></div>
-<div class="preview-color" style="background-color:#6fc2ef"></div>
-<div class="preview-color" style="background-color:#e1a3ee"></div>
-<div class="preview-color" style="background-color:#12cfc0"></div>
-</div>
-</div>
-<h3 id="base16-codeschool-dark">Base16 Codeschool Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#9ea7a6"></div>
-<div class="preview-color" style="background-color:#232c31"></div>
-<div class="preview-color" style="background-color:#2a5491"></div>
-<div class="preview-color" style="background-color:#237986"></div>
-<div class="preview-color" style="background-color:#a03b1e"></div>
-<div class="preview-color" style="background-color:#484d79"></div>
-<div class="preview-color" style="background-color:#c59820"></div>
-<div class="preview-color" style="background-color:#b02f30"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#232c31"></div>
-<div class="preview-color" style="background-color:#3f4944"></div>
-<div class="preview-color" style="background-color:#2a5491"></div>
-<div class="preview-color" style="background-color:#237986"></div>
-<div class="preview-color" style="background-color:#a03b1e"></div>
-<div class="preview-color" style="background-color:#484d79"></div>
-<div class="preview-color" style="background-color:#c59820"></div>
-<div class="preview-color" style="background-color:#b02f30"></div>
-</div>
-</div>
-<h3 id="base16-codeschool-light">Base16 Codeschool Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#2a343a"></div>
-<div class="preview-color" style="background-color:#232c31"></div>
-<div class="preview-color" style="background-color:#2a5491"></div>
-<div class="preview-color" style="background-color:#237986"></div>
-<div class="preview-color" style="background-color:#a03b1e"></div>
-<div class="preview-color" style="background-color:#484d79"></div>
-<div class="preview-color" style="background-color:#c59820"></div>
-<div class="preview-color" style="background-color:#b02f30"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#b5d8f6"></div>
-<div class="preview-color" style="background-color:#3f4944"></div>
-<div class="preview-color" style="background-color:#2a5491"></div>
-<div class="preview-color" style="background-color:#237986"></div>
-<div class="preview-color" style="background-color:#a03b1e"></div>
-<div class="preview-color" style="background-color:#484d79"></div>
-<div class="preview-color" style="background-color:#c59820"></div>
-<div class="preview-color" style="background-color:#b02f30"></div>
-</div>
-</div>
-<h3 id="base16-colors-dark">Base16 Colors Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#bbbbbb"></div>
-<div class="preview-color" style="background-color:#111111"></div>
-<div class="preview-color" style="background-color:#ff4136"></div>
-<div class="preview-color" style="background-color:#2ecc40"></div>
-<div class="preview-color" style="background-color:#ffdc00"></div>
-<div class="preview-color" style="background-color:#0074d9"></div>
-<div class="preview-color" style="background-color:#b10dc9"></div>
-<div class="preview-color" style="background-color:#7fdbff"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#111111"></div>
-<div class="preview-color" style="background-color:#777777"></div>
-<div class="preview-color" style="background-color:#ff4136"></div>
-<div class="preview-color" style="background-color:#2ecc40"></div>
-<div class="preview-color" style="background-color:#ffdc00"></div>
-<div class="preview-color" style="background-color:#0074d9"></div>
-<div class="preview-color" style="background-color:#b10dc9"></div>
-<div class="preview-color" style="background-color:#7fdbff"></div>
-</div>
-</div>
-<h3 id="base16-colors-light">Base16 Colors Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#555555"></div>
-<div class="preview-color" style="background-color:#111111"></div>
-<div class="preview-color" style="background-color:#ff4136"></div>
-<div class="preview-color" style="background-color:#2ecc40"></div>
-<div class="preview-color" style="background-color:#ffdc00"></div>
-<div class="preview-color" style="background-color:#0074d9"></div>
-<div class="preview-color" style="background-color:#b10dc9"></div>
-<div class="preview-color" style="background-color:#7fdbff"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#ffffff"></div>
-<div class="preview-color" style="background-color:#777777"></div>
-<div class="preview-color" style="background-color:#ff4136"></div>
-<div class="preview-color" style="background-color:#2ecc40"></div>
-<div class="preview-color" style="background-color:#ffdc00"></div>
-<div class="preview-color" style="background-color:#0074d9"></div>
-<div class="preview-color" style="background-color:#b10dc9"></div>
-<div class="preview-color" style="background-color:#7fdbff"></div>
-</div>
-</div>
-<h3 id="base16-default-dark">Base16 Default Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#d8d8d8"></div>
-<div class="preview-color" style="background-color:#181818"></div>
-<div class="preview-color" style="background-color:#ab4642"></div>
-<div class="preview-color" style="background-color:#a1b56c"></div>
-<div class="preview-color" style="background-color:#f7ca88"></div>
-<div class="preview-color" style="background-color:#7cafc2"></div>
-<div class="preview-color" style="background-color:#ba8baf"></div>
-<div class="preview-color" style="background-color:#86c1b9"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#181818"></div>
-<div class="preview-color" style="background-color:#585858"></div>
-<div class="preview-color" style="background-color:#ab4642"></div>
-<div class="preview-color" style="background-color:#a1b56c"></div>
-<div class="preview-color" style="background-color:#f7ca88"></div>
-<div class="preview-color" style="background-color:#7cafc2"></div>
-<div class="preview-color" style="background-color:#ba8baf"></div>
-<div class="preview-color" style="background-color:#86c1b9"></div>
-</div>
-</div>
-<h3 id="base16-default-light">Base16 Default Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#383838"></div>
-<div class="preview-color" style="background-color:#181818"></div>
-<div class="preview-color" style="background-color:#ab4642"></div>
-<div class="preview-color" style="background-color:#a1b56c"></div>
-<div class="preview-color" style="background-color:#f7ca88"></div>
-<div class="preview-color" style="background-color:#7cafc2"></div>
-<div class="preview-color" style="background-color:#ba8baf"></div>
-<div class="preview-color" style="background-color:#86c1b9"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#f8f8f8"></div>
-<div class="preview-color" style="background-color:#585858"></div>
-<div class="preview-color" style="background-color:#ab4642"></div>
-<div class="preview-color" style="background-color:#a1b56c"></div>
-<div class="preview-color" style="background-color:#f7ca88"></div>
-<div class="preview-color" style="background-color:#7cafc2"></div>
-<div class="preview-color" style="background-color:#ba8baf"></div>
-<div class="preview-color" style="background-color:#86c1b9"></div>
-</div>
-</div>
-<h3 id="base16-eighties-dark">Base16 Eighties Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#d3d0c8"></div>
-<div class="preview-color" style="background-color:#2d2d2d"></div>
-<div class="preview-color" style="background-color:#f2777a"></div>
-<div class="preview-color" style="background-color:#99cc99"></div>
-<div class="preview-color" style="background-color:#ffcc66"></div>
-<div class="preview-color" style="background-color:#6699cc"></div>
-<div class="preview-color" style="background-color:#cc99cc"></div>
-<div class="preview-color" style="background-color:#66cccc"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#2d2d2d"></div>
-<div class="preview-color" style="background-color:#747369"></div>
-<div class="preview-color" style="background-color:#f2777a"></div>
-<div class="preview-color" style="background-color:#99cc99"></div>
-<div class="preview-color" style="background-color:#ffcc66"></div>
-<div class="preview-color" style="background-color:#6699cc"></div>
-<div class="preview-color" style="background-color:#cc99cc"></div>
-<div class="preview-color" style="background-color:#66cccc"></div>
-</div>
-</div>
-<h3 id="base16-eighties-light">Base16 Eighties Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#515151"></div>
-<div class="preview-color" style="background-color:#2d2d2d"></div>
-<div class="preview-color" style="background-color:#f2777a"></div>
-<div class="preview-color" style="background-color:#99cc99"></div>
-<div class="preview-color" style="background-color:#ffcc66"></div>
-<div class="preview-color" style="background-color:#6699cc"></div>
-<div class="preview-color" style="background-color:#cc99cc"></div>
-<div class="preview-color" style="background-color:#66cccc"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#f2f0ec"></div>
-<div class="preview-color" style="background-color:#747369"></div>
-<div class="preview-color" style="background-color:#f2777a"></div>
-<div class="preview-color" style="background-color:#99cc99"></div>
-<div class="preview-color" style="background-color:#ffcc66"></div>
-<div class="preview-color" style="background-color:#6699cc"></div>
-<div class="preview-color" style="background-color:#cc99cc"></div>
-<div class="preview-color" style="background-color:#66cccc"></div>
-</div>
-</div>
-<h3 id="base16-embers-dark">Base16 Embers Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#A39A90"></div>
-<div class="preview-color" style="background-color:#16130F"></div>
-<div class="preview-color" style="background-color:#826D57"></div>
-<div class="preview-color" style="background-color:#57826D"></div>
-<div class="preview-color" style="background-color:#6D8257"></div>
-<div class="preview-color" style="background-color:#6D5782"></div>
-<div class="preview-color" style="background-color:#82576D"></div>
-<div class="preview-color" style="background-color:#576D82"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#16130F"></div>
-<div class="preview-color" style="background-color:#5A5047"></div>
-<div class="preview-color" style="background-color:#826D57"></div>
-<div class="preview-color" style="background-color:#57826D"></div>
-<div class="preview-color" style="background-color:#6D8257"></div>
-<div class="preview-color" style="background-color:#6D5782"></div>
-<div class="preview-color" style="background-color:#82576D"></div>
-<div class="preview-color" style="background-color:#576D82"></div>
-</div>
-</div>
-<h3 id="base16-embers-light">Base16 Embers Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#433B32"></div>
-<div class="preview-color" style="background-color:#16130F"></div>
-<div class="preview-color" style="background-color:#826D57"></div>
-<div class="preview-color" style="background-color:#57826D"></div>
-<div class="preview-color" style="background-color:#6D8257"></div>
-<div class="preview-color" style="background-color:#6D5782"></div>
-<div class="preview-color" style="background-color:#82576D"></div>
-<div class="preview-color" style="background-color:#576D82"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#DBD6D1"></div>
-<div class="preview-color" style="background-color:#5A5047"></div>
-<div class="preview-color" style="background-color:#826D57"></div>
-<div class="preview-color" style="background-color:#57826D"></div>
-<div class="preview-color" style="background-color:#6D8257"></div>
-<div class="preview-color" style="background-color:#6D5782"></div>
-<div class="preview-color" style="background-color:#82576D"></div>
-<div class="preview-color" style="background-color:#576D82"></div>
-</div>
-</div>
-<h3 id="base16-flat-dark">Base16 Flat Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#e0e0e0"></div>
-<div class="preview-color" style="background-color:#2C3E50"></div>
-<div class="preview-color" style="background-color:#E74C3C"></div>
-<div class="preview-color" style="background-color:#2ECC71"></div>
-<div class="preview-color" style="background-color:#F1C40F"></div>
-<div class="preview-color" style="background-color:#3498DB"></div>
-<div class="preview-color" style="background-color:#9B59B6"></div>
-<div class="preview-color" style="background-color:#1ABC9C"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#2C3E50"></div>
-<div class="preview-color" style="background-color:#95A5A6"></div>
-<div class="preview-color" style="background-color:#E74C3C"></div>
-<div class="preview-color" style="background-color:#2ECC71"></div>
-<div class="preview-color" style="background-color:#F1C40F"></div>
-<div class="preview-color" style="background-color:#3498DB"></div>
-<div class="preview-color" style="background-color:#9B59B6"></div>
-<div class="preview-color" style="background-color:#1ABC9C"></div>
-</div>
-</div>
-<h3 id="base16-flat-light">Base16 Flat Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#7F8C8D"></div>
-<div class="preview-color" style="background-color:#2C3E50"></div>
-<div class="preview-color" style="background-color:#E74C3C"></div>
-<div class="preview-color" style="background-color:#2ECC71"></div>
-<div class="preview-color" style="background-color:#F1C40F"></div>
-<div class="preview-color" style="background-color:#3498DB"></div>
-<div class="preview-color" style="background-color:#9B59B6"></div>
-<div class="preview-color" style="background-color:#1ABC9C"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#ECF0F1"></div>
-<div class="preview-color" style="background-color:#95A5A6"></div>
-<div class="preview-color" style="background-color:#E74C3C"></div>
-<div class="preview-color" style="background-color:#2ECC71"></div>
-<div class="preview-color" style="background-color:#F1C40F"></div>
-<div class="preview-color" style="background-color:#3498DB"></div>
-<div class="preview-color" style="background-color:#9B59B6"></div>
-<div class="preview-color" style="background-color:#1ABC9C"></div>
-</div>
-</div>
-<h3 id="base16-google-dark">Base16 Google Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#c5c8c6"></div>
-<div class="preview-color" style="background-color:#1d1f21"></div>
-<div class="preview-color" style="background-color:#CC342B"></div>
-<div class="preview-color" style="background-color:#198844"></div>
-<div class="preview-color" style="background-color:#FBA922"></div>
-<div class="preview-color" style="background-color:#3971ED"></div>
-<div class="preview-color" style="background-color:#A36AC7"></div>
-<div class="preview-color" style="background-color:#3971ED"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#1d1f21"></div>
-<div class="preview-color" style="background-color:#969896"></div>
-<div class="preview-color" style="background-color:#CC342B"></div>
-<div class="preview-color" style="background-color:#198844"></div>
-<div class="preview-color" style="background-color:#FBA922"></div>
-<div class="preview-color" style="background-color:#3971ED"></div>
-<div class="preview-color" style="background-color:#A36AC7"></div>
-<div class="preview-color" style="background-color:#3971ED"></div>
-</div>
-</div>
-<h3 id="base16-google-light">Base16 Google Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#373b41"></div>
-<div class="preview-color" style="background-color:#1d1f21"></div>
-<div class="preview-color" style="background-color:#CC342B"></div>
-<div class="preview-color" style="background-color:#198844"></div>
-<div class="preview-color" style="background-color:#FBA922"></div>
-<div class="preview-color" style="background-color:#3971ED"></div>
-<div class="preview-color" style="background-color:#A36AC7"></div>
-<div class="preview-color" style="background-color:#3971ED"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#ffffff"></div>
-<div class="preview-color" style="background-color:#969896"></div>
-<div class="preview-color" style="background-color:#CC342B"></div>
-<div class="preview-color" style="background-color:#198844"></div>
-<div class="preview-color" style="background-color:#FBA922"></div>
-<div class="preview-color" style="background-color:#3971ED"></div>
-<div class="preview-color" style="background-color:#A36AC7"></div>
-<div class="preview-color" style="background-color:#3971ED"></div>
-</div>
-</div>
-<h3 id="base16-grayscale-dark">Base16 Grayscale Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#b9b9b9"></div>
-<div class="preview-color" style="background-color:#101010"></div>
-<div class="preview-color" style="background-color:#7c7c7c"></div>
-<div class="preview-color" style="background-color:#8e8e8e"></div>
-<div class="preview-color" style="background-color:#a0a0a0"></div>
-<div class="preview-color" style="background-color:#686868"></div>
-<div class="preview-color" style="background-color:#747474"></div>
-<div class="preview-color" style="background-color:#868686"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#101010"></div>
-<div class="preview-color" style="background-color:#525252"></div>
-<div class="preview-color" style="background-color:#7c7c7c"></div>
-<div class="preview-color" style="background-color:#8e8e8e"></div>
-<div class="preview-color" style="background-color:#a0a0a0"></div>
-<div class="preview-color" style="background-color:#686868"></div>
-<div class="preview-color" style="background-color:#747474"></div>
-<div class="preview-color" style="background-color:#868686"></div>
-</div>
-</div>
-<h3 id="base16-grayscale-light">Base16 Grayscale Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#464646"></div>
-<div class="preview-color" style="background-color:#101010"></div>
-<div class="preview-color" style="background-color:#7c7c7c"></div>
-<div class="preview-color" style="background-color:#8e8e8e"></div>
-<div class="preview-color" style="background-color:#a0a0a0"></div>
-<div class="preview-color" style="background-color:#686868"></div>
-<div class="preview-color" style="background-color:#747474"></div>
-<div class="preview-color" style="background-color:#868686"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#f7f7f7"></div>
-<div class="preview-color" style="background-color:#525252"></div>
-<div class="preview-color" style="background-color:#7c7c7c"></div>
-<div class="preview-color" style="background-color:#8e8e8e"></div>
-<div class="preview-color" style="background-color:#a0a0a0"></div>
-<div class="preview-color" style="background-color:#686868"></div>
-<div class="preview-color" style="background-color:#747474"></div>
-<div class="preview-color" style="background-color:#868686"></div>
-</div>
-</div>
-<h3 id="base16-greenscreen-dark">Base16 Greenscreen Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#00bb00"></div>
-<div class="preview-color" style="background-color:#001100"></div>
-<div class="preview-color" style="background-color:#007700"></div>
-<div class="preview-color" style="background-color:#00bb00"></div>
-<div class="preview-color" style="background-color:#007700"></div>
-<div class="preview-color" style="background-color:#009900"></div>
-<div class="preview-color" style="background-color:#00bb00"></div>
-<div class="preview-color" style="background-color:#005500"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#001100"></div>
-<div class="preview-color" style="background-color:#007700"></div>
-<div class="preview-color" style="background-color:#007700"></div>
-<div class="preview-color" style="background-color:#00bb00"></div>
-<div class="preview-color" style="background-color:#007700"></div>
-<div class="preview-color" style="background-color:#009900"></div>
-<div class="preview-color" style="background-color:#00bb00"></div>
-<div class="preview-color" style="background-color:#005500"></div>
-</div>
-</div>
-<h3 id="base16-greenscreen-light">Base16 Greenscreen Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#005500"></div>
-<div class="preview-color" style="background-color:#001100"></div>
-<div class="preview-color" style="background-color:#007700"></div>
-<div class="preview-color" style="background-color:#00bb00"></div>
-<div class="preview-color" style="background-color:#007700"></div>
-<div class="preview-color" style="background-color:#009900"></div>
-<div class="preview-color" style="background-color:#00bb00"></div>
-<div class="preview-color" style="background-color:#005500"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#00ff00"></div>
-<div class="preview-color" style="background-color:#007700"></div>
-<div class="preview-color" style="background-color:#007700"></div>
-<div class="preview-color" style="background-color:#00bb00"></div>
-<div class="preview-color" style="background-color:#007700"></div>
-<div class="preview-color" style="background-color:#009900"></div>
-<div class="preview-color" style="background-color:#00bb00"></div>
-<div class="preview-color" style="background-color:#005500"></div>
-</div>
-</div>
-<h3 id="base16-harmonic16-dark">Base16 Harmonic16 Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#cbd6e2"></div>
-<div class="preview-color" style="background-color:#0b1c2c"></div>
-<div class="preview-color" style="background-color:#bf8b56"></div>
-<div class="preview-color" style="background-color:#56bf8b"></div>
-<div class="preview-color" style="background-color:#8bbf56"></div>
-<div class="preview-color" style="background-color:#8b56bf"></div>
-<div class="preview-color" style="background-color:#bf568b"></div>
-<div class="preview-color" style="background-color:#568bbf"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#0b1c2c"></div>
-<div class="preview-color" style="background-color:#627e99"></div>
-<div class="preview-color" style="background-color:#bf8b56"></div>
-<div class="preview-color" style="background-color:#56bf8b"></div>
-<div class="preview-color" style="background-color:#8bbf56"></div>
-<div class="preview-color" style="background-color:#8b56bf"></div>
-<div class="preview-color" style="background-color:#bf568b"></div>
-<div class="preview-color" style="background-color:#568bbf"></div>
-</div>
-</div>
-<h3 id="base16-harmonic16-light">Base16 Harmonic16 Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#405c79"></div>
-<div class="preview-color" style="background-color:#0b1c2c"></div>
-<div class="preview-color" style="background-color:#bf8b56"></div>
-<div class="preview-color" style="background-color:#56bf8b"></div>
-<div class="preview-color" style="background-color:#8bbf56"></div>
-<div class="preview-color" style="background-color:#8b56bf"></div>
-<div class="preview-color" style="background-color:#bf568b"></div>
-<div class="preview-color" style="background-color:#568bbf"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#f7f9fb"></div>
-<div class="preview-color" style="background-color:#627e99"></div>
-<div class="preview-color" style="background-color:#bf8b56"></div>
-<div class="preview-color" style="background-color:#56bf8b"></div>
-<div class="preview-color" style="background-color:#8bbf56"></div>
-<div class="preview-color" style="background-color:#8b56bf"></div>
-<div class="preview-color" style="background-color:#bf568b"></div>
-<div class="preview-color" style="background-color:#568bbf"></div>
-</div>
-</div>
-<h3 id="base16-isotope-dark">Base16 Isotope Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#d0d0d0"></div>
-<div class="preview-color" style="background-color:#000000"></div>
-<div class="preview-color" style="background-color:#ff0000"></div>
-<div class="preview-color" style="background-color:#33ff00"></div>
-<div class="preview-color" style="background-color:#ff0099"></div>
-<div class="preview-color" style="background-color:#0066ff"></div>
-<div class="preview-color" style="background-color:#cc00ff"></div>
-<div class="preview-color" style="background-color:#00ffff"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#000000"></div>
-<div class="preview-color" style="background-color:#808080"></div>
-<div class="preview-color" style="background-color:#ff0000"></div>
-<div class="preview-color" style="background-color:#33ff00"></div>
-<div class="preview-color" style="background-color:#ff0099"></div>
-<div class="preview-color" style="background-color:#0066ff"></div>
-<div class="preview-color" style="background-color:#cc00ff"></div>
-<div class="preview-color" style="background-color:#00ffff"></div>
-</div>
-</div>
-<h3 id="base16-isotope-light">Base16 Isotope Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#606060"></div>
-<div class="preview-color" style="background-color:#000000"></div>
-<div class="preview-color" style="background-color:#ff0000"></div>
-<div class="preview-color" style="background-color:#33ff00"></div>
-<div class="preview-color" style="background-color:#ff0099"></div>
-<div class="preview-color" style="background-color:#0066ff"></div>
-<div class="preview-color" style="background-color:#cc00ff"></div>
-<div class="preview-color" style="background-color:#00ffff"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#ffffff"></div>
-<div class="preview-color" style="background-color:#808080"></div>
-<div class="preview-color" style="background-color:#ff0000"></div>
-<div class="preview-color" style="background-color:#33ff00"></div>
-<div class="preview-color" style="background-color:#ff0099"></div>
-<div class="preview-color" style="background-color:#0066ff"></div>
-<div class="preview-color" style="background-color:#cc00ff"></div>
-<div class="preview-color" style="background-color:#00ffff"></div>
-</div>
-</div>
-<h3 id="base16-londontube-dark">Base16 Londontube Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#d9d8d8"></div>
-<div class="preview-color" style="background-color:#231f20"></div>
-<div class="preview-color" style="background-color:#ee2e24"></div>
-<div class="preview-color" style="background-color:#00853e"></div>
-<div class="preview-color" style="background-color:#ffd204"></div>
-<div class="preview-color" style="background-color:#009ddc"></div>
-<div class="preview-color" style="background-color:#98005d"></div>
-<div class="preview-color" style="background-color:#85cebc"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#231f20"></div>
-<div class="preview-color" style="background-color:#737171"></div>
-<div class="preview-color" style="background-color:#ee2e24"></div>
-<div class="preview-color" style="background-color:#00853e"></div>
-<div class="preview-color" style="background-color:#ffd204"></div>
-<div class="preview-color" style="background-color:#009ddc"></div>
-<div class="preview-color" style="background-color:#98005d"></div>
-<div class="preview-color" style="background-color:#85cebc"></div>
-</div>
-</div>
-<h3 id="base16-londontube-light">Base16 Londontube Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#5a5758"></div>
-<div class="preview-color" style="background-color:#231f20"></div>
-<div class="preview-color" style="background-color:#ee2e24"></div>
-<div class="preview-color" style="background-color:#00853e"></div>
-<div class="preview-color" style="background-color:#ffd204"></div>
-<div class="preview-color" style="background-color:#009ddc"></div>
-<div class="preview-color" style="background-color:#98005d"></div>
-<div class="preview-color" style="background-color:#85cebc"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#ffffff"></div>
-<div class="preview-color" style="background-color:#737171"></div>
-<div class="preview-color" style="background-color:#ee2e24"></div>
-<div class="preview-color" style="background-color:#00853e"></div>
-<div class="preview-color" style="background-color:#ffd204"></div>
-<div class="preview-color" style="background-color:#009ddc"></div>
-<div class="preview-color" style="background-color:#98005d"></div>
-<div class="preview-color" style="background-color:#85cebc"></div>
-</div>
-</div>
-<h3 id="base16-marrakesh-dark">Base16 Marrakesh Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#948e48"></div>
-<div class="preview-color" style="background-color:#201602"></div>
-<div class="preview-color" style="background-color:#c35359"></div>
-<div class="preview-color" style="background-color:#18974e"></div>
-<div class="preview-color" style="background-color:#a88339"></div>
-<div class="preview-color" style="background-color:#477ca1"></div>
-<div class="preview-color" style="background-color:#8868b3"></div>
-<div class="preview-color" style="background-color:#75a738"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#201602"></div>
-<div class="preview-color" style="background-color:#6c6823"></div>
-<div class="preview-color" style="background-color:#c35359"></div>
-<div class="preview-color" style="background-color:#18974e"></div>
-<div class="preview-color" style="background-color:#a88339"></div>
-<div class="preview-color" style="background-color:#477ca1"></div>
-<div class="preview-color" style="background-color:#8868b3"></div>
-<div class="preview-color" style="background-color:#75a738"></div>
-</div>
-</div>
-<h3 id="base16-marrakesh-light">Base16 Marrakesh Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#5f5b17"></div>
-<div class="preview-color" style="background-color:#201602"></div>
-<div class="preview-color" style="background-color:#c35359"></div>
-<div class="preview-color" style="background-color:#18974e"></div>
-<div class="preview-color" style="background-color:#a88339"></div>
-<div class="preview-color" style="background-color:#477ca1"></div>
-<div class="preview-color" style="background-color:#8868b3"></div>
-<div class="preview-color" style="background-color:#75a738"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#faf0a5"></div>
-<div class="preview-color" style="background-color:#6c6823"></div>
-<div class="preview-color" style="background-color:#c35359"></div>
-<div class="preview-color" style="background-color:#18974e"></div>
-<div class="preview-color" style="background-color:#a88339"></div>
-<div class="preview-color" style="background-color:#477ca1"></div>
-<div class="preview-color" style="background-color:#8868b3"></div>
-<div class="preview-color" style="background-color:#75a738"></div>
-</div>
-</div>
-<h3 id="base16-mocha-dark">Base16 Mocha Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#d0c8c6"></div>
-<div class="preview-color" style="background-color:#3B3228"></div>
-<div class="preview-color" style="background-color:#cb6077"></div>
-<div class="preview-color" style="background-color:#beb55b"></div>
-<div class="preview-color" style="background-color:#f4bc87"></div>
-<div class="preview-color" style="background-color:#8ab3b5"></div>
-<div class="preview-color" style="background-color:#a89bb9"></div>
-<div class="preview-color" style="background-color:#7bbda4"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#3B3228"></div>
-<div class="preview-color" style="background-color:#7e705a"></div>
-<div class="preview-color" style="background-color:#cb6077"></div>
-<div class="preview-color" style="background-color:#beb55b"></div>
-<div class="preview-color" style="background-color:#f4bc87"></div>
-<div class="preview-color" style="background-color:#8ab3b5"></div>
-<div class="preview-color" style="background-color:#a89bb9"></div>
-<div class="preview-color" style="background-color:#7bbda4"></div>
-</div>
-</div>
-<h3 id="base16-mocha-light">Base16 Mocha Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#645240"></div>
-<div class="preview-color" style="background-color:#3B3228"></div>
-<div class="preview-color" style="background-color:#cb6077"></div>
-<div class="preview-color" style="background-color:#beb55b"></div>
-<div class="preview-color" style="background-color:#f4bc87"></div>
-<div class="preview-color" style="background-color:#8ab3b5"></div>
-<div class="preview-color" style="background-color:#a89bb9"></div>
-<div class="preview-color" style="background-color:#7bbda4"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#f5eeeb"></div>
-<div class="preview-color" style="background-color:#7e705a"></div>
-<div class="preview-color" style="background-color:#cb6077"></div>
-<div class="preview-color" style="background-color:#beb55b"></div>
-<div class="preview-color" style="background-color:#f4bc87"></div>
-<div class="preview-color" style="background-color:#8ab3b5"></div>
-<div class="preview-color" style="background-color:#a89bb9"></div>
-<div class="preview-color" style="background-color:#7bbda4"></div>
-</div>
-</div>
-<h3 id="base16-monokai-dark">Base16 Monokai Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#f8f8f2"></div>
-<div class="preview-color" style="background-color:#272822"></div>
-<div class="preview-color" style="background-color:#f92672"></div>
-<div class="preview-color" style="background-color:#a6e22e"></div>
-<div class="preview-color" style="background-color:#f4bf75"></div>
-<div class="preview-color" style="background-color:#66d9ef"></div>
-<div class="preview-color" style="background-color:#ae81ff"></div>
-<div class="preview-color" style="background-color:#a1efe4"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#272822"></div>
-<div class="preview-color" style="background-color:#75715e"></div>
-<div class="preview-color" style="background-color:#f92672"></div>
-<div class="preview-color" style="background-color:#a6e22e"></div>
-<div class="preview-color" style="background-color:#f4bf75"></div>
-<div class="preview-color" style="background-color:#66d9ef"></div>
-<div class="preview-color" style="background-color:#ae81ff"></div>
-<div class="preview-color" style="background-color:#a1efe4"></div>
-</div>
-</div>
-<h3 id="base16-monokai-light">Base16 Monokai Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#49483e"></div>
-<div class="preview-color" style="background-color:#272822"></div>
-<div class="preview-color" style="background-color:#f92672"></div>
-<div class="preview-color" style="background-color:#a6e22e"></div>
-<div class="preview-color" style="background-color:#f4bf75"></div>
-<div class="preview-color" style="background-color:#66d9ef"></div>
-<div class="preview-color" style="background-color:#ae81ff"></div>
-<div class="preview-color" style="background-color:#a1efe4"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#f9f8f5"></div>
-<div class="preview-color" style="background-color:#75715e"></div>
-<div class="preview-color" style="background-color:#f92672"></div>
-<div class="preview-color" style="background-color:#a6e22e"></div>
-<div class="preview-color" style="background-color:#f4bf75"></div>
-<div class="preview-color" style="background-color:#66d9ef"></div>
-<div class="preview-color" style="background-color:#ae81ff"></div>
-<div class="preview-color" style="background-color:#a1efe4"></div>
-</div>
-</div>
-<h3 id="base16-ocean-dark">Base16 Ocean Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#c0c5ce"></div>
-<div class="preview-color" style="background-color:#2b303b"></div>
-<div class="preview-color" style="background-color:#bf616a"></div>
-<div class="preview-color" style="background-color:#a3be8c"></div>
-<div class="preview-color" style="background-color:#ebcb8b"></div>
-<div class="preview-color" style="background-color:#8fa1b3"></div>
-<div class="preview-color" style="background-color:#b48ead"></div>
-<div class="preview-color" style="background-color:#96b5b4"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#2b303b"></div>
-<div class="preview-color" style="background-color:#65737e"></div>
-<div class="preview-color" style="background-color:#bf616a"></div>
-<div class="preview-color" style="background-color:#a3be8c"></div>
-<div class="preview-color" style="background-color:#ebcb8b"></div>
-<div class="preview-color" style="background-color:#8fa1b3"></div>
-<div class="preview-color" style="background-color:#b48ead"></div>
-<div class="preview-color" style="background-color:#96b5b4"></div>
-</div>
-</div>
-<h3 id="base16-ocean-light">Base16 Ocean Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#4f5b66"></div>
-<div class="preview-color" style="background-color:#2b303b"></div>
-<div class="preview-color" style="background-color:#bf616a"></div>
-<div class="preview-color" style="background-color:#a3be8c"></div>
-<div class="preview-color" style="background-color:#ebcb8b"></div>
-<div class="preview-color" style="background-color:#8fa1b3"></div>
-<div class="preview-color" style="background-color:#b48ead"></div>
-<div class="preview-color" style="background-color:#96b5b4"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#eff1f5"></div>
-<div class="preview-color" style="background-color:#65737e"></div>
-<div class="preview-color" style="background-color:#bf616a"></div>
-<div class="preview-color" style="background-color:#a3be8c"></div>
-<div class="preview-color" style="background-color:#ebcb8b"></div>
-<div class="preview-color" style="background-color:#8fa1b3"></div>
-<div class="preview-color" style="background-color:#b48ead"></div>
-<div class="preview-color" style="background-color:#96b5b4"></div>
-</div>
-</div>
-<h3 id="base16-paraiso-dark">Base16 Paraiso Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#a39e9b"></div>
-<div class="preview-color" style="background-color:#2f1e2e"></div>
-<div class="preview-color" style="background-color:#ef6155"></div>
-<div class="preview-color" style="background-color:#48b685"></div>
-<div class="preview-color" style="background-color:#fec418"></div>
-<div class="preview-color" style="background-color:#06b6ef"></div>
-<div class="preview-color" style="background-color:#815ba4"></div>
-<div class="preview-color" style="background-color:#5bc4bf"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#2f1e2e"></div>
-<div class="preview-color" style="background-color:#776e71"></div>
-<div class="preview-color" style="background-color:#ef6155"></div>
-<div class="preview-color" style="background-color:#48b685"></div>
-<div class="preview-color" style="background-color:#fec418"></div>
-<div class="preview-color" style="background-color:#06b6ef"></div>
-<div class="preview-color" style="background-color:#815ba4"></div>
-<div class="preview-color" style="background-color:#5bc4bf"></div>
-</div>
-</div>
-<h3 id="base16-paraiso-light">Base16 Paraiso Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#4f424c"></div>
-<div class="preview-color" style="background-color:#2f1e2e"></div>
-<div class="preview-color" style="background-color:#ef6155"></div>
-<div class="preview-color" style="background-color:#48b685"></div>
-<div class="preview-color" style="background-color:#fec418"></div>
-<div class="preview-color" style="background-color:#06b6ef"></div>
-<div class="preview-color" style="background-color:#815ba4"></div>
-<div class="preview-color" style="background-color:#5bc4bf"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#e7e9db"></div>
-<div class="preview-color" style="background-color:#776e71"></div>
-<div class="preview-color" style="background-color:#ef6155"></div>
-<div class="preview-color" style="background-color:#48b685"></div>
-<div class="preview-color" style="background-color:#fec418"></div>
-<div class="preview-color" style="background-color:#06b6ef"></div>
-<div class="preview-color" style="background-color:#815ba4"></div>
-<div class="preview-color" style="background-color:#5bc4bf"></div>
-</div>
-</div>
-<h3 id="base16-railscasts-dark">Base16 Railscasts Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#e6e1dc"></div>
-<div class="preview-color" style="background-color:#2b2b2b"></div>
-<div class="preview-color" style="background-color:#da4939"></div>
-<div class="preview-color" style="background-color:#a5c261"></div>
-<div class="preview-color" style="background-color:#ffc66d"></div>
-<div class="preview-color" style="background-color:#6d9cbe"></div>
-<div class="preview-color" style="background-color:#b6b3eb"></div>
-<div class="preview-color" style="background-color:#519f50"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#2b2b2b"></div>
-<div class="preview-color" style="background-color:#5a647e"></div>
-<div class="preview-color" style="background-color:#da4939"></div>
-<div class="preview-color" style="background-color:#a5c261"></div>
-<div class="preview-color" style="background-color:#ffc66d"></div>
-<div class="preview-color" style="background-color:#6d9cbe"></div>
-<div class="preview-color" style="background-color:#b6b3eb"></div>
-<div class="preview-color" style="background-color:#519f50"></div>
-</div>
-</div>
-<h3 id="base16-railscasts-light">Base16 Railscasts Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#3a4055"></div>
-<div class="preview-color" style="background-color:#2b2b2b"></div>
-<div class="preview-color" style="background-color:#da4939"></div>
-<div class="preview-color" style="background-color:#a5c261"></div>
-<div class="preview-color" style="background-color:#ffc66d"></div>
-<div class="preview-color" style="background-color:#6d9cbe"></div>
-<div class="preview-color" style="background-color:#b6b3eb"></div>
-<div class="preview-color" style="background-color:#519f50"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#f9f7f3"></div>
-<div class="preview-color" style="background-color:#5a647e"></div>
-<div class="preview-color" style="background-color:#da4939"></div>
-<div class="preview-color" style="background-color:#a5c261"></div>
-<div class="preview-color" style="background-color:#ffc66d"></div>
-<div class="preview-color" style="background-color:#6d9cbe"></div>
-<div class="preview-color" style="background-color:#b6b3eb"></div>
-<div class="preview-color" style="background-color:#519f50"></div>
-</div>
-</div>
-<h3 id="base16-shapeshifter-dark">Base16 Shapeshifter Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#ababab"></div>
-<div class="preview-color" style="background-color:#000000"></div>
-<div class="preview-color" style="background-color:#e92f2f"></div>
-<div class="preview-color" style="background-color:#0ed839"></div>
-<div class="preview-color" style="background-color:#dddd13"></div>
-<div class="preview-color" style="background-color:#3b48e3"></div>
-<div class="preview-color" style="background-color:#f996e2"></div>
-<div class="preview-color" style="background-color:#23edda"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#000000"></div>
-<div class="preview-color" style="background-color:#343434"></div>
-<div class="preview-color" style="background-color:#e92f2f"></div>
-<div class="preview-color" style="background-color:#0ed839"></div>
-<div class="preview-color" style="background-color:#dddd13"></div>
-<div class="preview-color" style="background-color:#3b48e3"></div>
-<div class="preview-color" style="background-color:#f996e2"></div>
-<div class="preview-color" style="background-color:#23edda"></div>
-</div>
-</div>
-<h3 id="base16-shapeshifter-light">Base16 Shapeshifter Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#102015"></div>
-<div class="preview-color" style="background-color:#000000"></div>
-<div class="preview-color" style="background-color:#e92f2f"></div>
-<div class="preview-color" style="background-color:#0ed839"></div>
-<div class="preview-color" style="background-color:#dddd13"></div>
-<div class="preview-color" style="background-color:#3b48e3"></div>
-<div class="preview-color" style="background-color:#f996e2"></div>
-<div class="preview-color" style="background-color:#23edda"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#f9f9f9"></div>
-<div class="preview-color" style="background-color:#343434"></div>
-<div class="preview-color" style="background-color:#e92f2f"></div>
-<div class="preview-color" style="background-color:#0ed839"></div>
-<div class="preview-color" style="background-color:#dddd13"></div>
-<div class="preview-color" style="background-color:#3b48e3"></div>
-<div class="preview-color" style="background-color:#f996e2"></div>
-<div class="preview-color" style="background-color:#23edda"></div>
-</div>
-</div>
-<h3 id="base16-solarized-dark">Base16 Solarized Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#93a1a1"></div>
-<div class="preview-color" style="background-color:#002b36"></div>
-<div class="preview-color" style="background-color:#dc322f"></div>
-<div class="preview-color" style="background-color:#859900"></div>
-<div class="preview-color" style="background-color:#b58900"></div>
-<div class="preview-color" style="background-color:#268bd2"></div>
-<div class="preview-color" style="background-color:#6c71c4"></div>
-<div class="preview-color" style="background-color:#2aa198"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#002b36"></div>
-<div class="preview-color" style="background-color:#657b83"></div>
-<div class="preview-color" style="background-color:#dc322f"></div>
-<div class="preview-color" style="background-color:#859900"></div>
-<div class="preview-color" style="background-color:#b58900"></div>
-<div class="preview-color" style="background-color:#268bd2"></div>
-<div class="preview-color" style="background-color:#6c71c4"></div>
-<div class="preview-color" style="background-color:#2aa198"></div>
-</div>
-</div>
-<h3 id="base16-solarized-light">Base16 Solarized Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#586e75"></div>
-<div class="preview-color" style="background-color:#002b36"></div>
-<div class="preview-color" style="background-color:#dc322f"></div>
-<div class="preview-color" style="background-color:#859900"></div>
-<div class="preview-color" style="background-color:#b58900"></div>
-<div class="preview-color" style="background-color:#268bd2"></div>
-<div class="preview-color" style="background-color:#6c71c4"></div>
-<div class="preview-color" style="background-color:#2aa198"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#fdf6e3"></div>
-<div class="preview-color" style="background-color:#657b83"></div>
-<div class="preview-color" style="background-color:#cb4b16"></div>
-<div class="preview-color" style="background-color:#073642"></div>
-<div class="preview-color" style="background-color:#586e75"></div>
-<div class="preview-color" style="background-color:#839496"></div>
-<div class="preview-color" style="background-color:#eee8d5"></div>
-<div class="preview-color" style="background-color:#d33682"></div>
-</div>
-</div>
-<h3 id="base16-summerfruit-dark">Base16 Summerfruit Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#D0D0D0"></div>
-<div class="preview-color" style="background-color:#151515"></div>
-<div class="preview-color" style="background-color:#FF0086"></div>
-<div class="preview-color" style="background-color:#00C918"></div>
-<div class="preview-color" style="background-color:#ABA800"></div>
-<div class="preview-color" style="background-color:#3777E6"></div>
-<div class="preview-color" style="background-color:#AD00A1"></div>
-<div class="preview-color" style="background-color:#1faaaa"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#151515"></div>
-<div class="preview-color" style="background-color:#505050"></div>
-<div class="preview-color" style="background-color:#FF0086"></div>
-<div class="preview-color" style="background-color:#00C918"></div>
-<div class="preview-color" style="background-color:#ABA800"></div>
-<div class="preview-color" style="background-color:#3777E6"></div>
-<div class="preview-color" style="background-color:#AD00A1"></div>
-<div class="preview-color" style="background-color:#1faaaa"></div>
-</div>
-</div>
-<h3 id="base16-summerfruit-light">Base16 Summerfruit Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#303030"></div>
-<div class="preview-color" style="background-color:#151515"></div>
-<div class="preview-color" style="background-color:#FF0086"></div>
-<div class="preview-color" style="background-color:#00C918"></div>
-<div class="preview-color" style="background-color:#ABA800"></div>
-<div class="preview-color" style="background-color:#3777E6"></div>
-<div class="preview-color" style="background-color:#AD00A1"></div>
-<div class="preview-color" style="background-color:#1faaaa"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#FFFFFF"></div>
-<div class="preview-color" style="background-color:#505050"></div>
-<div class="preview-color" style="background-color:#FF0086"></div>
-<div class="preview-color" style="background-color:#00C918"></div>
-<div class="preview-color" style="background-color:#ABA800"></div>
-<div class="preview-color" style="background-color:#3777E6"></div>
-<div class="preview-color" style="background-color:#AD00A1"></div>
-<div class="preview-color" style="background-color:#1faaaa"></div>
-</div>
-</div>
-<h3 id="base16-tomorrow-dark">Base16 Tomorrow Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#c5c8c6"></div>
-<div class="preview-color" style="background-color:#1d1f21"></div>
-<div class="preview-color" style="background-color:#cc6666"></div>
-<div class="preview-color" style="background-color:#b5bd68"></div>
-<div class="preview-color" style="background-color:#f0c674"></div>
-<div class="preview-color" style="background-color:#81a2be"></div>
-<div class="preview-color" style="background-color:#b294bb"></div>
-<div class="preview-color" style="background-color:#8abeb7"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#1d1f21"></div>
-<div class="preview-color" style="background-color:#969896"></div>
-<div class="preview-color" style="background-color:#cc6666"></div>
-<div class="preview-color" style="background-color:#b5bd68"></div>
-<div class="preview-color" style="background-color:#f0c674"></div>
-<div class="preview-color" style="background-color:#81a2be"></div>
-<div class="preview-color" style="background-color:#b294bb"></div>
-<div class="preview-color" style="background-color:#8abeb7"></div>
-</div>
-</div>
-<h3 id="base16-tomorrow-light">Base16 Tomorrow Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#373b41"></div>
-<div class="preview-color" style="background-color:#1d1f21"></div>
-<div class="preview-color" style="background-color:#cc6666"></div>
-<div class="preview-color" style="background-color:#b5bd68"></div>
-<div class="preview-color" style="background-color:#f0c674"></div>
-<div class="preview-color" style="background-color:#81a2be"></div>
-<div class="preview-color" style="background-color:#b294bb"></div>
-<div class="preview-color" style="background-color:#8abeb7"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#ffffff"></div>
-<div class="preview-color" style="background-color:#969896"></div>
-<div class="preview-color" style="background-color:#cc6666"></div>
-<div class="preview-color" style="background-color:#b5bd68"></div>
-<div class="preview-color" style="background-color:#f0c674"></div>
-<div class="preview-color" style="background-color:#81a2be"></div>
-<div class="preview-color" style="background-color:#b294bb"></div>
-<div class="preview-color" style="background-color:#8abeb7"></div>
-</div>
-</div>
-<h3 id="base16-twilight-dark">Base16 Twilight Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#a7a7a7"></div>
-<div class="preview-color" style="background-color:#1e1e1e"></div>
-<div class="preview-color" style="background-color:#cf6a4c"></div>
-<div class="preview-color" style="background-color:#8f9d6a"></div>
-<div class="preview-color" style="background-color:#f9ee98"></div>
-<div class="preview-color" style="background-color:#7587a6"></div>
-<div class="preview-color" style="background-color:#9b859d"></div>
-<div class="preview-color" style="background-color:#afc4db"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#1e1e1e"></div>
-<div class="preview-color" style="background-color:#5f5a60"></div>
-<div class="preview-color" style="background-color:#cf6a4c"></div>
-<div class="preview-color" style="background-color:#8f9d6a"></div>
-<div class="preview-color" style="background-color:#f9ee98"></div>
-<div class="preview-color" style="background-color:#7587a6"></div>
-<div class="preview-color" style="background-color:#9b859d"></div>
-<div class="preview-color" style="background-color:#afc4db"></div>
-</div>
-</div>
-<h3 id="base16-twilight-light">Base16 Twilight Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#464b50"></div>
-<div class="preview-color" style="background-color:#1e1e1e"></div>
-<div class="preview-color" style="background-color:#cf6a4c"></div>
-<div class="preview-color" style="background-color:#8f9d6a"></div>
-<div class="preview-color" style="background-color:#f9ee98"></div>
-<div class="preview-color" style="background-color:#7587a6"></div>
-<div class="preview-color" style="background-color:#9b859d"></div>
-<div class="preview-color" style="background-color:#afc4db"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#ffffff"></div>
-<div class="preview-color" style="background-color:#5f5a60"></div>
-<div class="preview-color" style="background-color:#cf6a4c"></div>
-<div class="preview-color" style="background-color:#8f9d6a"></div>
-<div class="preview-color" style="background-color:#f9ee98"></div>
-<div class="preview-color" style="background-color:#7587a6"></div>
-<div class="preview-color" style="background-color:#9b859d"></div>
-<div class="preview-color" style="background-color:#afc4db"></div>
-</div>
-</div>
-<h3 id="dracula">Dracula</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#f8f8f2"></div>
-<div class="preview-color" style="background-color:#000000"></div>
-<div class="preview-color" style="background-color:#ff5555"></div>
-<div class="preview-color" style="background-color:#50fa7b"></div>
-<div class="preview-color" style="background-color:#f1fa8c"></div>
-<div class="preview-color" style="background-color:#caa9fa"></div>
-<div class="preview-color" style="background-color:#ff79c6"></div>
-<div class="preview-color" style="background-color:#8be9fd"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#282a36"></div>
-<div class="preview-color" style="background-color:#4d4d4d"></div>
-<div class="preview-color" style="background-color:#ff6e67"></div>
-<div class="preview-color" style="background-color:#5af78e"></div>
-<div class="preview-color" style="background-color:#f4f99d"></div>
-<div class="preview-color" style="background-color:#caa9fa"></div>
-<div class="preview-color" style="background-color:#ff92d0"></div>
-<div class="preview-color" style="background-color:#9aedfe"></div>
-</div>
-</div>
-<h3 id="gnometerm">Gnometerm</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:none"></div>
-<div class="preview-color" style="background-color:#000000"></div>
-<div class="preview-color" style="background-color:#cc0000"></div>
-<div class="preview-color" style="background-color:#4e9a06"></div>
-<div class="preview-color" style="background-color:#c4a000"></div>
-<div class="preview-color" style="background-color:#3465a4"></div>
-<div class="preview-color" style="background-color:#75507b"></div>
-<div class="preview-color" style="background-color:#06989a"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:none"></div>
-<div class="preview-color" style="background-color:#555753"></div>
-<div class="preview-color" style="background-color:#ef2929"></div>
-<div class="preview-color" style="background-color:#8ae234"></div>
-<div class="preview-color" style="background-color:#fce94f"></div>
-<div class="preview-color" style="background-color:#729fcf"></div>
-<div class="preview-color" style="background-color:#ad7fa8"></div>
-<div class="preview-color" style="background-color:#34e2e2"></div>
-</div>
-</div>
-<h3 id="gotham">Gotham</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#98d1ce"></div>
-<div class="preview-color" style="background-color:#0a0f14"></div>
-<div class="preview-color" style="background-color:#c33027"></div>
-<div class="preview-color" style="background-color:#26a98b"></div>
-<div class="preview-color" style="background-color:#edb54b"></div>
-<div class="preview-color" style="background-color:#195465"></div>
-<div class="preview-color" style="background-color:#4e5165"></div>
-<div class="preview-color" style="background-color:#33859d"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#0a0f14"></div>
-<div class="preview-color" style="background-color:#10151b"></div>
-<div class="preview-color" style="background-color:#d26939"></div>
-<div class="preview-color" style="background-color:#081f2d"></div>
-<div class="preview-color" style="background-color:#245361"></div>
-<div class="preview-color" style="background-color:#093748"></div>
-<div class="preview-color" style="background-color:#888ba5"></div>
-<div class="preview-color" style="background-color:#599caa"></div>
-</div>
-</div>
-<h3 id="gruvbox-dark">Gruvbox Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#ebdbb2"></div>
-<div class="preview-color" style="background-color:#282828"></div>
-<div class="preview-color" style="background-color:#cc241d"></div>
-<div class="preview-color" style="background-color:#98971a"></div>
-<div class="preview-color" style="background-color:#d79921"></div>
-<div class="preview-color" style="background-color:#458588"></div>
-<div class="preview-color" style="background-color:#b16286"></div>
-<div class="preview-color" style="background-color:#689d6a"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#1d2021"></div>
-<div class="preview-color" style="background-color:#928374"></div>
-<div class="preview-color" style="background-color:#fb4934"></div>
-<div class="preview-color" style="background-color:#b8bb26"></div>
-<div class="preview-color" style="background-color:#fabd2f"></div>
-<div class="preview-color" style="background-color:#83a598"></div>
-<div class="preview-color" style="background-color:#d3869b"></div>
-<div class="preview-color" style="background-color:#8ec07c"></div>
-</div>
-</div>
-<h3 id="gruvbox-light">Gruvbox Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#3c3836"></div>
-<div class="preview-color" style="background-color:#fdf4c1"></div>
-<div class="preview-color" style="background-color:#cc241d"></div>
-<div class="preview-color" style="background-color:#98971a"></div>
-<div class="preview-color" style="background-color:#d79921"></div>
-<div class="preview-color" style="background-color:#458588"></div>
-<div class="preview-color" style="background-color:#b16286"></div>
-<div class="preview-color" style="background-color:#689d6a"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#f9f5d7"></div>
-<div class="preview-color" style="background-color:#928374"></div>
-<div class="preview-color" style="background-color:#9d0006"></div>
-<div class="preview-color" style="background-color:#79740e"></div>
-<div class="preview-color" style="background-color:#b57614"></div>
-<div class="preview-color" style="background-color:#076678"></div>
-<div class="preview-color" style="background-color:#8f3f71"></div>
-<div class="preview-color" style="background-color:#427b58"></div>
-</div>
-</div>
-<h3 id="material">Material</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#eceff1"></div>
-<div class="preview-color" style="background-color:#263238"></div>
-<div class="preview-color" style="background-color:#ff9800"></div>
-<div class="preview-color" style="background-color:#8bc34a"></div>
-<div class="preview-color" style="background-color:#ffc107"></div>
-<div class="preview-color" style="background-color:#03a9f4"></div>
-<div class="preview-color" style="background-color:#e91e63"></div>
-<div class="preview-color" style="background-color:#009688"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#263238"></div>
-<div class="preview-color" style="background-color:#37474f"></div>
-<div class="preview-color" style="background-color:#ffa74d"></div>
-<div class="preview-color" style="background-color:#9ccc65"></div>
-<div class="preview-color" style="background-color:#ffa000"></div>
-<div class="preview-color" style="background-color:#81d4fa"></div>
-<div class="preview-color" style="background-color:#ad1457"></div>
-<div class="preview-color" style="background-color:#26a69a"></div>
-</div>
-</div>
-<h3 id="nancy">Nancy</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#fff"></div>
-<div class="preview-color" style="background-color:#1b1d1e"></div>
-<div class="preview-color" style="background-color:#f92672"></div>
-<div class="preview-color" style="background-color:#82b414"></div>
-<div class="preview-color" style="background-color:#fd971f"></div>
-<div class="preview-color" style="background-color:#4e82aa"></div>
-<div class="preview-color" style="background-color:#8c54fe"></div>
-<div class="preview-color" style="background-color:#465457"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#010101"></div>
-<div class="preview-color" style="background-color:#505354"></div>
-<div class="preview-color" style="background-color:#ff5995"></div>
-<div class="preview-color" style="background-color:#b6e354"></div>
-<div class="preview-color" style="background-color:#feed6c"></div>
-<div class="preview-color" style="background-color:#0c73c2"></div>
-<div class="preview-color" style="background-color:#9e6ffe"></div>
-<div class="preview-color" style="background-color:#899ca1"></div>
-</div>
-</div>
-<h3 id="neon">Neon</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#F8F8F8"></div>
-<div class="preview-color" style="background-color:#171717"></div>
-<div class="preview-color" style="background-color:#D81765"></div>
-<div class="preview-color" style="background-color:#97D01A"></div>
-<div class="preview-color" style="background-color:#FFA800"></div>
-<div class="preview-color" style="background-color:#16B1FB"></div>
-<div class="preview-color" style="background-color:#FF2491"></div>
-<div class="preview-color" style="background-color:#0FDCB6"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#171717"></div>
-<div class="preview-color" style="background-color:#38252C"></div>
-<div class="preview-color" style="background-color:#FF0000"></div>
-<div class="preview-color" style="background-color:#76B639"></div>
-<div class="preview-color" style="background-color:#E1A126"></div>
-<div class="preview-color" style="background-color:#289CD5"></div>
-<div class="preview-color" style="background-color:#FF2491"></div>
-<div class="preview-color" style="background-color:#0A9B81"></div>
-</div>
-</div>
-<h3 id="rydgel">Rydgel</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:none"></div>
-<div class="preview-color" style="background-color:#303430"></div>
-<div class="preview-color" style="background-color:#bf7979"></div>
-<div class="preview-color" style="background-color:#97b26b"></div>
-<div class="preview-color" style="background-color:#cdcdc1"></div>
-<div class="preview-color" style="background-color:#86a2be"></div>
-<div class="preview-color" style="background-color:#d9b798"></div>
-<div class="preview-color" style="background-color:#a1b5cd"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:none"></div>
-<div class="preview-color" style="background-color:#cdb5cd"></div>
-<div class="preview-color" style="background-color:#f4a45f"></div>
-<div class="preview-color" style="background-color:#c5f779"></div>
-<div class="preview-color" style="background-color:#ffffed"></div>
-<div class="preview-color" style="background-color:#98afd9"></div>
-<div class="preview-color" style="background-color:#d7d998"></div>
-<div class="preview-color" style="background-color:#a1b5cd"></div>
-</div>
-</div>
-<h3 id="solarized-dark">Solarized Dark</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#839496"></div>
-<div class="preview-color" style="background-color:#073642"></div>
-<div class="preview-color" style="background-color:#dc322f"></div>
-<div class="preview-color" style="background-color:#859900"></div>
-<div class="preview-color" style="background-color:#b58900"></div>
-<div class="preview-color" style="background-color:#268bd2"></div>
-<div class="preview-color" style="background-color:#d33682"></div>
-<div class="preview-color" style="background-color:#2aa198"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#002b36"></div>
-<div class="preview-color" style="background-color:#002b36"></div>
-<div class="preview-color" style="background-color:#cb4b16"></div>
-<div class="preview-color" style="background-color:#586e75"></div>
-<div class="preview-color" style="background-color:#657b83"></div>
-<div class="preview-color" style="background-color:#839496"></div>
-<div class="preview-color" style="background-color:#6c71c4"></div>
-<div class="preview-color" style="background-color:#93a1a1"></div>
-</div>
-</div>
-<h3 id="solarized-light">Solarized Light</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#657b83"></div>
-<div class="preview-color" style="background-color:#073642"></div>
-<div class="preview-color" style="background-color:#dc322f"></div>
-<div class="preview-color" style="background-color:#859900"></div>
-<div class="preview-color" style="background-color:#b58900"></div>
-<div class="preview-color" style="background-color:#268bd2"></div>
-<div class="preview-color" style="background-color:#d33682"></div>
-<div class="preview-color" style="background-color:#2aa198"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#fdf6e3"></div>
-<div class="preview-color" style="background-color:#002b36"></div>
-<div class="preview-color" style="background-color:#cb4b16"></div>
-<div class="preview-color" style="background-color:#586e75"></div>
-<div class="preview-color" style="background-color:#657b83"></div>
-<div class="preview-color" style="background-color:#839496"></div>
-<div class="preview-color" style="background-color:#6c71c4"></div>
-<div class="preview-color" style="background-color:#93a1a1"></div>
-</div>
-</div>
-<h3 id="tomorrow-night">Tomorrow Night</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#c5c8c6"></div>
-<div class="preview-color" style="background-color:#1d1f21"></div>
-<div class="preview-color" style="background-color:#cc6666"></div>
-<div class="preview-color" style="background-color:#b5bd68"></div>
-<div class="preview-color" style="background-color:#f0c674"></div>
-<div class="preview-color" style="background-color:#81a2be"></div>
-<div class="preview-color" style="background-color:#b294bb"></div>
-<div class="preview-color" style="background-color:#8abeb7"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#1d1f21"></div>
-<div class="preview-color" style="background-color:#cc6666"></div>
-<div class="preview-color" style="background-color:#969896"></div>
-<div class="preview-color" style="background-color:#b5bd68"></div>
-<div class="preview-color" style="background-color:#f0c674"></div>
-<div class="preview-color" style="background-color:#81a2be"></div>
-<div class="preview-color" style="background-color:#b294bb"></div>
-<div class="preview-color" style="background-color:#8abeb7"></div>
-</div>
-</div>
-<h3 id="zenburn">Zenburn</h3>
-<div class="preview-color-block">
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#ffffff"></div>
-<div class="preview-color" style="background-color:#000000"></div>
-<div class="preview-color" style="background-color:#9e1828"></div>
-<div class="preview-color" style="background-color:#aece92"></div>
-<div class="preview-color" style="background-color:#968a38"></div>
-<div class="preview-color" style="background-color:#414171"></div>
-<div class="preview-color" style="background-color:#963c59"></div>
-<div class="preview-color" style="background-color:#418179"></div>
-</div>
-<div class="preview-color-row">
-<div class="preview-color" style="background-color:#000010"></div>
-<div class="preview-color" style="background-color:#666666"></div>
-<div class="preview-color" style="background-color:#cf6171"></div>
-<div class="preview-color" style="background-color:#c5f779"></div>
-<div class="preview-color" style="background-color:#fff796"></div>
-<div class="preview-color" style="background-color:#4186be"></div>
-<div class="preview-color" style="background-color:#cf9ebe"></div>
-<div class="preview-color" style="background-color:#71bebe"></div>
-</div>
-</div>
+
+* [Base16 3024 Dark](#base16-3024-dark)
+* [Base16 3024 Light](#base16-3024-light)
+* [Base16 Apathy Dark](#base16-apathy-dark)
+* [Base16 Apathy Light](#base16-apathy-light)
+* [Base16 Ashes Dark](#base16-ashes-dark)
+* [Base16 Ashes Light](#base16-ashes-light)
+* [Base16 Atelierdune Dark](#base16-atelierdune-dark)
+* [Base16 Atelierdune Light](#base16-atelierdune-light)
+* [Base16 Atelierforest Dark](#base16-atelierforest-dark)
+* [Base16 Atelierforest Light](#base16-atelierforest-light)
+* [Base16 Atelierheath Dark](#base16-atelierheath-dark)
+* [Base16 Atelierheath Light](#base16-atelierheath-light)
+* [Base16 Atelierlakeside Dark](#base16-atelierlakeside-dark)
+* [Base16 Atelierlakeside Light](#base16-atelierlakeside-light)
+* [Base16 Atelierseaside Dark](#base16-atelierseaside-dark)
+* [Base16 Atelierseaside Light](#base16-atelierseaside-light)
+* [Base16 Bespin Dark](#base16-bespin-dark)
+* [Base16 Bespin Light](#base16-bespin-light)
+* [Base16 Brewer Dark](#base16-brewer-dark)
+* [Base16 Brewer Light](#base16-brewer-light)
+* [Base16 Bright Dark](#base16-bright-dark)
+* [Base16 Bright Light](#base16-bright-light)
+* [Base16 Chalk Dark](#base16-chalk-dark)
+* [Base16 Chalk Light](#base16-chalk-light)
+* [Base16 Codeschool Dark](#base16-codeschool-dark)
+* [Base16 Codeschool Light](#base16-codeschool-light)
+* [Base16 Colors Dark](#base16-colors-dark)
+* [Base16 Colors Light](#base16-colors-light)
+* [Base16 Default Dark](#base16-default-dark)
+* [Base16 Default Light](#base16-default-light)
+* [Base16 Eighties Dark](#base16-eighties-dark)
+* [Base16 Eighties Light](#base16-eighties-light)
+* [Base16 Embers Dark](#base16-embers-dark)
+* [Base16 Embers Light](#base16-embers-light)
+* [Base16 Flat Dark](#base16-flat-dark)
+* [Base16 Flat Light](#base16-flat-light)
+* [Base16 Google Dark](#base16-google-dark)
+* [Base16 Google Light](#base16-google-light)
+* [Base16 Grayscale Dark](#base16-grayscale-dark)
+* [Base16 Grayscale Light](#base16-grayscale-light)
+* [Base16 Greenscreen Dark](#base16-greenscreen-dark)
+* [Base16 Greenscreen Light](#base16-greenscreen-light)
+* [Base16 Harmonic16 Dark](#base16-harmonic16-dark)
+* [Base16 Harmonic16 Light](#base16-harmonic16-light)
+* [Base16 Isotope Dark](#base16-isotope-dark)
+* [Base16 Isotope Light](#base16-isotope-light)
+* [Base16 Londontube Dark](#base16-londontube-dark)
+* [Base16 Londontube Light](#base16-londontube-light)
+* [Base16 Marrakesh Dark](#base16-marrakesh-dark)
+* [Base16 Marrakesh Light](#base16-marrakesh-light)
+* [Base16 Mocha Dark](#base16-mocha-dark)
+* [Base16 Mocha Light](#base16-mocha-light)
+* [Base16 Monokai Dark](#base16-monokai-dark)
+* [Base16 Monokai Light](#base16-monokai-light)
+* [Base16 Ocean Dark](#base16-ocean-dark)
+* [Base16 Ocean Light](#base16-ocean-light)
+* [Base16 Paraiso Dark](#base16-paraiso-dark)
+* [Base16 Paraiso Light](#base16-paraiso-light)
+* [Base16 Railscasts Dark](#base16-railscasts-dark)
+* [Base16 Railscasts Light](#base16-railscasts-light)
+* [Base16 Shapeshifter Dark](#base16-shapeshifter-dark)
+* [Base16 Shapeshifter Light](#base16-shapeshifter-light)
+* [Base16 Solarized Dark](#base16-solarized-dark)
+* [Base16 Solarized Light](#base16-solarized-light)
+* [Base16 Summerfruit Dark](#base16-summerfruit-dark)
+* [Base16 Summerfruit Light](#base16-summerfruit-light)
+* [Base16 Tomorrow Dark](#base16-tomorrow-dark)
+* [Base16 Tomorrow Light](#base16-tomorrow-light)
+* [Base16 Twilight Dark](#base16-twilight-dark)
+* [Base16 Twilight Light](#base16-twilight-light)
+* [Dracula](#dracula)
+* [Gnometerm](#gnometerm)
+* [Gotham](#gotham)
+* [Gruvbox Dark](#gruvbox-dark)
+* [Gruvbox Light](#gruvbox-light)
+* [Material](#material)
+* [Nancy](#nancy)
+* [Neon](#neon)
+* [Rydgel](#rydgel)
+* [Solarized Dark](#solarized-dark)
+* [Solarized Light](#solarized-light)
+* [Tomorrow Night](#tomorrow-night)
+* [Zenburn](#zenburn)
+
+<h3 id="base16-3024-dark">Base16 3024 Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#a5a2a2"></div><div class="preview-color" style="background-color:#090300"></div><div class="preview-color" style="background-color:#db2d20"></div><div class="preview-color" style="background-color:#01a252"></div><div class="preview-color" style="background-color:#fded02"></div><div class="preview-color" style="background-color:#01a0e4"></div><div class="preview-color" style="background-color:#a16a94"></div><div class="preview-color" style="background-color:#b5e4f4"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#090300"></div><div class="preview-color" style="background-color:#5c5855"></div><div class="preview-color" style="background-color:#db2d20"></div><div class="preview-color" style="background-color:#01a252"></div><div class="preview-color" style="background-color:#fded02"></div><div class="preview-color" style="background-color:#01a0e4"></div><div class="preview-color" style="background-color:#a16a94"></div><div class="preview-color" style="background-color:#b5e4f4"></div></div></div><style>.codeexample-base16-3024-dark .highlight code, .codeexample-base16-3024-dark .highlight pre{color:#a5a2a2;background-color:#090300}.codeexample-base16-3024-dark .highlight .hll{background-color:#5c5855}.codeexample-base16-3024-dark .highlight .c{color:#a5a2a2}.codeexample-base16-3024-dark .highlight .err{color:#01a252;background-color:#5c5855}.codeexample-base16-3024-dark .highlight .g{color:#a5a2a2}.codeexample-base16-3024-dark .highlight .k{color:#01a0e4}.codeexample-base16-3024-dark .highlight .l{color:#a16a94}.codeexample-base16-3024-dark .highlight .n{color:#a5a2a2}.codeexample-base16-3024-dark .highlight .o{color:#fded02}.codeexample-base16-3024-dark .highlight .x{color:#a16a94}.codeexample-base16-3024-dark .highlight .p{color:#f7f7f7}.codeexample-base16-3024-dark .highlight .cm{color:#a5a2a2}.codeexample-base16-3024-dark .highlight .cp{color:#a5a2a2}.codeexample-base16-3024-dark .highlight .c1{color:#a5a2a2}.codeexample-base16-3024-dark .highlight .cs{color:#01a252;font-weight:bold}.codeexample-base16-3024-dark .highlight .gd{color:#01a252}.codeexample-base16-3024-dark .highlight .ge{color:#a16a94;font-style:italic}.codeexample-base16-3024-dark .highlight .gr{color:#01a252}.codeexample-base16-3024-dark .highlight .gh{color:#a5a2a2;font-weight:bold}.codeexample-base16-3024-dark .highlight .gi{color:#fded02}.codeexample-base16-3024-dark .highlight .go{color:#5c5855}.codeexample-base16-3024-dark .highlight .gp{color:#a5a2a2;font-weight:bold}.codeexample-base16-3024-dark .highlight .gs{color:#a16a94;font-weight:bold}.codeexample-base16-3024-dark .highlight .gu{color:#a16a94;font-weight:bold}.codeexample-base16-3024-dark .highlight .gt{color:#01a0e4}.codeexample-base16-3024-dark .highlight .kc{color:#db2d20}.codeexample-base16-3024-dark .highlight .kd{color:#fded02}.codeexample-base16-3024-dark .highlight .kn{color:#01a0e4;font-weight:bold}.codeexample-base16-3024-dark .highlight .kp{color:#01a252}.codeexample-base16-3024-dark .highlight .kr{color:#01a252}.codeexample-base16-3024-dark .highlight .kt{color:#a5a2a2}.codeexample-base16-3024-dark .highlight .ld{color:#b5e4f4}.codeexample-base16-3024-dark .highlight .m{color:#a16a94}.codeexample-base16-3024-dark .highlight .s{color:#b5e4f4}.codeexample-base16-3024-dark .highlight .na{color:#01a252}.codeexample-base16-3024-dark .highlight .nb{color:#01a0e4}.codeexample-base16-3024-dark .highlight .nc{color:#01a0e4}.codeexample-base16-3024-dark .highlight .no{color:#a16a94}.codeexample-base16-3024-dark .highlight .nd{color:#a16a94}.codeexample-base16-3024-dark .highlight .ni{color:#db2d20}.codeexample-base16-3024-dark .highlight .ne{color:#fded02;font-weight:bold}.codeexample-base16-3024-dark .highlight .nf{color:#01a0e4}.codeexample-base16-3024-dark .highlight .nl{color:#a16a94}.codeexample-base16-3024-dark .highlight .nn{color:#01a0e4}.codeexample-base16-3024-dark .highlight .nx{color:#a16a94}.codeexample-base16-3024-dark .highlight .py{color:#a16a94}.codeexample-base16-3024-dark .highlight .nt{color:#01a252}.codeexample-base16-3024-dark .highlight .nv{color:#a5a2a2}.codeexample-base16-3024-dark .highlight .ow{color:#fded02}.codeexample-base16-3024-dark .highlight .w{color:#a16a94}.codeexample-base16-3024-dark .highlight .mf{color:#a16a94}.codeexample-base16-3024-dark .highlight .mh{color:#a16a94}.codeexample-base16-3024-dark .highlight .mi{color:#a16a94}.codeexample-base16-3024-dark .highlight .mo{color:#a16a94}.codeexample-base16-3024-dark .highlight .sb{color:#b5e4f4}.codeexample-base16-3024-dark .highlight .sc{color:#b5e4f4}.codeexample-base16-3024-dark .highlight .sd{color:#b5e4f4}.codeexample-base16-3024-dark .highlight .s2{color:#b5e4f4}.codeexample-base16-3024-dark .highlight .se{color:#b5e4f4}.codeexample-base16-3024-dark .highlight .sh{color:#b5e4f4}.codeexample-base16-3024-dark .highlight .si{color:#b5e4f4}.codeexample-base16-3024-dark .highlight .sx{color:#b5e4f4}.codeexample-base16-3024-dark .highlight .sr{color:#b5e4f4}.codeexample-base16-3024-dark .highlight .s1{color:#b5e4f4}.codeexample-base16-3024-dark .highlight .ss{color:#b5e4f4}.codeexample-base16-3024-dark .highlight .bp{color:#01a0e4}.codeexample-base16-3024-dark .highlight .vc{color:#01a0e4}.codeexample-base16-3024-dark .highlight .vg{color:#a5a2a2}.codeexample-base16-3024-dark .highlight .vi{color:#fded02}.codeexample-base16-3024-dark .highlight .il{color:#a16a94}</style><div class="codeexample codeexample-base16-3024-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-3024-light">Base16 3024 Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#4a4543"></div><div class="preview-color" style="background-color:#090300"></div><div class="preview-color" style="background-color:#db2d20"></div><div class="preview-color" style="background-color:#01a252"></div><div class="preview-color" style="background-color:#fded02"></div><div class="preview-color" style="background-color:#01a0e4"></div><div class="preview-color" style="background-color:#a16a94"></div><div class="preview-color" style="background-color:#b5e4f4"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#f7f7f7"></div><div class="preview-color" style="background-color:#5c5855"></div><div class="preview-color" style="background-color:#db2d20"></div><div class="preview-color" style="background-color:#01a252"></div><div class="preview-color" style="background-color:#fded02"></div><div class="preview-color" style="background-color:#01a0e4"></div><div class="preview-color" style="background-color:#a16a94"></div><div class="preview-color" style="background-color:#b5e4f4"></div></div></div><style>.codeexample-base16-3024-light .highlight code, .codeexample-base16-3024-light .highlight pre{color:#4a4543;background-color:#f7f7f7}.codeexample-base16-3024-light .highlight .hll{background-color:#5c5855}.codeexample-base16-3024-light .highlight .c{color:#a5a2a2}.codeexample-base16-3024-light .highlight .err{color:#01a252;background-color:#5c5855}.codeexample-base16-3024-light .highlight .g{color:#a5a2a2}.codeexample-base16-3024-light .highlight .k{color:#01a0e4}.codeexample-base16-3024-light .highlight .l{color:#a16a94}.codeexample-base16-3024-light .highlight .n{color:#4a4543}.codeexample-base16-3024-light .highlight .o{color:#fded02}.codeexample-base16-3024-light .highlight .x{color:#a16a94}.codeexample-base16-3024-light .highlight .p{color:#f7f7f7}.codeexample-base16-3024-light .highlight .cm{color:#a5a2a2}.codeexample-base16-3024-light .highlight .cp{color:#a5a2a2}.codeexample-base16-3024-light .highlight .c1{color:#a5a2a2}.codeexample-base16-3024-light .highlight .cs{color:#01a252;font-weight:bold}.codeexample-base16-3024-light .highlight .gd{color:#01a252}.codeexample-base16-3024-light .highlight .ge{color:#a16a94;font-style:italic}.codeexample-base16-3024-light .highlight .gr{color:#01a252}.codeexample-base16-3024-light .highlight .gh{color:#4a4543;font-weight:bold}.codeexample-base16-3024-light .highlight .gi{color:#fded02}.codeexample-base16-3024-light .highlight .go{color:#5c5855}.codeexample-base16-3024-light .highlight .gp{color:#4a4543;font-weight:bold}.codeexample-base16-3024-light .highlight .gs{color:#a16a94;font-weight:bold}.codeexample-base16-3024-light .highlight .gu{color:#a16a94;font-weight:bold}.codeexample-base16-3024-light .highlight .gt{color:#01a0e4}.codeexample-base16-3024-light .highlight .kc{color:#db2d20}.codeexample-base16-3024-light .highlight .kd{color:#fded02}.codeexample-base16-3024-light .highlight .kn{color:#01a0e4;font-weight:bold}.codeexample-base16-3024-light .highlight .kp{color:#01a252}.codeexample-base16-3024-light .highlight .kr{color:#01a252}.codeexample-base16-3024-light .highlight .kt{color:#a5a2a2}.codeexample-base16-3024-light .highlight .ld{color:#b5e4f4}.codeexample-base16-3024-light .highlight .m{color:#a16a94}.codeexample-base16-3024-light .highlight .s{color:#b5e4f4}.codeexample-base16-3024-light .highlight .na{color:#01a252}.codeexample-base16-3024-light .highlight .nb{color:#01a0e4}.codeexample-base16-3024-light .highlight .nc{color:#01a0e4}.codeexample-base16-3024-light .highlight .no{color:#a16a94}.codeexample-base16-3024-light .highlight .nd{color:#a16a94}.codeexample-base16-3024-light .highlight .ni{color:#db2d20}.codeexample-base16-3024-light .highlight .ne{color:#fded02;font-weight:bold}.codeexample-base16-3024-light .highlight .nf{color:#01a0e4}.codeexample-base16-3024-light .highlight .nl{color:#a16a94}.codeexample-base16-3024-light .highlight .nn{color:#01a0e4}.codeexample-base16-3024-light .highlight .nx{color:#a16a94}.codeexample-base16-3024-light .highlight .py{color:#a16a94}.codeexample-base16-3024-light .highlight .nt{color:#01a252}.codeexample-base16-3024-light .highlight .nv{color:#4a4543}.codeexample-base16-3024-light .highlight .ow{color:#fded02}.codeexample-base16-3024-light .highlight .w{color:#a16a94}.codeexample-base16-3024-light .highlight .mf{color:#a16a94}.codeexample-base16-3024-light .highlight .mh{color:#a16a94}.codeexample-base16-3024-light .highlight .mi{color:#a16a94}.codeexample-base16-3024-light .highlight .mo{color:#a16a94}.codeexample-base16-3024-light .highlight .sb{color:#b5e4f4}.codeexample-base16-3024-light .highlight .sc{color:#b5e4f4}.codeexample-base16-3024-light .highlight .sd{color:#b5e4f4}.codeexample-base16-3024-light .highlight .s2{color:#b5e4f4}.codeexample-base16-3024-light .highlight .se{color:#b5e4f4}.codeexample-base16-3024-light .highlight .sh{color:#b5e4f4}.codeexample-base16-3024-light .highlight .si{color:#b5e4f4}.codeexample-base16-3024-light .highlight .sx{color:#b5e4f4}.codeexample-base16-3024-light .highlight .sr{color:#b5e4f4}.codeexample-base16-3024-light .highlight .s1{color:#b5e4f4}.codeexample-base16-3024-light .highlight .ss{color:#b5e4f4}.codeexample-base16-3024-light .highlight .bp{color:#01a0e4}.codeexample-base16-3024-light .highlight .vc{color:#01a0e4}.codeexample-base16-3024-light .highlight .vg{color:#4a4543}.codeexample-base16-3024-light .highlight .vi{color:#fded02}.codeexample-base16-3024-light .highlight .il{color:#a16a94}</style><div class="codeexample codeexample-base16-3024-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-apathy-dark">Base16 Apathy Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#81B5AC"></div><div class="preview-color" style="background-color:#031A16"></div><div class="preview-color" style="background-color:#3E9688"></div><div class="preview-color" style="background-color:#883E96"></div><div class="preview-color" style="background-color:#3E4C96"></div><div class="preview-color" style="background-color:#96883E"></div><div class="preview-color" style="background-color:#4C963E"></div><div class="preview-color" style="background-color:#963E4C"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#031A16"></div><div class="preview-color" style="background-color:#2B685E"></div><div class="preview-color" style="background-color:#3E9688"></div><div class="preview-color" style="background-color:#883E96"></div><div class="preview-color" style="background-color:#3E4C96"></div><div class="preview-color" style="background-color:#96883E"></div><div class="preview-color" style="background-color:#4C963E"></div><div class="preview-color" style="background-color:#963E4C"></div></div></div><style>.codeexample-base16-apathy-dark .highlight code, .codeexample-base16-apathy-dark .highlight pre{color:#81B5AC;background-color:#031A16}.codeexample-base16-apathy-dark .highlight .hll{background-color:#2B685E}.codeexample-base16-apathy-dark .highlight .c{color:#81B5AC}.codeexample-base16-apathy-dark .highlight .err{color:#883E96;background-color:#2B685E}.codeexample-base16-apathy-dark .highlight .g{color:#81B5AC}.codeexample-base16-apathy-dark .highlight .k{color:#96883E}.codeexample-base16-apathy-dark .highlight .l{color:#4C963E}.codeexample-base16-apathy-dark .highlight .n{color:#81B5AC}.codeexample-base16-apathy-dark .highlight .o{color:#3E4C96}.codeexample-base16-apathy-dark .highlight .x{color:#4C963E}.codeexample-base16-apathy-dark .highlight .p{color:#D2E7E4}.codeexample-base16-apathy-dark .highlight .cm{color:#81B5AC}.codeexample-base16-apathy-dark .highlight .cp{color:#81B5AC}.codeexample-base16-apathy-dark .highlight .c1{color:#81B5AC}.codeexample-base16-apathy-dark .highlight .cs{color:#883E96;font-weight:bold}.codeexample-base16-apathy-dark .highlight .gd{color:#883E96}.codeexample-base16-apathy-dark .highlight .ge{color:#4C963E;font-style:italic}.codeexample-base16-apathy-dark .highlight .gr{color:#883E96}.codeexample-base16-apathy-dark .highlight .gh{color:#81B5AC;font-weight:bold}.codeexample-base16-apathy-dark .highlight .gi{color:#3E4C96}.codeexample-base16-apathy-dark .highlight .go{color:#2B685E}.codeexample-base16-apathy-dark .highlight .gp{color:#81B5AC;font-weight:bold}.codeexample-base16-apathy-dark .highlight .gs{color:#4C963E;font-weight:bold}.codeexample-base16-apathy-dark .highlight .gu{color:#4C963E;font-weight:bold}.codeexample-base16-apathy-dark .highlight .gt{color:#96883E}.codeexample-base16-apathy-dark .highlight .kc{color:#3E9688}.codeexample-base16-apathy-dark .highlight .kd{color:#3E4C96}.codeexample-base16-apathy-dark .highlight .kn{color:#96883E;font-weight:bold}.codeexample-base16-apathy-dark .highlight .kp{color:#883E96}.codeexample-base16-apathy-dark .highlight .kr{color:#883E96}.codeexample-base16-apathy-dark .highlight .kt{color:#81B5AC}.codeexample-base16-apathy-dark .highlight .ld{color:#963E4C}.codeexample-base16-apathy-dark .highlight .m{color:#4C963E}.codeexample-base16-apathy-dark .highlight .s{color:#963E4C}.codeexample-base16-apathy-dark .highlight .na{color:#883E96}.codeexample-base16-apathy-dark .highlight .nb{color:#96883E}.codeexample-base16-apathy-dark .highlight .nc{color:#96883E}.codeexample-base16-apathy-dark .highlight .no{color:#4C963E}.codeexample-base16-apathy-dark .highlight .nd{color:#4C963E}.codeexample-base16-apathy-dark .highlight .ni{color:#3E9688}.codeexample-base16-apathy-dark .highlight .ne{color:#3E4C96;font-weight:bold}.codeexample-base16-apathy-dark .highlight .nf{color:#96883E}.codeexample-base16-apathy-dark .highlight .nl{color:#4C963E}.codeexample-base16-apathy-dark .highlight .nn{color:#96883E}.codeexample-base16-apathy-dark .highlight .nx{color:#4C963E}.codeexample-base16-apathy-dark .highlight .py{color:#4C963E}.codeexample-base16-apathy-dark .highlight .nt{color:#883E96}.codeexample-base16-apathy-dark .highlight .nv{color:#81B5AC}.codeexample-base16-apathy-dark .highlight .ow{color:#3E4C96}.codeexample-base16-apathy-dark .highlight .w{color:#4C963E}.codeexample-base16-apathy-dark .highlight .mf{color:#4C963E}.codeexample-base16-apathy-dark .highlight .mh{color:#4C963E}.codeexample-base16-apathy-dark .highlight .mi{color:#4C963E}.codeexample-base16-apathy-dark .highlight .mo{color:#4C963E}.codeexample-base16-apathy-dark .highlight .sb{color:#963E4C}.codeexample-base16-apathy-dark .highlight .sc{color:#963E4C}.codeexample-base16-apathy-dark .highlight .sd{color:#963E4C}.codeexample-base16-apathy-dark .highlight .s2{color:#963E4C}.codeexample-base16-apathy-dark .highlight .se{color:#963E4C}.codeexample-base16-apathy-dark .highlight .sh{color:#963E4C}.codeexample-base16-apathy-dark .highlight .si{color:#963E4C}.codeexample-base16-apathy-dark .highlight .sx{color:#963E4C}.codeexample-base16-apathy-dark .highlight .sr{color:#963E4C}.codeexample-base16-apathy-dark .highlight .s1{color:#963E4C}.codeexample-base16-apathy-dark .highlight .ss{color:#963E4C}.codeexample-base16-apathy-dark .highlight .bp{color:#96883E}.codeexample-base16-apathy-dark .highlight .vc{color:#96883E}.codeexample-base16-apathy-dark .highlight .vg{color:#81B5AC}.codeexample-base16-apathy-dark .highlight .vi{color:#3E4C96}.codeexample-base16-apathy-dark .highlight .il{color:#4C963E}</style><div class="codeexample codeexample-base16-apathy-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-apathy-light">Base16 Apathy Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#184E45"></div><div class="preview-color" style="background-color:#031A16"></div><div class="preview-color" style="background-color:#3E9688"></div><div class="preview-color" style="background-color:#883E96"></div><div class="preview-color" style="background-color:#3E4C96"></div><div class="preview-color" style="background-color:#96883E"></div><div class="preview-color" style="background-color:#4C963E"></div><div class="preview-color" style="background-color:#963E4C"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#D2E7E4"></div><div class="preview-color" style="background-color:#2B685E"></div><div class="preview-color" style="background-color:#3E9688"></div><div class="preview-color" style="background-color:#883E96"></div><div class="preview-color" style="background-color:#3E4C96"></div><div class="preview-color" style="background-color:#96883E"></div><div class="preview-color" style="background-color:#4C963E"></div><div class="preview-color" style="background-color:#963E4C"></div></div></div><style>.codeexample-base16-apathy-light .highlight code, .codeexample-base16-apathy-light .highlight pre{color:#184E45;background-color:#D2E7E4}.codeexample-base16-apathy-light .highlight .hll{background-color:#2B685E}.codeexample-base16-apathy-light .highlight .c{color:#81B5AC}.codeexample-base16-apathy-light .highlight .err{color:#883E96;background-color:#2B685E}.codeexample-base16-apathy-light .highlight .g{color:#81B5AC}.codeexample-base16-apathy-light .highlight .k{color:#96883E}.codeexample-base16-apathy-light .highlight .l{color:#4C963E}.codeexample-base16-apathy-light .highlight .n{color:#184E45}.codeexample-base16-apathy-light .highlight .o{color:#3E4C96}.codeexample-base16-apathy-light .highlight .x{color:#4C963E}.codeexample-base16-apathy-light .highlight .p{color:#D2E7E4}.codeexample-base16-apathy-light .highlight .cm{color:#81B5AC}.codeexample-base16-apathy-light .highlight .cp{color:#81B5AC}.codeexample-base16-apathy-light .highlight .c1{color:#81B5AC}.codeexample-base16-apathy-light .highlight .cs{color:#883E96;font-weight:bold}.codeexample-base16-apathy-light .highlight .gd{color:#883E96}.codeexample-base16-apathy-light .highlight .ge{color:#4C963E;font-style:italic}.codeexample-base16-apathy-light .highlight .gr{color:#883E96}.codeexample-base16-apathy-light .highlight .gh{color:#184E45;font-weight:bold}.codeexample-base16-apathy-light .highlight .gi{color:#3E4C96}.codeexample-base16-apathy-light .highlight .go{color:#2B685E}.codeexample-base16-apathy-light .highlight .gp{color:#184E45;font-weight:bold}.codeexample-base16-apathy-light .highlight .gs{color:#4C963E;font-weight:bold}.codeexample-base16-apathy-light .highlight .gu{color:#4C963E;font-weight:bold}.codeexample-base16-apathy-light .highlight .gt{color:#96883E}.codeexample-base16-apathy-light .highlight .kc{color:#3E9688}.codeexample-base16-apathy-light .highlight .kd{color:#3E4C96}.codeexample-base16-apathy-light .highlight .kn{color:#96883E;font-weight:bold}.codeexample-base16-apathy-light .highlight .kp{color:#883E96}.codeexample-base16-apathy-light .highlight .kr{color:#883E96}.codeexample-base16-apathy-light .highlight .kt{color:#81B5AC}.codeexample-base16-apathy-light .highlight .ld{color:#963E4C}.codeexample-base16-apathy-light .highlight .m{color:#4C963E}.codeexample-base16-apathy-light .highlight .s{color:#963E4C}.codeexample-base16-apathy-light .highlight .na{color:#883E96}.codeexample-base16-apathy-light .highlight .nb{color:#96883E}.codeexample-base16-apathy-light .highlight .nc{color:#96883E}.codeexample-base16-apathy-light .highlight .no{color:#4C963E}.codeexample-base16-apathy-light .highlight .nd{color:#4C963E}.codeexample-base16-apathy-light .highlight .ni{color:#3E9688}.codeexample-base16-apathy-light .highlight .ne{color:#3E4C96;font-weight:bold}.codeexample-base16-apathy-light .highlight .nf{color:#96883E}.codeexample-base16-apathy-light .highlight .nl{color:#4C963E}.codeexample-base16-apathy-light .highlight .nn{color:#96883E}.codeexample-base16-apathy-light .highlight .nx{color:#4C963E}.codeexample-base16-apathy-light .highlight .py{color:#4C963E}.codeexample-base16-apathy-light .highlight .nt{color:#883E96}.codeexample-base16-apathy-light .highlight .nv{color:#184E45}.codeexample-base16-apathy-light .highlight .ow{color:#3E4C96}.codeexample-base16-apathy-light .highlight .w{color:#4C963E}.codeexample-base16-apathy-light .highlight .mf{color:#4C963E}.codeexample-base16-apathy-light .highlight .mh{color:#4C963E}.codeexample-base16-apathy-light .highlight .mi{color:#4C963E}.codeexample-base16-apathy-light .highlight .mo{color:#4C963E}.codeexample-base16-apathy-light .highlight .sb{color:#963E4C}.codeexample-base16-apathy-light .highlight .sc{color:#963E4C}.codeexample-base16-apathy-light .highlight .sd{color:#963E4C}.codeexample-base16-apathy-light .highlight .s2{color:#963E4C}.codeexample-base16-apathy-light .highlight .se{color:#963E4C}.codeexample-base16-apathy-light .highlight .sh{color:#963E4C}.codeexample-base16-apathy-light .highlight .si{color:#963E4C}.codeexample-base16-apathy-light .highlight .sx{color:#963E4C}.codeexample-base16-apathy-light .highlight .sr{color:#963E4C}.codeexample-base16-apathy-light .highlight .s1{color:#963E4C}.codeexample-base16-apathy-light .highlight .ss{color:#963E4C}.codeexample-base16-apathy-light .highlight .bp{color:#96883E}.codeexample-base16-apathy-light .highlight .vc{color:#96883E}.codeexample-base16-apathy-light .highlight .vg{color:#184E45}.codeexample-base16-apathy-light .highlight .vi{color:#3E4C96}.codeexample-base16-apathy-light .highlight .il{color:#4C963E}</style><div class="codeexample codeexample-base16-apathy-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-ashes-dark">Base16 Ashes Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#C7CCD1"></div><div class="preview-color" style="background-color:#1C2023"></div><div class="preview-color" style="background-color:#C7AE95"></div><div class="preview-color" style="background-color:#95C7AE"></div><div class="preview-color" style="background-color:#AEC795"></div><div class="preview-color" style="background-color:#AE95C7"></div><div class="preview-color" style="background-color:#C795AE"></div><div class="preview-color" style="background-color:#95AEC7"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#1C2023"></div><div class="preview-color" style="background-color:#747C84"></div><div class="preview-color" style="background-color:#C7AE95"></div><div class="preview-color" style="background-color:#95C7AE"></div><div class="preview-color" style="background-color:#AEC795"></div><div class="preview-color" style="background-color:#AE95C7"></div><div class="preview-color" style="background-color:#C795AE"></div><div class="preview-color" style="background-color:#95AEC7"></div></div></div><style>.codeexample-base16-ashes-dark .highlight code, .codeexample-base16-ashes-dark .highlight pre{color:#C7CCD1;background-color:#1C2023}.codeexample-base16-ashes-dark .highlight .hll{background-color:#747C84}.codeexample-base16-ashes-dark .highlight .c{color:#C7CCD1}.codeexample-base16-ashes-dark .highlight .err{color:#95C7AE;background-color:#747C84}.codeexample-base16-ashes-dark .highlight .g{color:#C7CCD1}.codeexample-base16-ashes-dark .highlight .k{color:#AE95C7}.codeexample-base16-ashes-dark .highlight .l{color:#C795AE}.codeexample-base16-ashes-dark .highlight .n{color:#C7CCD1}.codeexample-base16-ashes-dark .highlight .o{color:#AEC795}.codeexample-base16-ashes-dark .highlight .x{color:#C795AE}.codeexample-base16-ashes-dark .highlight .p{color:#F3F4F5}.codeexample-base16-ashes-dark .highlight .cm{color:#C7CCD1}.codeexample-base16-ashes-dark .highlight .cp{color:#C7CCD1}.codeexample-base16-ashes-dark .highlight .c1{color:#C7CCD1}.codeexample-base16-ashes-dark .highlight .cs{color:#95C7AE;font-weight:bold}.codeexample-base16-ashes-dark .highlight .gd{color:#95C7AE}.codeexample-base16-ashes-dark .highlight .ge{color:#C795AE;font-style:italic}.codeexample-base16-ashes-dark .highlight .gr{color:#95C7AE}.codeexample-base16-ashes-dark .highlight .gh{color:#C7CCD1;font-weight:bold}.codeexample-base16-ashes-dark .highlight .gi{color:#AEC795}.codeexample-base16-ashes-dark .highlight .go{color:#747C84}.codeexample-base16-ashes-dark .highlight .gp{color:#C7CCD1;font-weight:bold}.codeexample-base16-ashes-dark .highlight .gs{color:#C795AE;font-weight:bold}.codeexample-base16-ashes-dark .highlight .gu{color:#C795AE;font-weight:bold}.codeexample-base16-ashes-dark .highlight .gt{color:#AE95C7}.codeexample-base16-ashes-dark .highlight .kc{color:#C7AE95}.codeexample-base16-ashes-dark .highlight .kd{color:#AEC795}.codeexample-base16-ashes-dark .highlight .kn{color:#AE95C7;font-weight:bold}.codeexample-base16-ashes-dark .highlight .kp{color:#95C7AE}.codeexample-base16-ashes-dark .highlight .kr{color:#95C7AE}.codeexample-base16-ashes-dark .highlight .kt{color:#C7CCD1}.codeexample-base16-ashes-dark .highlight .ld{color:#95AEC7}.codeexample-base16-ashes-dark .highlight .m{color:#C795AE}.codeexample-base16-ashes-dark .highlight .s{color:#95AEC7}.codeexample-base16-ashes-dark .highlight .na{color:#95C7AE}.codeexample-base16-ashes-dark .highlight .nb{color:#AE95C7}.codeexample-base16-ashes-dark .highlight .nc{color:#AE95C7}.codeexample-base16-ashes-dark .highlight .no{color:#C795AE}.codeexample-base16-ashes-dark .highlight .nd{color:#C795AE}.codeexample-base16-ashes-dark .highlight .ni{color:#C7AE95}.codeexample-base16-ashes-dark .highlight .ne{color:#AEC795;font-weight:bold}.codeexample-base16-ashes-dark .highlight .nf{color:#AE95C7}.codeexample-base16-ashes-dark .highlight .nl{color:#C795AE}.codeexample-base16-ashes-dark .highlight .nn{color:#AE95C7}.codeexample-base16-ashes-dark .highlight .nx{color:#C795AE}.codeexample-base16-ashes-dark .highlight .py{color:#C795AE}.codeexample-base16-ashes-dark .highlight .nt{color:#95C7AE}.codeexample-base16-ashes-dark .highlight .nv{color:#C7CCD1}.codeexample-base16-ashes-dark .highlight .ow{color:#AEC795}.codeexample-base16-ashes-dark .highlight .w{color:#C795AE}.codeexample-base16-ashes-dark .highlight .mf{color:#C795AE}.codeexample-base16-ashes-dark .highlight .mh{color:#C795AE}.codeexample-base16-ashes-dark .highlight .mi{color:#C795AE}.codeexample-base16-ashes-dark .highlight .mo{color:#C795AE}.codeexample-base16-ashes-dark .highlight .sb{color:#95AEC7}.codeexample-base16-ashes-dark .highlight .sc{color:#95AEC7}.codeexample-base16-ashes-dark .highlight .sd{color:#95AEC7}.codeexample-base16-ashes-dark .highlight .s2{color:#95AEC7}.codeexample-base16-ashes-dark .highlight .se{color:#95AEC7}.codeexample-base16-ashes-dark .highlight .sh{color:#95AEC7}.codeexample-base16-ashes-dark .highlight .si{color:#95AEC7}.codeexample-base16-ashes-dark .highlight .sx{color:#95AEC7}.codeexample-base16-ashes-dark .highlight .sr{color:#95AEC7}.codeexample-base16-ashes-dark .highlight .s1{color:#95AEC7}.codeexample-base16-ashes-dark .highlight .ss{color:#95AEC7}.codeexample-base16-ashes-dark .highlight .bp{color:#AE95C7}.codeexample-base16-ashes-dark .highlight .vc{color:#AE95C7}.codeexample-base16-ashes-dark .highlight .vg{color:#C7CCD1}.codeexample-base16-ashes-dark .highlight .vi{color:#AEC795}.codeexample-base16-ashes-dark .highlight .il{color:#C795AE}</style><div class="codeexample codeexample-base16-ashes-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-ashes-light">Base16 Ashes Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#565E65"></div><div class="preview-color" style="background-color:#1C2023"></div><div class="preview-color" style="background-color:#C7AE95"></div><div class="preview-color" style="background-color:#95C7AE"></div><div class="preview-color" style="background-color:#AEC795"></div><div class="preview-color" style="background-color:#AE95C7"></div><div class="preview-color" style="background-color:#C795AE"></div><div class="preview-color" style="background-color:#95AEC7"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#F3F4F5"></div><div class="preview-color" style="background-color:#747C84"></div><div class="preview-color" style="background-color:#C7AE95"></div><div class="preview-color" style="background-color:#95C7AE"></div><div class="preview-color" style="background-color:#AEC795"></div><div class="preview-color" style="background-color:#AE95C7"></div><div class="preview-color" style="background-color:#C795AE"></div><div class="preview-color" style="background-color:#95AEC7"></div></div></div><style>.codeexample-base16-ashes-light .highlight code, .codeexample-base16-ashes-light .highlight pre{color:#565E65;background-color:#F3F4F5}.codeexample-base16-ashes-light .highlight .hll{background-color:#747C84}.codeexample-base16-ashes-light .highlight .c{color:#C7CCD1}.codeexample-base16-ashes-light .highlight .err{color:#95C7AE;background-color:#747C84}.codeexample-base16-ashes-light .highlight .g{color:#C7CCD1}.codeexample-base16-ashes-light .highlight .k{color:#AE95C7}.codeexample-base16-ashes-light .highlight .l{color:#C795AE}.codeexample-base16-ashes-light .highlight .n{color:#565E65}.codeexample-base16-ashes-light .highlight .o{color:#AEC795}.codeexample-base16-ashes-light .highlight .x{color:#C795AE}.codeexample-base16-ashes-light .highlight .p{color:#F3F4F5}.codeexample-base16-ashes-light .highlight .cm{color:#C7CCD1}.codeexample-base16-ashes-light .highlight .cp{color:#C7CCD1}.codeexample-base16-ashes-light .highlight .c1{color:#C7CCD1}.codeexample-base16-ashes-light .highlight .cs{color:#95C7AE;font-weight:bold}.codeexample-base16-ashes-light .highlight .gd{color:#95C7AE}.codeexample-base16-ashes-light .highlight .ge{color:#C795AE;font-style:italic}.codeexample-base16-ashes-light .highlight .gr{color:#95C7AE}.codeexample-base16-ashes-light .highlight .gh{color:#565E65;font-weight:bold}.codeexample-base16-ashes-light .highlight .gi{color:#AEC795}.codeexample-base16-ashes-light .highlight .go{color:#747C84}.codeexample-base16-ashes-light .highlight .gp{color:#565E65;font-weight:bold}.codeexample-base16-ashes-light .highlight .gs{color:#C795AE;font-weight:bold}.codeexample-base16-ashes-light .highlight .gu{color:#C795AE;font-weight:bold}.codeexample-base16-ashes-light .highlight .gt{color:#AE95C7}.codeexample-base16-ashes-light .highlight .kc{color:#C7AE95}.codeexample-base16-ashes-light .highlight .kd{color:#AEC795}.codeexample-base16-ashes-light .highlight .kn{color:#AE95C7;font-weight:bold}.codeexample-base16-ashes-light .highlight .kp{color:#95C7AE}.codeexample-base16-ashes-light .highlight .kr{color:#95C7AE}.codeexample-base16-ashes-light .highlight .kt{color:#C7CCD1}.codeexample-base16-ashes-light .highlight .ld{color:#95AEC7}.codeexample-base16-ashes-light .highlight .m{color:#C795AE}.codeexample-base16-ashes-light .highlight .s{color:#95AEC7}.codeexample-base16-ashes-light .highlight .na{color:#95C7AE}.codeexample-base16-ashes-light .highlight .nb{color:#AE95C7}.codeexample-base16-ashes-light .highlight .nc{color:#AE95C7}.codeexample-base16-ashes-light .highlight .no{color:#C795AE}.codeexample-base16-ashes-light .highlight .nd{color:#C795AE}.codeexample-base16-ashes-light .highlight .ni{color:#C7AE95}.codeexample-base16-ashes-light .highlight .ne{color:#AEC795;font-weight:bold}.codeexample-base16-ashes-light .highlight .nf{color:#AE95C7}.codeexample-base16-ashes-light .highlight .nl{color:#C795AE}.codeexample-base16-ashes-light .highlight .nn{color:#AE95C7}.codeexample-base16-ashes-light .highlight .nx{color:#C795AE}.codeexample-base16-ashes-light .highlight .py{color:#C795AE}.codeexample-base16-ashes-light .highlight .nt{color:#95C7AE}.codeexample-base16-ashes-light .highlight .nv{color:#565E65}.codeexample-base16-ashes-light .highlight .ow{color:#AEC795}.codeexample-base16-ashes-light .highlight .w{color:#C795AE}.codeexample-base16-ashes-light .highlight .mf{color:#C795AE}.codeexample-base16-ashes-light .highlight .mh{color:#C795AE}.codeexample-base16-ashes-light .highlight .mi{color:#C795AE}.codeexample-base16-ashes-light .highlight .mo{color:#C795AE}.codeexample-base16-ashes-light .highlight .sb{color:#95AEC7}.codeexample-base16-ashes-light .highlight .sc{color:#95AEC7}.codeexample-base16-ashes-light .highlight .sd{color:#95AEC7}.codeexample-base16-ashes-light .highlight .s2{color:#95AEC7}.codeexample-base16-ashes-light .highlight .se{color:#95AEC7}.codeexample-base16-ashes-light .highlight .sh{color:#95AEC7}.codeexample-base16-ashes-light .highlight .si{color:#95AEC7}.codeexample-base16-ashes-light .highlight .sx{color:#95AEC7}.codeexample-base16-ashes-light .highlight .sr{color:#95AEC7}.codeexample-base16-ashes-light .highlight .s1{color:#95AEC7}.codeexample-base16-ashes-light .highlight .ss{color:#95AEC7}.codeexample-base16-ashes-light .highlight .bp{color:#AE95C7}.codeexample-base16-ashes-light .highlight .vc{color:#AE95C7}.codeexample-base16-ashes-light .highlight .vg{color:#565E65}.codeexample-base16-ashes-light .highlight .vi{color:#AEC795}.codeexample-base16-ashes-light .highlight .il{color:#C795AE}</style><div class="codeexample codeexample-base16-ashes-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-atelierdune-dark">Base16 Atelierdune Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#a6a28c"></div><div class="preview-color" style="background-color:#20201d"></div><div class="preview-color" style="background-color:#d73737"></div><div class="preview-color" style="background-color:#60ac39"></div><div class="preview-color" style="background-color:#cfb017"></div><div class="preview-color" style="background-color:#6684e1"></div><div class="preview-color" style="background-color:#b854d4"></div><div class="preview-color" style="background-color:#1fad83"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#20201d"></div><div class="preview-color" style="background-color:#7d7a68"></div><div class="preview-color" style="background-color:#d73737"></div><div class="preview-color" style="background-color:#60ac39"></div><div class="preview-color" style="background-color:#cfb017"></div><div class="preview-color" style="background-color:#6684e1"></div><div class="preview-color" style="background-color:#b854d4"></div><div class="preview-color" style="background-color:#1fad83"></div></div></div><style>.codeexample-base16-atelierdune-dark .highlight code, .codeexample-base16-atelierdune-dark .highlight pre{color:#a6a28c;background-color:#20201d}.codeexample-base16-atelierdune-dark .highlight .hll{background-color:#7d7a68}.codeexample-base16-atelierdune-dark .highlight .c{color:#a6a28c}.codeexample-base16-atelierdune-dark .highlight .err{color:#60ac39;background-color:#7d7a68}.codeexample-base16-atelierdune-dark .highlight .g{color:#a6a28c}.codeexample-base16-atelierdune-dark .highlight .k{color:#6684e1}.codeexample-base16-atelierdune-dark .highlight .l{color:#b854d4}.codeexample-base16-atelierdune-dark .highlight .n{color:#a6a28c}.codeexample-base16-atelierdune-dark .highlight .o{color:#cfb017}.codeexample-base16-atelierdune-dark .highlight .x{color:#b854d4}.codeexample-base16-atelierdune-dark .highlight .p{color:#fefbec}.codeexample-base16-atelierdune-dark .highlight .cm{color:#a6a28c}.codeexample-base16-atelierdune-dark .highlight .cp{color:#a6a28c}.codeexample-base16-atelierdune-dark .highlight .c1{color:#a6a28c}.codeexample-base16-atelierdune-dark .highlight .cs{color:#60ac39;font-weight:bold}.codeexample-base16-atelierdune-dark .highlight .gd{color:#60ac39}.codeexample-base16-atelierdune-dark .highlight .ge{color:#b854d4;font-style:italic}.codeexample-base16-atelierdune-dark .highlight .gr{color:#60ac39}.codeexample-base16-atelierdune-dark .highlight .gh{color:#a6a28c;font-weight:bold}.codeexample-base16-atelierdune-dark .highlight .gi{color:#cfb017}.codeexample-base16-atelierdune-dark .highlight .go{color:#7d7a68}.codeexample-base16-atelierdune-dark .highlight .gp{color:#a6a28c;font-weight:bold}.codeexample-base16-atelierdune-dark .highlight .gs{color:#b854d4;font-weight:bold}.codeexample-base16-atelierdune-dark .highlight .gu{color:#b854d4;font-weight:bold}.codeexample-base16-atelierdune-dark .highlight .gt{color:#6684e1}.codeexample-base16-atelierdune-dark .highlight .kc{color:#d73737}.codeexample-base16-atelierdune-dark .highlight .kd{color:#cfb017}.codeexample-base16-atelierdune-dark .highlight .kn{color:#6684e1;font-weight:bold}.codeexample-base16-atelierdune-dark .highlight .kp{color:#60ac39}.codeexample-base16-atelierdune-dark .highlight .kr{color:#60ac39}.codeexample-base16-atelierdune-dark .highlight .kt{color:#a6a28c}.codeexample-base16-atelierdune-dark .highlight .ld{color:#1fad83}.codeexample-base16-atelierdune-dark .highlight .m{color:#b854d4}.codeexample-base16-atelierdune-dark .highlight .s{color:#1fad83}.codeexample-base16-atelierdune-dark .highlight .na{color:#60ac39}.codeexample-base16-atelierdune-dark .highlight .nb{color:#6684e1}.codeexample-base16-atelierdune-dark .highlight .nc{color:#6684e1}.codeexample-base16-atelierdune-dark .highlight .no{color:#b854d4}.codeexample-base16-atelierdune-dark .highlight .nd{color:#b854d4}.codeexample-base16-atelierdune-dark .highlight .ni{color:#d73737}.codeexample-base16-atelierdune-dark .highlight .ne{color:#cfb017;font-weight:bold}.codeexample-base16-atelierdune-dark .highlight .nf{color:#6684e1}.codeexample-base16-atelierdune-dark .highlight .nl{color:#b854d4}.codeexample-base16-atelierdune-dark .highlight .nn{color:#6684e1}.codeexample-base16-atelierdune-dark .highlight .nx{color:#b854d4}.codeexample-base16-atelierdune-dark .highlight .py{color:#b854d4}.codeexample-base16-atelierdune-dark .highlight .nt{color:#60ac39}.codeexample-base16-atelierdune-dark .highlight .nv{color:#a6a28c}.codeexample-base16-atelierdune-dark .highlight .ow{color:#cfb017}.codeexample-base16-atelierdune-dark .highlight .w{color:#b854d4}.codeexample-base16-atelierdune-dark .highlight .mf{color:#b854d4}.codeexample-base16-atelierdune-dark .highlight .mh{color:#b854d4}.codeexample-base16-atelierdune-dark .highlight .mi{color:#b854d4}.codeexample-base16-atelierdune-dark .highlight .mo{color:#b854d4}.codeexample-base16-atelierdune-dark .highlight .sb{color:#1fad83}.codeexample-base16-atelierdune-dark .highlight .sc{color:#1fad83}.codeexample-base16-atelierdune-dark .highlight .sd{color:#1fad83}.codeexample-base16-atelierdune-dark .highlight .s2{color:#1fad83}.codeexample-base16-atelierdune-dark .highlight .se{color:#1fad83}.codeexample-base16-atelierdune-dark .highlight .sh{color:#1fad83}.codeexample-base16-atelierdune-dark .highlight .si{color:#1fad83}.codeexample-base16-atelierdune-dark .highlight .sx{color:#1fad83}.codeexample-base16-atelierdune-dark .highlight .sr{color:#1fad83}.codeexample-base16-atelierdune-dark .highlight .s1{color:#1fad83}.codeexample-base16-atelierdune-dark .highlight .ss{color:#1fad83}.codeexample-base16-atelierdune-dark .highlight .bp{color:#6684e1}.codeexample-base16-atelierdune-dark .highlight .vc{color:#6684e1}.codeexample-base16-atelierdune-dark .highlight .vg{color:#a6a28c}.codeexample-base16-atelierdune-dark .highlight .vi{color:#cfb017}.codeexample-base16-atelierdune-dark .highlight .il{color:#b854d4}</style><div class="codeexample codeexample-base16-atelierdune-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-atelierdune-light">Base16 Atelierdune Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#6e6b5e"></div><div class="preview-color" style="background-color:#20201d"></div><div class="preview-color" style="background-color:#d73737"></div><div class="preview-color" style="background-color:#60ac39"></div><div class="preview-color" style="background-color:#cfb017"></div><div class="preview-color" style="background-color:#6684e1"></div><div class="preview-color" style="background-color:#b854d4"></div><div class="preview-color" style="background-color:#1fad83"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#fefbec"></div><div class="preview-color" style="background-color:#7d7a68"></div><div class="preview-color" style="background-color:#d73737"></div><div class="preview-color" style="background-color:#60ac39"></div><div class="preview-color" style="background-color:#cfb017"></div><div class="preview-color" style="background-color:#6684e1"></div><div class="preview-color" style="background-color:#b854d4"></div><div class="preview-color" style="background-color:#1fad83"></div></div></div><style>.codeexample-base16-atelierdune-light .highlight code, .codeexample-base16-atelierdune-light .highlight pre{color:#6e6b5e;background-color:#fefbec}.codeexample-base16-atelierdune-light .highlight .hll{background-color:#7d7a68}.codeexample-base16-atelierdune-light .highlight .c{color:#a6a28c}.codeexample-base16-atelierdune-light .highlight .err{color:#60ac39;background-color:#7d7a68}.codeexample-base16-atelierdune-light .highlight .g{color:#a6a28c}.codeexample-base16-atelierdune-light .highlight .k{color:#6684e1}.codeexample-base16-atelierdune-light .highlight .l{color:#b854d4}.codeexample-base16-atelierdune-light .highlight .n{color:#6e6b5e}.codeexample-base16-atelierdune-light .highlight .o{color:#cfb017}.codeexample-base16-atelierdune-light .highlight .x{color:#b854d4}.codeexample-base16-atelierdune-light .highlight .p{color:#fefbec}.codeexample-base16-atelierdune-light .highlight .cm{color:#a6a28c}.codeexample-base16-atelierdune-light .highlight .cp{color:#a6a28c}.codeexample-base16-atelierdune-light .highlight .c1{color:#a6a28c}.codeexample-base16-atelierdune-light .highlight .cs{color:#60ac39;font-weight:bold}.codeexample-base16-atelierdune-light .highlight .gd{color:#60ac39}.codeexample-base16-atelierdune-light .highlight .ge{color:#b854d4;font-style:italic}.codeexample-base16-atelierdune-light .highlight .gr{color:#60ac39}.codeexample-base16-atelierdune-light .highlight .gh{color:#6e6b5e;font-weight:bold}.codeexample-base16-atelierdune-light .highlight .gi{color:#cfb017}.codeexample-base16-atelierdune-light .highlight .go{color:#7d7a68}.codeexample-base16-atelierdune-light .highlight .gp{color:#6e6b5e;font-weight:bold}.codeexample-base16-atelierdune-light .highlight .gs{color:#b854d4;font-weight:bold}.codeexample-base16-atelierdune-light .highlight .gu{color:#b854d4;font-weight:bold}.codeexample-base16-atelierdune-light .highlight .gt{color:#6684e1}.codeexample-base16-atelierdune-light .highlight .kc{color:#d73737}.codeexample-base16-atelierdune-light .highlight .kd{color:#cfb017}.codeexample-base16-atelierdune-light .highlight .kn{color:#6684e1;font-weight:bold}.codeexample-base16-atelierdune-light .highlight .kp{color:#60ac39}.codeexample-base16-atelierdune-light .highlight .kr{color:#60ac39}.codeexample-base16-atelierdune-light .highlight .kt{color:#a6a28c}.codeexample-base16-atelierdune-light .highlight .ld{color:#1fad83}.codeexample-base16-atelierdune-light .highlight .m{color:#b854d4}.codeexample-base16-atelierdune-light .highlight .s{color:#1fad83}.codeexample-base16-atelierdune-light .highlight .na{color:#60ac39}.codeexample-base16-atelierdune-light .highlight .nb{color:#6684e1}.codeexample-base16-atelierdune-light .highlight .nc{color:#6684e1}.codeexample-base16-atelierdune-light .highlight .no{color:#b854d4}.codeexample-base16-atelierdune-light .highlight .nd{color:#b854d4}.codeexample-base16-atelierdune-light .highlight .ni{color:#d73737}.codeexample-base16-atelierdune-light .highlight .ne{color:#cfb017;font-weight:bold}.codeexample-base16-atelierdune-light .highlight .nf{color:#6684e1}.codeexample-base16-atelierdune-light .highlight .nl{color:#b854d4}.codeexample-base16-atelierdune-light .highlight .nn{color:#6684e1}.codeexample-base16-atelierdune-light .highlight .nx{color:#b854d4}.codeexample-base16-atelierdune-light .highlight .py{color:#b854d4}.codeexample-base16-atelierdune-light .highlight .nt{color:#60ac39}.codeexample-base16-atelierdune-light .highlight .nv{color:#6e6b5e}.codeexample-base16-atelierdune-light .highlight .ow{color:#cfb017}.codeexample-base16-atelierdune-light .highlight .w{color:#b854d4}.codeexample-base16-atelierdune-light .highlight .mf{color:#b854d4}.codeexample-base16-atelierdune-light .highlight .mh{color:#b854d4}.codeexample-base16-atelierdune-light .highlight .mi{color:#b854d4}.codeexample-base16-atelierdune-light .highlight .mo{color:#b854d4}.codeexample-base16-atelierdune-light .highlight .sb{color:#1fad83}.codeexample-base16-atelierdune-light .highlight .sc{color:#1fad83}.codeexample-base16-atelierdune-light .highlight .sd{color:#1fad83}.codeexample-base16-atelierdune-light .highlight .s2{color:#1fad83}.codeexample-base16-atelierdune-light .highlight .se{color:#1fad83}.codeexample-base16-atelierdune-light .highlight .sh{color:#1fad83}.codeexample-base16-atelierdune-light .highlight .si{color:#1fad83}.codeexample-base16-atelierdune-light .highlight .sx{color:#1fad83}.codeexample-base16-atelierdune-light .highlight .sr{color:#1fad83}.codeexample-base16-atelierdune-light .highlight .s1{color:#1fad83}.codeexample-base16-atelierdune-light .highlight .ss{color:#1fad83}.codeexample-base16-atelierdune-light .highlight .bp{color:#6684e1}.codeexample-base16-atelierdune-light .highlight .vc{color:#6684e1}.codeexample-base16-atelierdune-light .highlight .vg{color:#6e6b5e}.codeexample-base16-atelierdune-light .highlight .vi{color:#cfb017}.codeexample-base16-atelierdune-light .highlight .il{color:#b854d4}</style><div class="codeexample codeexample-base16-atelierdune-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-atelierforest-dark">Base16 Atelierforest Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#a8a19f"></div><div class="preview-color" style="background-color:#1b1918"></div><div class="preview-color" style="background-color:#f22c40"></div><div class="preview-color" style="background-color:#5ab738"></div><div class="preview-color" style="background-color:#d5911a"></div><div class="preview-color" style="background-color:#407ee7"></div><div class="preview-color" style="background-color:#6666ea"></div><div class="preview-color" style="background-color:#00ad9c"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#1b1918"></div><div class="preview-color" style="background-color:#766e6b"></div><div class="preview-color" style="background-color:#f22c40"></div><div class="preview-color" style="background-color:#5ab738"></div><div class="preview-color" style="background-color:#d5911a"></div><div class="preview-color" style="background-color:#407ee7"></div><div class="preview-color" style="background-color:#6666ea"></div><div class="preview-color" style="background-color:#00ad9c"></div></div></div><style>.codeexample-base16-atelierforest-dark .highlight code, .codeexample-base16-atelierforest-dark .highlight pre{color:#a8a19f;background-color:#1b1918}.codeexample-base16-atelierforest-dark .highlight .hll{background-color:#766e6b}.codeexample-base16-atelierforest-dark .highlight .c{color:#a8a19f}.codeexample-base16-atelierforest-dark .highlight .err{color:#5ab738;background-color:#766e6b}.codeexample-base16-atelierforest-dark .highlight .g{color:#a8a19f}.codeexample-base16-atelierforest-dark .highlight .k{color:#407ee7}.codeexample-base16-atelierforest-dark .highlight .l{color:#6666ea}.codeexample-base16-atelierforest-dark .highlight .n{color:#a8a19f}.codeexample-base16-atelierforest-dark .highlight .o{color:#d5911a}.codeexample-base16-atelierforest-dark .highlight .x{color:#6666ea}.codeexample-base16-atelierforest-dark .highlight .p{color:#f1efee}.codeexample-base16-atelierforest-dark .highlight .cm{color:#a8a19f}.codeexample-base16-atelierforest-dark .highlight .cp{color:#a8a19f}.codeexample-base16-atelierforest-dark .highlight .c1{color:#a8a19f}.codeexample-base16-atelierforest-dark .highlight .cs{color:#5ab738;font-weight:bold}.codeexample-base16-atelierforest-dark .highlight .gd{color:#5ab738}.codeexample-base16-atelierforest-dark .highlight .ge{color:#6666ea;font-style:italic}.codeexample-base16-atelierforest-dark .highlight .gr{color:#5ab738}.codeexample-base16-atelierforest-dark .highlight .gh{color:#a8a19f;font-weight:bold}.codeexample-base16-atelierforest-dark .highlight .gi{color:#d5911a}.codeexample-base16-atelierforest-dark .highlight .go{color:#766e6b}.codeexample-base16-atelierforest-dark .highlight .gp{color:#a8a19f;font-weight:bold}.codeexample-base16-atelierforest-dark .highlight .gs{color:#6666ea;font-weight:bold}.codeexample-base16-atelierforest-dark .highlight .gu{color:#6666ea;font-weight:bold}.codeexample-base16-atelierforest-dark .highlight .gt{color:#407ee7}.codeexample-base16-atelierforest-dark .highlight .kc{color:#f22c40}.codeexample-base16-atelierforest-dark .highlight .kd{color:#d5911a}.codeexample-base16-atelierforest-dark .highlight .kn{color:#407ee7;font-weight:bold}.codeexample-base16-atelierforest-dark .highlight .kp{color:#5ab738}.codeexample-base16-atelierforest-dark .highlight .kr{color:#5ab738}.codeexample-base16-atelierforest-dark .highlight .kt{color:#a8a19f}.codeexample-base16-atelierforest-dark .highlight .ld{color:#00ad9c}.codeexample-base16-atelierforest-dark .highlight .m{color:#6666ea}.codeexample-base16-atelierforest-dark .highlight .s{color:#00ad9c}.codeexample-base16-atelierforest-dark .highlight .na{color:#5ab738}.codeexample-base16-atelierforest-dark .highlight .nb{color:#407ee7}.codeexample-base16-atelierforest-dark .highlight .nc{color:#407ee7}.codeexample-base16-atelierforest-dark .highlight .no{color:#6666ea}.codeexample-base16-atelierforest-dark .highlight .nd{color:#6666ea}.codeexample-base16-atelierforest-dark .highlight .ni{color:#f22c40}.codeexample-base16-atelierforest-dark .highlight .ne{color:#d5911a;font-weight:bold}.codeexample-base16-atelierforest-dark .highlight .nf{color:#407ee7}.codeexample-base16-atelierforest-dark .highlight .nl{color:#6666ea}.codeexample-base16-atelierforest-dark .highlight .nn{color:#407ee7}.codeexample-base16-atelierforest-dark .highlight .nx{color:#6666ea}.codeexample-base16-atelierforest-dark .highlight .py{color:#6666ea}.codeexample-base16-atelierforest-dark .highlight .nt{color:#5ab738}.codeexample-base16-atelierforest-dark .highlight .nv{color:#a8a19f}.codeexample-base16-atelierforest-dark .highlight .ow{color:#d5911a}.codeexample-base16-atelierforest-dark .highlight .w{color:#6666ea}.codeexample-base16-atelierforest-dark .highlight .mf{color:#6666ea}.codeexample-base16-atelierforest-dark .highlight .mh{color:#6666ea}.codeexample-base16-atelierforest-dark .highlight .mi{color:#6666ea}.codeexample-base16-atelierforest-dark .highlight .mo{color:#6666ea}.codeexample-base16-atelierforest-dark .highlight .sb{color:#00ad9c}.codeexample-base16-atelierforest-dark .highlight .sc{color:#00ad9c}.codeexample-base16-atelierforest-dark .highlight .sd{color:#00ad9c}.codeexample-base16-atelierforest-dark .highlight .s2{color:#00ad9c}.codeexample-base16-atelierforest-dark .highlight .se{color:#00ad9c}.codeexample-base16-atelierforest-dark .highlight .sh{color:#00ad9c}.codeexample-base16-atelierforest-dark .highlight .si{color:#00ad9c}.codeexample-base16-atelierforest-dark .highlight .sx{color:#00ad9c}.codeexample-base16-atelierforest-dark .highlight .sr{color:#00ad9c}.codeexample-base16-atelierforest-dark .highlight .s1{color:#00ad9c}.codeexample-base16-atelierforest-dark .highlight .ss{color:#00ad9c}.codeexample-base16-atelierforest-dark .highlight .bp{color:#407ee7}.codeexample-base16-atelierforest-dark .highlight .vc{color:#407ee7}.codeexample-base16-atelierforest-dark .highlight .vg{color:#a8a19f}.codeexample-base16-atelierforest-dark .highlight .vi{color:#d5911a}.codeexample-base16-atelierforest-dark .highlight .il{color:#6666ea}</style><div class="codeexample codeexample-base16-atelierforest-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-atelierforest-light">Base16 Atelierforest Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#68615e"></div><div class="preview-color" style="background-color:#1b1918"></div><div class="preview-color" style="background-color:#f22c40"></div><div class="preview-color" style="background-color:#5ab738"></div><div class="preview-color" style="background-color:#d5911a"></div><div class="preview-color" style="background-color:#407ee7"></div><div class="preview-color" style="background-color:#6666ea"></div><div class="preview-color" style="background-color:#00ad9c"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#f1efee"></div><div class="preview-color" style="background-color:#766e6b"></div><div class="preview-color" style="background-color:#f22c40"></div><div class="preview-color" style="background-color:#5ab738"></div><div class="preview-color" style="background-color:#d5911a"></div><div class="preview-color" style="background-color:#407ee7"></div><div class="preview-color" style="background-color:#6666ea"></div><div class="preview-color" style="background-color:#00ad9c"></div></div></div><style>.codeexample-base16-atelierforest-light .highlight code, .codeexample-base16-atelierforest-light .highlight pre{color:#68615e;background-color:#f1efee}.codeexample-base16-atelierforest-light .highlight .hll{background-color:#766e6b}.codeexample-base16-atelierforest-light .highlight .c{color:#a8a19f}.codeexample-base16-atelierforest-light .highlight .err{color:#5ab738;background-color:#766e6b}.codeexample-base16-atelierforest-light .highlight .g{color:#a8a19f}.codeexample-base16-atelierforest-light .highlight .k{color:#407ee7}.codeexample-base16-atelierforest-light .highlight .l{color:#6666ea}.codeexample-base16-atelierforest-light .highlight .n{color:#68615e}.codeexample-base16-atelierforest-light .highlight .o{color:#d5911a}.codeexample-base16-atelierforest-light .highlight .x{color:#6666ea}.codeexample-base16-atelierforest-light .highlight .p{color:#f1efee}.codeexample-base16-atelierforest-light .highlight .cm{color:#a8a19f}.codeexample-base16-atelierforest-light .highlight .cp{color:#a8a19f}.codeexample-base16-atelierforest-light .highlight .c1{color:#a8a19f}.codeexample-base16-atelierforest-light .highlight .cs{color:#5ab738;font-weight:bold}.codeexample-base16-atelierforest-light .highlight .gd{color:#5ab738}.codeexample-base16-atelierforest-light .highlight .ge{color:#6666ea;font-style:italic}.codeexample-base16-atelierforest-light .highlight .gr{color:#5ab738}.codeexample-base16-atelierforest-light .highlight .gh{color:#68615e;font-weight:bold}.codeexample-base16-atelierforest-light .highlight .gi{color:#d5911a}.codeexample-base16-atelierforest-light .highlight .go{color:#766e6b}.codeexample-base16-atelierforest-light .highlight .gp{color:#68615e;font-weight:bold}.codeexample-base16-atelierforest-light .highlight .gs{color:#6666ea;font-weight:bold}.codeexample-base16-atelierforest-light .highlight .gu{color:#6666ea;font-weight:bold}.codeexample-base16-atelierforest-light .highlight .gt{color:#407ee7}.codeexample-base16-atelierforest-light .highlight .kc{color:#f22c40}.codeexample-base16-atelierforest-light .highlight .kd{color:#d5911a}.codeexample-base16-atelierforest-light .highlight .kn{color:#407ee7;font-weight:bold}.codeexample-base16-atelierforest-light .highlight .kp{color:#5ab738}.codeexample-base16-atelierforest-light .highlight .kr{color:#5ab738}.codeexample-base16-atelierforest-light .highlight .kt{color:#a8a19f}.codeexample-base16-atelierforest-light .highlight .ld{color:#00ad9c}.codeexample-base16-atelierforest-light .highlight .m{color:#6666ea}.codeexample-base16-atelierforest-light .highlight .s{color:#00ad9c}.codeexample-base16-atelierforest-light .highlight .na{color:#5ab738}.codeexample-base16-atelierforest-light .highlight .nb{color:#407ee7}.codeexample-base16-atelierforest-light .highlight .nc{color:#407ee7}.codeexample-base16-atelierforest-light .highlight .no{color:#6666ea}.codeexample-base16-atelierforest-light .highlight .nd{color:#6666ea}.codeexample-base16-atelierforest-light .highlight .ni{color:#f22c40}.codeexample-base16-atelierforest-light .highlight .ne{color:#d5911a;font-weight:bold}.codeexample-base16-atelierforest-light .highlight .nf{color:#407ee7}.codeexample-base16-atelierforest-light .highlight .nl{color:#6666ea}.codeexample-base16-atelierforest-light .highlight .nn{color:#407ee7}.codeexample-base16-atelierforest-light .highlight .nx{color:#6666ea}.codeexample-base16-atelierforest-light .highlight .py{color:#6666ea}.codeexample-base16-atelierforest-light .highlight .nt{color:#5ab738}.codeexample-base16-atelierforest-light .highlight .nv{color:#68615e}.codeexample-base16-atelierforest-light .highlight .ow{color:#d5911a}.codeexample-base16-atelierforest-light .highlight .w{color:#6666ea}.codeexample-base16-atelierforest-light .highlight .mf{color:#6666ea}.codeexample-base16-atelierforest-light .highlight .mh{color:#6666ea}.codeexample-base16-atelierforest-light .highlight .mi{color:#6666ea}.codeexample-base16-atelierforest-light .highlight .mo{color:#6666ea}.codeexample-base16-atelierforest-light .highlight .sb{color:#00ad9c}.codeexample-base16-atelierforest-light .highlight .sc{color:#00ad9c}.codeexample-base16-atelierforest-light .highlight .sd{color:#00ad9c}.codeexample-base16-atelierforest-light .highlight .s2{color:#00ad9c}.codeexample-base16-atelierforest-light .highlight .se{color:#00ad9c}.codeexample-base16-atelierforest-light .highlight .sh{color:#00ad9c}.codeexample-base16-atelierforest-light .highlight .si{color:#00ad9c}.codeexample-base16-atelierforest-light .highlight .sx{color:#00ad9c}.codeexample-base16-atelierforest-light .highlight .sr{color:#00ad9c}.codeexample-base16-atelierforest-light .highlight .s1{color:#00ad9c}.codeexample-base16-atelierforest-light .highlight .ss{color:#00ad9c}.codeexample-base16-atelierforest-light .highlight .bp{color:#407ee7}.codeexample-base16-atelierforest-light .highlight .vc{color:#407ee7}.codeexample-base16-atelierforest-light .highlight .vg{color:#68615e}.codeexample-base16-atelierforest-light .highlight .vi{color:#d5911a}.codeexample-base16-atelierforest-light .highlight .il{color:#6666ea}</style><div class="codeexample codeexample-base16-atelierforest-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-atelierheath-dark">Base16 Atelierheath Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#ab9bab"></div><div class="preview-color" style="background-color:#1b181b"></div><div class="preview-color" style="background-color:#ca402b"></div><div class="preview-color" style="background-color:#379a37"></div><div class="preview-color" style="background-color:#bb8a35"></div><div class="preview-color" style="background-color:#516aec"></div><div class="preview-color" style="background-color:#7b59c0"></div><div class="preview-color" style="background-color:#159393"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#1b181b"></div><div class="preview-color" style="background-color:#776977"></div><div class="preview-color" style="background-color:#ca402b"></div><div class="preview-color" style="background-color:#379a37"></div><div class="preview-color" style="background-color:#bb8a35"></div><div class="preview-color" style="background-color:#516aec"></div><div class="preview-color" style="background-color:#7b59c0"></div><div class="preview-color" style="background-color:#159393"></div></div></div><style>.codeexample-base16-atelierheath-dark .highlight code, .codeexample-base16-atelierheath-dark .highlight pre{color:#ab9bab;background-color:#1b181b}.codeexample-base16-atelierheath-dark .highlight .hll{background-color:#776977}.codeexample-base16-atelierheath-dark .highlight .c{color:#ab9bab}.codeexample-base16-atelierheath-dark .highlight .err{color:#379a37;background-color:#776977}.codeexample-base16-atelierheath-dark .highlight .g{color:#ab9bab}.codeexample-base16-atelierheath-dark .highlight .k{color:#516aec}.codeexample-base16-atelierheath-dark .highlight .l{color:#7b59c0}.codeexample-base16-atelierheath-dark .highlight .n{color:#ab9bab}.codeexample-base16-atelierheath-dark .highlight .o{color:#bb8a35}.codeexample-base16-atelierheath-dark .highlight .x{color:#7b59c0}.codeexample-base16-atelierheath-dark .highlight .p{color:#f7f3f7}.codeexample-base16-atelierheath-dark .highlight .cm{color:#ab9bab}.codeexample-base16-atelierheath-dark .highlight .cp{color:#ab9bab}.codeexample-base16-atelierheath-dark .highlight .c1{color:#ab9bab}.codeexample-base16-atelierheath-dark .highlight .cs{color:#379a37;font-weight:bold}.codeexample-base16-atelierheath-dark .highlight .gd{color:#379a37}.codeexample-base16-atelierheath-dark .highlight .ge{color:#7b59c0;font-style:italic}.codeexample-base16-atelierheath-dark .highlight .gr{color:#379a37}.codeexample-base16-atelierheath-dark .highlight .gh{color:#ab9bab;font-weight:bold}.codeexample-base16-atelierheath-dark .highlight .gi{color:#bb8a35}.codeexample-base16-atelierheath-dark .highlight .go{color:#776977}.codeexample-base16-atelierheath-dark .highlight .gp{color:#ab9bab;font-weight:bold}.codeexample-base16-atelierheath-dark .highlight .gs{color:#7b59c0;font-weight:bold}.codeexample-base16-atelierheath-dark .highlight .gu{color:#7b59c0;font-weight:bold}.codeexample-base16-atelierheath-dark .highlight .gt{color:#516aec}.codeexample-base16-atelierheath-dark .highlight .kc{color:#ca402b}.codeexample-base16-atelierheath-dark .highlight .kd{color:#bb8a35}.codeexample-base16-atelierheath-dark .highlight .kn{color:#516aec;font-weight:bold}.codeexample-base16-atelierheath-dark .highlight .kp{color:#379a37}.codeexample-base16-atelierheath-dark .highlight .kr{color:#379a37}.codeexample-base16-atelierheath-dark .highlight .kt{color:#ab9bab}.codeexample-base16-atelierheath-dark .highlight .ld{color:#159393}.codeexample-base16-atelierheath-dark .highlight .m{color:#7b59c0}.codeexample-base16-atelierheath-dark .highlight .s{color:#159393}.codeexample-base16-atelierheath-dark .highlight .na{color:#379a37}.codeexample-base16-atelierheath-dark .highlight .nb{color:#516aec}.codeexample-base16-atelierheath-dark .highlight .nc{color:#516aec}.codeexample-base16-atelierheath-dark .highlight .no{color:#7b59c0}.codeexample-base16-atelierheath-dark .highlight .nd{color:#7b59c0}.codeexample-base16-atelierheath-dark .highlight .ni{color:#ca402b}.codeexample-base16-atelierheath-dark .highlight .ne{color:#bb8a35;font-weight:bold}.codeexample-base16-atelierheath-dark .highlight .nf{color:#516aec}.codeexample-base16-atelierheath-dark .highlight .nl{color:#7b59c0}.codeexample-base16-atelierheath-dark .highlight .nn{color:#516aec}.codeexample-base16-atelierheath-dark .highlight .nx{color:#7b59c0}.codeexample-base16-atelierheath-dark .highlight .py{color:#7b59c0}.codeexample-base16-atelierheath-dark .highlight .nt{color:#379a37}.codeexample-base16-atelierheath-dark .highlight .nv{color:#ab9bab}.codeexample-base16-atelierheath-dark .highlight .ow{color:#bb8a35}.codeexample-base16-atelierheath-dark .highlight .w{color:#7b59c0}.codeexample-base16-atelierheath-dark .highlight .mf{color:#7b59c0}.codeexample-base16-atelierheath-dark .highlight .mh{color:#7b59c0}.codeexample-base16-atelierheath-dark .highlight .mi{color:#7b59c0}.codeexample-base16-atelierheath-dark .highlight .mo{color:#7b59c0}.codeexample-base16-atelierheath-dark .highlight .sb{color:#159393}.codeexample-base16-atelierheath-dark .highlight .sc{color:#159393}.codeexample-base16-atelierheath-dark .highlight .sd{color:#159393}.codeexample-base16-atelierheath-dark .highlight .s2{color:#159393}.codeexample-base16-atelierheath-dark .highlight .se{color:#159393}.codeexample-base16-atelierheath-dark .highlight .sh{color:#159393}.codeexample-base16-atelierheath-dark .highlight .si{color:#159393}.codeexample-base16-atelierheath-dark .highlight .sx{color:#159393}.codeexample-base16-atelierheath-dark .highlight .sr{color:#159393}.codeexample-base16-atelierheath-dark .highlight .s1{color:#159393}.codeexample-base16-atelierheath-dark .highlight .ss{color:#159393}.codeexample-base16-atelierheath-dark .highlight .bp{color:#516aec}.codeexample-base16-atelierheath-dark .highlight .vc{color:#516aec}.codeexample-base16-atelierheath-dark .highlight .vg{color:#ab9bab}.codeexample-base16-atelierheath-dark .highlight .vi{color:#bb8a35}.codeexample-base16-atelierheath-dark .highlight .il{color:#7b59c0}</style><div class="codeexample codeexample-base16-atelierheath-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-atelierheath-light">Base16 Atelierheath Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#695d69"></div><div class="preview-color" style="background-color:#1b181b"></div><div class="preview-color" style="background-color:#ca402b"></div><div class="preview-color" style="background-color:#379a37"></div><div class="preview-color" style="background-color:#bb8a35"></div><div class="preview-color" style="background-color:#516aec"></div><div class="preview-color" style="background-color:#7b59c0"></div><div class="preview-color" style="background-color:#159393"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#f7f3f7"></div><div class="preview-color" style="background-color:#776977"></div><div class="preview-color" style="background-color:#ca402b"></div><div class="preview-color" style="background-color:#379a37"></div><div class="preview-color" style="background-color:#bb8a35"></div><div class="preview-color" style="background-color:#516aec"></div><div class="preview-color" style="background-color:#7b59c0"></div><div class="preview-color" style="background-color:#159393"></div></div></div><style>.codeexample-base16-atelierheath-light .highlight code, .codeexample-base16-atelierheath-light .highlight pre{color:#695d69;background-color:#f7f3f7}.codeexample-base16-atelierheath-light .highlight .hll{background-color:#776977}.codeexample-base16-atelierheath-light .highlight .c{color:#ab9bab}.codeexample-base16-atelierheath-light .highlight .err{color:#379a37;background-color:#776977}.codeexample-base16-atelierheath-light .highlight .g{color:#ab9bab}.codeexample-base16-atelierheath-light .highlight .k{color:#516aec}.codeexample-base16-atelierheath-light .highlight .l{color:#7b59c0}.codeexample-base16-atelierheath-light .highlight .n{color:#695d69}.codeexample-base16-atelierheath-light .highlight .o{color:#bb8a35}.codeexample-base16-atelierheath-light .highlight .x{color:#7b59c0}.codeexample-base16-atelierheath-light .highlight .p{color:#f7f3f7}.codeexample-base16-atelierheath-light .highlight .cm{color:#ab9bab}.codeexample-base16-atelierheath-light .highlight .cp{color:#ab9bab}.codeexample-base16-atelierheath-light .highlight .c1{color:#ab9bab}.codeexample-base16-atelierheath-light .highlight .cs{color:#379a37;font-weight:bold}.codeexample-base16-atelierheath-light .highlight .gd{color:#379a37}.codeexample-base16-atelierheath-light .highlight .ge{color:#7b59c0;font-style:italic}.codeexample-base16-atelierheath-light .highlight .gr{color:#379a37}.codeexample-base16-atelierheath-light .highlight .gh{color:#695d69;font-weight:bold}.codeexample-base16-atelierheath-light .highlight .gi{color:#bb8a35}.codeexample-base16-atelierheath-light .highlight .go{color:#776977}.codeexample-base16-atelierheath-light .highlight .gp{color:#695d69;font-weight:bold}.codeexample-base16-atelierheath-light .highlight .gs{color:#7b59c0;font-weight:bold}.codeexample-base16-atelierheath-light .highlight .gu{color:#7b59c0;font-weight:bold}.codeexample-base16-atelierheath-light .highlight .gt{color:#516aec}.codeexample-base16-atelierheath-light .highlight .kc{color:#ca402b}.codeexample-base16-atelierheath-light .highlight .kd{color:#bb8a35}.codeexample-base16-atelierheath-light .highlight .kn{color:#516aec;font-weight:bold}.codeexample-base16-atelierheath-light .highlight .kp{color:#379a37}.codeexample-base16-atelierheath-light .highlight .kr{color:#379a37}.codeexample-base16-atelierheath-light .highlight .kt{color:#ab9bab}.codeexample-base16-atelierheath-light .highlight .ld{color:#159393}.codeexample-base16-atelierheath-light .highlight .m{color:#7b59c0}.codeexample-base16-atelierheath-light .highlight .s{color:#159393}.codeexample-base16-atelierheath-light .highlight .na{color:#379a37}.codeexample-base16-atelierheath-light .highlight .nb{color:#516aec}.codeexample-base16-atelierheath-light .highlight .nc{color:#516aec}.codeexample-base16-atelierheath-light .highlight .no{color:#7b59c0}.codeexample-base16-atelierheath-light .highlight .nd{color:#7b59c0}.codeexample-base16-atelierheath-light .highlight .ni{color:#ca402b}.codeexample-base16-atelierheath-light .highlight .ne{color:#bb8a35;font-weight:bold}.codeexample-base16-atelierheath-light .highlight .nf{color:#516aec}.codeexample-base16-atelierheath-light .highlight .nl{color:#7b59c0}.codeexample-base16-atelierheath-light .highlight .nn{color:#516aec}.codeexample-base16-atelierheath-light .highlight .nx{color:#7b59c0}.codeexample-base16-atelierheath-light .highlight .py{color:#7b59c0}.codeexample-base16-atelierheath-light .highlight .nt{color:#379a37}.codeexample-base16-atelierheath-light .highlight .nv{color:#695d69}.codeexample-base16-atelierheath-light .highlight .ow{color:#bb8a35}.codeexample-base16-atelierheath-light .highlight .w{color:#7b59c0}.codeexample-base16-atelierheath-light .highlight .mf{color:#7b59c0}.codeexample-base16-atelierheath-light .highlight .mh{color:#7b59c0}.codeexample-base16-atelierheath-light .highlight .mi{color:#7b59c0}.codeexample-base16-atelierheath-light .highlight .mo{color:#7b59c0}.codeexample-base16-atelierheath-light .highlight .sb{color:#159393}.codeexample-base16-atelierheath-light .highlight .sc{color:#159393}.codeexample-base16-atelierheath-light .highlight .sd{color:#159393}.codeexample-base16-atelierheath-light .highlight .s2{color:#159393}.codeexample-base16-atelierheath-light .highlight .se{color:#159393}.codeexample-base16-atelierheath-light .highlight .sh{color:#159393}.codeexample-base16-atelierheath-light .highlight .si{color:#159393}.codeexample-base16-atelierheath-light .highlight .sx{color:#159393}.codeexample-base16-atelierheath-light .highlight .sr{color:#159393}.codeexample-base16-atelierheath-light .highlight .s1{color:#159393}.codeexample-base16-atelierheath-light .highlight .ss{color:#159393}.codeexample-base16-atelierheath-light .highlight .bp{color:#516aec}.codeexample-base16-atelierheath-light .highlight .vc{color:#516aec}.codeexample-base16-atelierheath-light .highlight .vg{color:#695d69}.codeexample-base16-atelierheath-light .highlight .vi{color:#bb8a35}.codeexample-base16-atelierheath-light .highlight .il{color:#7b59c0}</style><div class="codeexample codeexample-base16-atelierheath-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-atelierlakeside-dark">Base16 Atelierlakeside Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#7ea2b4"></div><div class="preview-color" style="background-color:#161b1d"></div><div class="preview-color" style="background-color:#d22d72"></div><div class="preview-color" style="background-color:#568c3b"></div><div class="preview-color" style="background-color:#8a8a0f"></div><div class="preview-color" style="background-color:#257fad"></div><div class="preview-color" style="background-color:#5d5db1"></div><div class="preview-color" style="background-color:#2d8f6f"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#161b1d"></div><div class="preview-color" style="background-color:#5a7b8c"></div><div class="preview-color" style="background-color:#d22d72"></div><div class="preview-color" style="background-color:#568c3b"></div><div class="preview-color" style="background-color:#8a8a0f"></div><div class="preview-color" style="background-color:#257fad"></div><div class="preview-color" style="background-color:#5d5db1"></div><div class="preview-color" style="background-color:#2d8f6f"></div></div></div><style>.codeexample-base16-atelierlakeside-dark .highlight code, .codeexample-base16-atelierlakeside-dark .highlight pre{color:#7ea2b4;background-color:#161b1d}.codeexample-base16-atelierlakeside-dark .highlight .hll{background-color:#5a7b8c}.codeexample-base16-atelierlakeside-dark .highlight .c{color:#7ea2b4}.codeexample-base16-atelierlakeside-dark .highlight .err{color:#568c3b;background-color:#5a7b8c}.codeexample-base16-atelierlakeside-dark .highlight .g{color:#7ea2b4}.codeexample-base16-atelierlakeside-dark .highlight .k{color:#257fad}.codeexample-base16-atelierlakeside-dark .highlight .l{color:#5d5db1}.codeexample-base16-atelierlakeside-dark .highlight .n{color:#7ea2b4}.codeexample-base16-atelierlakeside-dark .highlight .o{color:#8a8a0f}.codeexample-base16-atelierlakeside-dark .highlight .x{color:#5d5db1}.codeexample-base16-atelierlakeside-dark .highlight .p{color:#ebf8ff}.codeexample-base16-atelierlakeside-dark .highlight .cm{color:#7ea2b4}.codeexample-base16-atelierlakeside-dark .highlight .cp{color:#7ea2b4}.codeexample-base16-atelierlakeside-dark .highlight .c1{color:#7ea2b4}.codeexample-base16-atelierlakeside-dark .highlight .cs{color:#568c3b;font-weight:bold}.codeexample-base16-atelierlakeside-dark .highlight .gd{color:#568c3b}.codeexample-base16-atelierlakeside-dark .highlight .ge{color:#5d5db1;font-style:italic}.codeexample-base16-atelierlakeside-dark .highlight .gr{color:#568c3b}.codeexample-base16-atelierlakeside-dark .highlight .gh{color:#7ea2b4;font-weight:bold}.codeexample-base16-atelierlakeside-dark .highlight .gi{color:#8a8a0f}.codeexample-base16-atelierlakeside-dark .highlight .go{color:#5a7b8c}.codeexample-base16-atelierlakeside-dark .highlight .gp{color:#7ea2b4;font-weight:bold}.codeexample-base16-atelierlakeside-dark .highlight .gs{color:#5d5db1;font-weight:bold}.codeexample-base16-atelierlakeside-dark .highlight .gu{color:#5d5db1;font-weight:bold}.codeexample-base16-atelierlakeside-dark .highlight .gt{color:#257fad}.codeexample-base16-atelierlakeside-dark .highlight .kc{color:#d22d72}.codeexample-base16-atelierlakeside-dark .highlight .kd{color:#8a8a0f}.codeexample-base16-atelierlakeside-dark .highlight .kn{color:#257fad;font-weight:bold}.codeexample-base16-atelierlakeside-dark .highlight .kp{color:#568c3b}.codeexample-base16-atelierlakeside-dark .highlight .kr{color:#568c3b}.codeexample-base16-atelierlakeside-dark .highlight .kt{color:#7ea2b4}.codeexample-base16-atelierlakeside-dark .highlight .ld{color:#2d8f6f}.codeexample-base16-atelierlakeside-dark .highlight .m{color:#5d5db1}.codeexample-base16-atelierlakeside-dark .highlight .s{color:#2d8f6f}.codeexample-base16-atelierlakeside-dark .highlight .na{color:#568c3b}.codeexample-base16-atelierlakeside-dark .highlight .nb{color:#257fad}.codeexample-base16-atelierlakeside-dark .highlight .nc{color:#257fad}.codeexample-base16-atelierlakeside-dark .highlight .no{color:#5d5db1}.codeexample-base16-atelierlakeside-dark .highlight .nd{color:#5d5db1}.codeexample-base16-atelierlakeside-dark .highlight .ni{color:#d22d72}.codeexample-base16-atelierlakeside-dark .highlight .ne{color:#8a8a0f;font-weight:bold}.codeexample-base16-atelierlakeside-dark .highlight .nf{color:#257fad}.codeexample-base16-atelierlakeside-dark .highlight .nl{color:#5d5db1}.codeexample-base16-atelierlakeside-dark .highlight .nn{color:#257fad}.codeexample-base16-atelierlakeside-dark .highlight .nx{color:#5d5db1}.codeexample-base16-atelierlakeside-dark .highlight .py{color:#5d5db1}.codeexample-base16-atelierlakeside-dark .highlight .nt{color:#568c3b}.codeexample-base16-atelierlakeside-dark .highlight .nv{color:#7ea2b4}.codeexample-base16-atelierlakeside-dark .highlight .ow{color:#8a8a0f}.codeexample-base16-atelierlakeside-dark .highlight .w{color:#5d5db1}.codeexample-base16-atelierlakeside-dark .highlight .mf{color:#5d5db1}.codeexample-base16-atelierlakeside-dark .highlight .mh{color:#5d5db1}.codeexample-base16-atelierlakeside-dark .highlight .mi{color:#5d5db1}.codeexample-base16-atelierlakeside-dark .highlight .mo{color:#5d5db1}.codeexample-base16-atelierlakeside-dark .highlight .sb{color:#2d8f6f}.codeexample-base16-atelierlakeside-dark .highlight .sc{color:#2d8f6f}.codeexample-base16-atelierlakeside-dark .highlight .sd{color:#2d8f6f}.codeexample-base16-atelierlakeside-dark .highlight .s2{color:#2d8f6f}.codeexample-base16-atelierlakeside-dark .highlight .se{color:#2d8f6f}.codeexample-base16-atelierlakeside-dark .highlight .sh{color:#2d8f6f}.codeexample-base16-atelierlakeside-dark .highlight .si{color:#2d8f6f}.codeexample-base16-atelierlakeside-dark .highlight .sx{color:#2d8f6f}.codeexample-base16-atelierlakeside-dark .highlight .sr{color:#2d8f6f}.codeexample-base16-atelierlakeside-dark .highlight .s1{color:#2d8f6f}.codeexample-base16-atelierlakeside-dark .highlight .ss{color:#2d8f6f}.codeexample-base16-atelierlakeside-dark .highlight .bp{color:#257fad}.codeexample-base16-atelierlakeside-dark .highlight .vc{color:#257fad}.codeexample-base16-atelierlakeside-dark .highlight .vg{color:#7ea2b4}.codeexample-base16-atelierlakeside-dark .highlight .vi{color:#8a8a0f}.codeexample-base16-atelierlakeside-dark .highlight .il{color:#5d5db1}</style><div class="codeexample codeexample-base16-atelierlakeside-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-atelierlakeside-light">Base16 Atelierlakeside Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#516d7b"></div><div class="preview-color" style="background-color:#161b1d"></div><div class="preview-color" style="background-color:#d22d72"></div><div class="preview-color" style="background-color:#568c3b"></div><div class="preview-color" style="background-color:#8a8a0f"></div><div class="preview-color" style="background-color:#257fad"></div><div class="preview-color" style="background-color:#5d5db1"></div><div class="preview-color" style="background-color:#2d8f6f"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#ebf8ff"></div><div class="preview-color" style="background-color:#5a7b8c"></div><div class="preview-color" style="background-color:#d22d72"></div><div class="preview-color" style="background-color:#568c3b"></div><div class="preview-color" style="background-color:#8a8a0f"></div><div class="preview-color" style="background-color:#257fad"></div><div class="preview-color" style="background-color:#5d5db1"></div><div class="preview-color" style="background-color:#2d8f6f"></div></div></div><style>.codeexample-base16-atelierlakeside-light .highlight code, .codeexample-base16-atelierlakeside-light .highlight pre{color:#516d7b;background-color:#ebf8ff}.codeexample-base16-atelierlakeside-light .highlight .hll{background-color:#5a7b8c}.codeexample-base16-atelierlakeside-light .highlight .c{color:#7ea2b4}.codeexample-base16-atelierlakeside-light .highlight .err{color:#568c3b;background-color:#5a7b8c}.codeexample-base16-atelierlakeside-light .highlight .g{color:#7ea2b4}.codeexample-base16-atelierlakeside-light .highlight .k{color:#257fad}.codeexample-base16-atelierlakeside-light .highlight .l{color:#5d5db1}.codeexample-base16-atelierlakeside-light .highlight .n{color:#516d7b}.codeexample-base16-atelierlakeside-light .highlight .o{color:#8a8a0f}.codeexample-base16-atelierlakeside-light .highlight .x{color:#5d5db1}.codeexample-base16-atelierlakeside-light .highlight .p{color:#ebf8ff}.codeexample-base16-atelierlakeside-light .highlight .cm{color:#7ea2b4}.codeexample-base16-atelierlakeside-light .highlight .cp{color:#7ea2b4}.codeexample-base16-atelierlakeside-light .highlight .c1{color:#7ea2b4}.codeexample-base16-atelierlakeside-light .highlight .cs{color:#568c3b;font-weight:bold}.codeexample-base16-atelierlakeside-light .highlight .gd{color:#568c3b}.codeexample-base16-atelierlakeside-light .highlight .ge{color:#5d5db1;font-style:italic}.codeexample-base16-atelierlakeside-light .highlight .gr{color:#568c3b}.codeexample-base16-atelierlakeside-light .highlight .gh{color:#516d7b;font-weight:bold}.codeexample-base16-atelierlakeside-light .highlight .gi{color:#8a8a0f}.codeexample-base16-atelierlakeside-light .highlight .go{color:#5a7b8c}.codeexample-base16-atelierlakeside-light .highlight .gp{color:#516d7b;font-weight:bold}.codeexample-base16-atelierlakeside-light .highlight .gs{color:#5d5db1;font-weight:bold}.codeexample-base16-atelierlakeside-light .highlight .gu{color:#5d5db1;font-weight:bold}.codeexample-base16-atelierlakeside-light .highlight .gt{color:#257fad}.codeexample-base16-atelierlakeside-light .highlight .kc{color:#d22d72}.codeexample-base16-atelierlakeside-light .highlight .kd{color:#8a8a0f}.codeexample-base16-atelierlakeside-light .highlight .kn{color:#257fad;font-weight:bold}.codeexample-base16-atelierlakeside-light .highlight .kp{color:#568c3b}.codeexample-base16-atelierlakeside-light .highlight .kr{color:#568c3b}.codeexample-base16-atelierlakeside-light .highlight .kt{color:#7ea2b4}.codeexample-base16-atelierlakeside-light .highlight .ld{color:#2d8f6f}.codeexample-base16-atelierlakeside-light .highlight .m{color:#5d5db1}.codeexample-base16-atelierlakeside-light .highlight .s{color:#2d8f6f}.codeexample-base16-atelierlakeside-light .highlight .na{color:#568c3b}.codeexample-base16-atelierlakeside-light .highlight .nb{color:#257fad}.codeexample-base16-atelierlakeside-light .highlight .nc{color:#257fad}.codeexample-base16-atelierlakeside-light .highlight .no{color:#5d5db1}.codeexample-base16-atelierlakeside-light .highlight .nd{color:#5d5db1}.codeexample-base16-atelierlakeside-light .highlight .ni{color:#d22d72}.codeexample-base16-atelierlakeside-light .highlight .ne{color:#8a8a0f;font-weight:bold}.codeexample-base16-atelierlakeside-light .highlight .nf{color:#257fad}.codeexample-base16-atelierlakeside-light .highlight .nl{color:#5d5db1}.codeexample-base16-atelierlakeside-light .highlight .nn{color:#257fad}.codeexample-base16-atelierlakeside-light .highlight .nx{color:#5d5db1}.codeexample-base16-atelierlakeside-light .highlight .py{color:#5d5db1}.codeexample-base16-atelierlakeside-light .highlight .nt{color:#568c3b}.codeexample-base16-atelierlakeside-light .highlight .nv{color:#516d7b}.codeexample-base16-atelierlakeside-light .highlight .ow{color:#8a8a0f}.codeexample-base16-atelierlakeside-light .highlight .w{color:#5d5db1}.codeexample-base16-atelierlakeside-light .highlight .mf{color:#5d5db1}.codeexample-base16-atelierlakeside-light .highlight .mh{color:#5d5db1}.codeexample-base16-atelierlakeside-light .highlight .mi{color:#5d5db1}.codeexample-base16-atelierlakeside-light .highlight .mo{color:#5d5db1}.codeexample-base16-atelierlakeside-light .highlight .sb{color:#2d8f6f}.codeexample-base16-atelierlakeside-light .highlight .sc{color:#2d8f6f}.codeexample-base16-atelierlakeside-light .highlight .sd{color:#2d8f6f}.codeexample-base16-atelierlakeside-light .highlight .s2{color:#2d8f6f}.codeexample-base16-atelierlakeside-light .highlight .se{color:#2d8f6f}.codeexample-base16-atelierlakeside-light .highlight .sh{color:#2d8f6f}.codeexample-base16-atelierlakeside-light .highlight .si{color:#2d8f6f}.codeexample-base16-atelierlakeside-light .highlight .sx{color:#2d8f6f}.codeexample-base16-atelierlakeside-light .highlight .sr{color:#2d8f6f}.codeexample-base16-atelierlakeside-light .highlight .s1{color:#2d8f6f}.codeexample-base16-atelierlakeside-light .highlight .ss{color:#2d8f6f}.codeexample-base16-atelierlakeside-light .highlight .bp{color:#257fad}.codeexample-base16-atelierlakeside-light .highlight .vc{color:#257fad}.codeexample-base16-atelierlakeside-light .highlight .vg{color:#516d7b}.codeexample-base16-atelierlakeside-light .highlight .vi{color:#8a8a0f}.codeexample-base16-atelierlakeside-light .highlight .il{color:#5d5db1}</style><div class="codeexample codeexample-base16-atelierlakeside-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-atelierseaside-dark">Base16 Atelierseaside Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#8ca68c"></div><div class="preview-color" style="background-color:#131513"></div><div class="preview-color" style="background-color:#e6193c"></div><div class="preview-color" style="background-color:#29a329"></div><div class="preview-color" style="background-color:#c3c322"></div><div class="preview-color" style="background-color:#3d62f5"></div><div class="preview-color" style="background-color:#ad2bee"></div><div class="preview-color" style="background-color:#1999b3"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#131513"></div><div class="preview-color" style="background-color:#687d68"></div><div class="preview-color" style="background-color:#e6193c"></div><div class="preview-color" style="background-color:#29a329"></div><div class="preview-color" style="background-color:#c3c322"></div><div class="preview-color" style="background-color:#3d62f5"></div><div class="preview-color" style="background-color:#ad2bee"></div><div class="preview-color" style="background-color:#1999b3"></div></div></div><style>.codeexample-base16-atelierseaside-dark .highlight code, .codeexample-base16-atelierseaside-dark .highlight pre{color:#8ca68c;background-color:#131513}.codeexample-base16-atelierseaside-dark .highlight .hll{background-color:#687d68}.codeexample-base16-atelierseaside-dark .highlight .c{color:#8ca68c}.codeexample-base16-atelierseaside-dark .highlight .err{color:#29a329;background-color:#687d68}.codeexample-base16-atelierseaside-dark .highlight .g{color:#8ca68c}.codeexample-base16-atelierseaside-dark .highlight .k{color:#3d62f5}.codeexample-base16-atelierseaside-dark .highlight .l{color:#ad2bee}.codeexample-base16-atelierseaside-dark .highlight .n{color:#8ca68c}.codeexample-base16-atelierseaside-dark .highlight .o{color:#c3c322}.codeexample-base16-atelierseaside-dark .highlight .x{color:#ad2bee}.codeexample-base16-atelierseaside-dark .highlight .p{color:#f0fff0}.codeexample-base16-atelierseaside-dark .highlight .cm{color:#8ca68c}.codeexample-base16-atelierseaside-dark .highlight .cp{color:#8ca68c}.codeexample-base16-atelierseaside-dark .highlight .c1{color:#8ca68c}.codeexample-base16-atelierseaside-dark .highlight .cs{color:#29a329;font-weight:bold}.codeexample-base16-atelierseaside-dark .highlight .gd{color:#29a329}.codeexample-base16-atelierseaside-dark .highlight .ge{color:#ad2bee;font-style:italic}.codeexample-base16-atelierseaside-dark .highlight .gr{color:#29a329}.codeexample-base16-atelierseaside-dark .highlight .gh{color:#8ca68c;font-weight:bold}.codeexample-base16-atelierseaside-dark .highlight .gi{color:#c3c322}.codeexample-base16-atelierseaside-dark .highlight .go{color:#687d68}.codeexample-base16-atelierseaside-dark .highlight .gp{color:#8ca68c;font-weight:bold}.codeexample-base16-atelierseaside-dark .highlight .gs{color:#ad2bee;font-weight:bold}.codeexample-base16-atelierseaside-dark .highlight .gu{color:#ad2bee;font-weight:bold}.codeexample-base16-atelierseaside-dark .highlight .gt{color:#3d62f5}.codeexample-base16-atelierseaside-dark .highlight .kc{color:#e6193c}.codeexample-base16-atelierseaside-dark .highlight .kd{color:#c3c322}.codeexample-base16-atelierseaside-dark .highlight .kn{color:#3d62f5;font-weight:bold}.codeexample-base16-atelierseaside-dark .highlight .kp{color:#29a329}.codeexample-base16-atelierseaside-dark .highlight .kr{color:#29a329}.codeexample-base16-atelierseaside-dark .highlight .kt{color:#8ca68c}.codeexample-base16-atelierseaside-dark .highlight .ld{color:#1999b3}.codeexample-base16-atelierseaside-dark .highlight .m{color:#ad2bee}.codeexample-base16-atelierseaside-dark .highlight .s{color:#1999b3}.codeexample-base16-atelierseaside-dark .highlight .na{color:#29a329}.codeexample-base16-atelierseaside-dark .highlight .nb{color:#3d62f5}.codeexample-base16-atelierseaside-dark .highlight .nc{color:#3d62f5}.codeexample-base16-atelierseaside-dark .highlight .no{color:#ad2bee}.codeexample-base16-atelierseaside-dark .highlight .nd{color:#ad2bee}.codeexample-base16-atelierseaside-dark .highlight .ni{color:#e6193c}.codeexample-base16-atelierseaside-dark .highlight .ne{color:#c3c322;font-weight:bold}.codeexample-base16-atelierseaside-dark .highlight .nf{color:#3d62f5}.codeexample-base16-atelierseaside-dark .highlight .nl{color:#ad2bee}.codeexample-base16-atelierseaside-dark .highlight .nn{color:#3d62f5}.codeexample-base16-atelierseaside-dark .highlight .nx{color:#ad2bee}.codeexample-base16-atelierseaside-dark .highlight .py{color:#ad2bee}.codeexample-base16-atelierseaside-dark .highlight .nt{color:#29a329}.codeexample-base16-atelierseaside-dark .highlight .nv{color:#8ca68c}.codeexample-base16-atelierseaside-dark .highlight .ow{color:#c3c322}.codeexample-base16-atelierseaside-dark .highlight .w{color:#ad2bee}.codeexample-base16-atelierseaside-dark .highlight .mf{color:#ad2bee}.codeexample-base16-atelierseaside-dark .highlight .mh{color:#ad2bee}.codeexample-base16-atelierseaside-dark .highlight .mi{color:#ad2bee}.codeexample-base16-atelierseaside-dark .highlight .mo{color:#ad2bee}.codeexample-base16-atelierseaside-dark .highlight .sb{color:#1999b3}.codeexample-base16-atelierseaside-dark .highlight .sc{color:#1999b3}.codeexample-base16-atelierseaside-dark .highlight .sd{color:#1999b3}.codeexample-base16-atelierseaside-dark .highlight .s2{color:#1999b3}.codeexample-base16-atelierseaside-dark .highlight .se{color:#1999b3}.codeexample-base16-atelierseaside-dark .highlight .sh{color:#1999b3}.codeexample-base16-atelierseaside-dark .highlight .si{color:#1999b3}.codeexample-base16-atelierseaside-dark .highlight .sx{color:#1999b3}.codeexample-base16-atelierseaside-dark .highlight .sr{color:#1999b3}.codeexample-base16-atelierseaside-dark .highlight .s1{color:#1999b3}.codeexample-base16-atelierseaside-dark .highlight .ss{color:#1999b3}.codeexample-base16-atelierseaside-dark .highlight .bp{color:#3d62f5}.codeexample-base16-atelierseaside-dark .highlight .vc{color:#3d62f5}.codeexample-base16-atelierseaside-dark .highlight .vg{color:#8ca68c}.codeexample-base16-atelierseaside-dark .highlight .vi{color:#c3c322}.codeexample-base16-atelierseaside-dark .highlight .il{color:#ad2bee}</style><div class="codeexample codeexample-base16-atelierseaside-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-atelierseaside-light">Base16 Atelierseaside Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#5e6e5e"></div><div class="preview-color" style="background-color:#131513"></div><div class="preview-color" style="background-color:#e6193c"></div><div class="preview-color" style="background-color:#29a329"></div><div class="preview-color" style="background-color:#c3c322"></div><div class="preview-color" style="background-color:#3d62f5"></div><div class="preview-color" style="background-color:#ad2bee"></div><div class="preview-color" style="background-color:#1999b3"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#f0fff0"></div><div class="preview-color" style="background-color:#687d68"></div><div class="preview-color" style="background-color:#e6193c"></div><div class="preview-color" style="background-color:#29a329"></div><div class="preview-color" style="background-color:#c3c322"></div><div class="preview-color" style="background-color:#3d62f5"></div><div class="preview-color" style="background-color:#ad2bee"></div><div class="preview-color" style="background-color:#1999b3"></div></div></div><style>.codeexample-base16-atelierseaside-light .highlight code, .codeexample-base16-atelierseaside-light .highlight pre{color:#5e6e5e;background-color:#f0fff0}.codeexample-base16-atelierseaside-light .highlight .hll{background-color:#687d68}.codeexample-base16-atelierseaside-light .highlight .c{color:#8ca68c}.codeexample-base16-atelierseaside-light .highlight .err{color:#29a329;background-color:#687d68}.codeexample-base16-atelierseaside-light .highlight .g{color:#8ca68c}.codeexample-base16-atelierseaside-light .highlight .k{color:#3d62f5}.codeexample-base16-atelierseaside-light .highlight .l{color:#ad2bee}.codeexample-base16-atelierseaside-light .highlight .n{color:#5e6e5e}.codeexample-base16-atelierseaside-light .highlight .o{color:#c3c322}.codeexample-base16-atelierseaside-light .highlight .x{color:#ad2bee}.codeexample-base16-atelierseaside-light .highlight .p{color:#f0fff0}.codeexample-base16-atelierseaside-light .highlight .cm{color:#8ca68c}.codeexample-base16-atelierseaside-light .highlight .cp{color:#8ca68c}.codeexample-base16-atelierseaside-light .highlight .c1{color:#8ca68c}.codeexample-base16-atelierseaside-light .highlight .cs{color:#29a329;font-weight:bold}.codeexample-base16-atelierseaside-light .highlight .gd{color:#29a329}.codeexample-base16-atelierseaside-light .highlight .ge{color:#ad2bee;font-style:italic}.codeexample-base16-atelierseaside-light .highlight .gr{color:#29a329}.codeexample-base16-atelierseaside-light .highlight .gh{color:#5e6e5e;font-weight:bold}.codeexample-base16-atelierseaside-light .highlight .gi{color:#c3c322}.codeexample-base16-atelierseaside-light .highlight .go{color:#687d68}.codeexample-base16-atelierseaside-light .highlight .gp{color:#5e6e5e;font-weight:bold}.codeexample-base16-atelierseaside-light .highlight .gs{color:#ad2bee;font-weight:bold}.codeexample-base16-atelierseaside-light .highlight .gu{color:#ad2bee;font-weight:bold}.codeexample-base16-atelierseaside-light .highlight .gt{color:#3d62f5}.codeexample-base16-atelierseaside-light .highlight .kc{color:#e6193c}.codeexample-base16-atelierseaside-light .highlight .kd{color:#c3c322}.codeexample-base16-atelierseaside-light .highlight .kn{color:#3d62f5;font-weight:bold}.codeexample-base16-atelierseaside-light .highlight .kp{color:#29a329}.codeexample-base16-atelierseaside-light .highlight .kr{color:#29a329}.codeexample-base16-atelierseaside-light .highlight .kt{color:#8ca68c}.codeexample-base16-atelierseaside-light .highlight .ld{color:#1999b3}.codeexample-base16-atelierseaside-light .highlight .m{color:#ad2bee}.codeexample-base16-atelierseaside-light .highlight .s{color:#1999b3}.codeexample-base16-atelierseaside-light .highlight .na{color:#29a329}.codeexample-base16-atelierseaside-light .highlight .nb{color:#3d62f5}.codeexample-base16-atelierseaside-light .highlight .nc{color:#3d62f5}.codeexample-base16-atelierseaside-light .highlight .no{color:#ad2bee}.codeexample-base16-atelierseaside-light .highlight .nd{color:#ad2bee}.codeexample-base16-atelierseaside-light .highlight .ni{color:#e6193c}.codeexample-base16-atelierseaside-light .highlight .ne{color:#c3c322;font-weight:bold}.codeexample-base16-atelierseaside-light .highlight .nf{color:#3d62f5}.codeexample-base16-atelierseaside-light .highlight .nl{color:#ad2bee}.codeexample-base16-atelierseaside-light .highlight .nn{color:#3d62f5}.codeexample-base16-atelierseaside-light .highlight .nx{color:#ad2bee}.codeexample-base16-atelierseaside-light .highlight .py{color:#ad2bee}.codeexample-base16-atelierseaside-light .highlight .nt{color:#29a329}.codeexample-base16-atelierseaside-light .highlight .nv{color:#5e6e5e}.codeexample-base16-atelierseaside-light .highlight .ow{color:#c3c322}.codeexample-base16-atelierseaside-light .highlight .w{color:#ad2bee}.codeexample-base16-atelierseaside-light .highlight .mf{color:#ad2bee}.codeexample-base16-atelierseaside-light .highlight .mh{color:#ad2bee}.codeexample-base16-atelierseaside-light .highlight .mi{color:#ad2bee}.codeexample-base16-atelierseaside-light .highlight .mo{color:#ad2bee}.codeexample-base16-atelierseaside-light .highlight .sb{color:#1999b3}.codeexample-base16-atelierseaside-light .highlight .sc{color:#1999b3}.codeexample-base16-atelierseaside-light .highlight .sd{color:#1999b3}.codeexample-base16-atelierseaside-light .highlight .s2{color:#1999b3}.codeexample-base16-atelierseaside-light .highlight .se{color:#1999b3}.codeexample-base16-atelierseaside-light .highlight .sh{color:#1999b3}.codeexample-base16-atelierseaside-light .highlight .si{color:#1999b3}.codeexample-base16-atelierseaside-light .highlight .sx{color:#1999b3}.codeexample-base16-atelierseaside-light .highlight .sr{color:#1999b3}.codeexample-base16-atelierseaside-light .highlight .s1{color:#1999b3}.codeexample-base16-atelierseaside-light .highlight .ss{color:#1999b3}.codeexample-base16-atelierseaside-light .highlight .bp{color:#3d62f5}.codeexample-base16-atelierseaside-light .highlight .vc{color:#3d62f5}.codeexample-base16-atelierseaside-light .highlight .vg{color:#5e6e5e}.codeexample-base16-atelierseaside-light .highlight .vi{color:#c3c322}.codeexample-base16-atelierseaside-light .highlight .il{color:#ad2bee}</style><div class="codeexample codeexample-base16-atelierseaside-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-bespin-dark">Base16 Bespin Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#8a8986"></div><div class="preview-color" style="background-color:#28211c"></div><div class="preview-color" style="background-color:#cf6a4c"></div><div class="preview-color" style="background-color:#54be0d"></div><div class="preview-color" style="background-color:#f9ee98"></div><div class="preview-color" style="background-color:#5ea6ea"></div><div class="preview-color" style="background-color:#9b859d"></div><div class="preview-color" style="background-color:#afc4db"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#28211c"></div><div class="preview-color" style="background-color:#666666"></div><div class="preview-color" style="background-color:#cf6a4c"></div><div class="preview-color" style="background-color:#54be0d"></div><div class="preview-color" style="background-color:#f9ee98"></div><div class="preview-color" style="background-color:#5ea6ea"></div><div class="preview-color" style="background-color:#9b859d"></div><div class="preview-color" style="background-color:#afc4db"></div></div></div><style>.codeexample-base16-bespin-dark .highlight code, .codeexample-base16-bespin-dark .highlight pre{color:#8a8986;background-color:#28211c}.codeexample-base16-bespin-dark .highlight .hll{background-color:#666666}.codeexample-base16-bespin-dark .highlight .c{color:#8a8986}.codeexample-base16-bespin-dark .highlight .err{color:#54be0d;background-color:#666666}.codeexample-base16-bespin-dark .highlight .g{color:#8a8986}.codeexample-base16-bespin-dark .highlight .k{color:#5ea6ea}.codeexample-base16-bespin-dark .highlight .l{color:#9b859d}.codeexample-base16-bespin-dark .highlight .n{color:#8a8986}.codeexample-base16-bespin-dark .highlight .o{color:#f9ee98}.codeexample-base16-bespin-dark .highlight .x{color:#9b859d}.codeexample-base16-bespin-dark .highlight .p{color:#baae9e}.codeexample-base16-bespin-dark .highlight .cm{color:#8a8986}.codeexample-base16-bespin-dark .highlight .cp{color:#8a8986}.codeexample-base16-bespin-dark .highlight .c1{color:#8a8986}.codeexample-base16-bespin-dark .highlight .cs{color:#54be0d;font-weight:bold}.codeexample-base16-bespin-dark .highlight .gd{color:#54be0d}.codeexample-base16-bespin-dark .highlight .ge{color:#9b859d;font-style:italic}.codeexample-base16-bespin-dark .highlight .gr{color:#54be0d}.codeexample-base16-bespin-dark .highlight .gh{color:#8a8986;font-weight:bold}.codeexample-base16-bespin-dark .highlight .gi{color:#f9ee98}.codeexample-base16-bespin-dark .highlight .go{color:#666666}.codeexample-base16-bespin-dark .highlight .gp{color:#8a8986;font-weight:bold}.codeexample-base16-bespin-dark .highlight .gs{color:#9b859d;font-weight:bold}.codeexample-base16-bespin-dark .highlight .gu{color:#9b859d;font-weight:bold}.codeexample-base16-bespin-dark .highlight .gt{color:#5ea6ea}.codeexample-base16-bespin-dark .highlight .kc{color:#cf6a4c}.codeexample-base16-bespin-dark .highlight .kd{color:#f9ee98}.codeexample-base16-bespin-dark .highlight .kn{color:#5ea6ea;font-weight:bold}.codeexample-base16-bespin-dark .highlight .kp{color:#54be0d}.codeexample-base16-bespin-dark .highlight .kr{color:#54be0d}.codeexample-base16-bespin-dark .highlight .kt{color:#8a8986}.codeexample-base16-bespin-dark .highlight .ld{color:#afc4db}.codeexample-base16-bespin-dark .highlight .m{color:#9b859d}.codeexample-base16-bespin-dark .highlight .s{color:#afc4db}.codeexample-base16-bespin-dark .highlight .na{color:#54be0d}.codeexample-base16-bespin-dark .highlight .nb{color:#5ea6ea}.codeexample-base16-bespin-dark .highlight .nc{color:#5ea6ea}.codeexample-base16-bespin-dark .highlight .no{color:#9b859d}.codeexample-base16-bespin-dark .highlight .nd{color:#9b859d}.codeexample-base16-bespin-dark .highlight .ni{color:#cf6a4c}.codeexample-base16-bespin-dark .highlight .ne{color:#f9ee98;font-weight:bold}.codeexample-base16-bespin-dark .highlight .nf{color:#5ea6ea}.codeexample-base16-bespin-dark .highlight .nl{color:#9b859d}.codeexample-base16-bespin-dark .highlight .nn{color:#5ea6ea}.codeexample-base16-bespin-dark .highlight .nx{color:#9b859d}.codeexample-base16-bespin-dark .highlight .py{color:#9b859d}.codeexample-base16-bespin-dark .highlight .nt{color:#54be0d}.codeexample-base16-bespin-dark .highlight .nv{color:#8a8986}.codeexample-base16-bespin-dark .highlight .ow{color:#f9ee98}.codeexample-base16-bespin-dark .highlight .w{color:#9b859d}.codeexample-base16-bespin-dark .highlight .mf{color:#9b859d}.codeexample-base16-bespin-dark .highlight .mh{color:#9b859d}.codeexample-base16-bespin-dark .highlight .mi{color:#9b859d}.codeexample-base16-bespin-dark .highlight .mo{color:#9b859d}.codeexample-base16-bespin-dark .highlight .sb{color:#afc4db}.codeexample-base16-bespin-dark .highlight .sc{color:#afc4db}.codeexample-base16-bespin-dark .highlight .sd{color:#afc4db}.codeexample-base16-bespin-dark .highlight .s2{color:#afc4db}.codeexample-base16-bespin-dark .highlight .se{color:#afc4db}.codeexample-base16-bespin-dark .highlight .sh{color:#afc4db}.codeexample-base16-bespin-dark .highlight .si{color:#afc4db}.codeexample-base16-bespin-dark .highlight .sx{color:#afc4db}.codeexample-base16-bespin-dark .highlight .sr{color:#afc4db}.codeexample-base16-bespin-dark .highlight .s1{color:#afc4db}.codeexample-base16-bespin-dark .highlight .ss{color:#afc4db}.codeexample-base16-bespin-dark .highlight .bp{color:#5ea6ea}.codeexample-base16-bespin-dark .highlight .vc{color:#5ea6ea}.codeexample-base16-bespin-dark .highlight .vg{color:#8a8986}.codeexample-base16-bespin-dark .highlight .vi{color:#f9ee98}.codeexample-base16-bespin-dark .highlight .il{color:#9b859d}</style><div class="codeexample codeexample-base16-bespin-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-bespin-light">Base16 Bespin Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#5e5d5c"></div><div class="preview-color" style="background-color:#28211c"></div><div class="preview-color" style="background-color:#cf6a4c"></div><div class="preview-color" style="background-color:#54be0d"></div><div class="preview-color" style="background-color:#f9ee98"></div><div class="preview-color" style="background-color:#5ea6ea"></div><div class="preview-color" style="background-color:#9b859d"></div><div class="preview-color" style="background-color:#afc4db"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#baae9e"></div><div class="preview-color" style="background-color:#666666"></div><div class="preview-color" style="background-color:#cf6a4c"></div><div class="preview-color" style="background-color:#54be0d"></div><div class="preview-color" style="background-color:#f9ee98"></div><div class="preview-color" style="background-color:#5ea6ea"></div><div class="preview-color" style="background-color:#9b859d"></div><div class="preview-color" style="background-color:#afc4db"></div></div></div><style>.codeexample-base16-bespin-light .highlight code, .codeexample-base16-bespin-light .highlight pre{color:#5e5d5c;background-color:#baae9e}.codeexample-base16-bespin-light .highlight .hll{background-color:#666666}.codeexample-base16-bespin-light .highlight .c{color:#8a8986}.codeexample-base16-bespin-light .highlight .err{color:#54be0d;background-color:#666666}.codeexample-base16-bespin-light .highlight .g{color:#8a8986}.codeexample-base16-bespin-light .highlight .k{color:#5ea6ea}.codeexample-base16-bespin-light .highlight .l{color:#9b859d}.codeexample-base16-bespin-light .highlight .n{color:#5e5d5c}.codeexample-base16-bespin-light .highlight .o{color:#f9ee98}.codeexample-base16-bespin-light .highlight .x{color:#9b859d}.codeexample-base16-bespin-light .highlight .p{color:#baae9e}.codeexample-base16-bespin-light .highlight .cm{color:#8a8986}.codeexample-base16-bespin-light .highlight .cp{color:#8a8986}.codeexample-base16-bespin-light .highlight .c1{color:#8a8986}.codeexample-base16-bespin-light .highlight .cs{color:#54be0d;font-weight:bold}.codeexample-base16-bespin-light .highlight .gd{color:#54be0d}.codeexample-base16-bespin-light .highlight .ge{color:#9b859d;font-style:italic}.codeexample-base16-bespin-light .highlight .gr{color:#54be0d}.codeexample-base16-bespin-light .highlight .gh{color:#5e5d5c;font-weight:bold}.codeexample-base16-bespin-light .highlight .gi{color:#f9ee98}.codeexample-base16-bespin-light .highlight .go{color:#666666}.codeexample-base16-bespin-light .highlight .gp{color:#5e5d5c;font-weight:bold}.codeexample-base16-bespin-light .highlight .gs{color:#9b859d;font-weight:bold}.codeexample-base16-bespin-light .highlight .gu{color:#9b859d;font-weight:bold}.codeexample-base16-bespin-light .highlight .gt{color:#5ea6ea}.codeexample-base16-bespin-light .highlight .kc{color:#cf6a4c}.codeexample-base16-bespin-light .highlight .kd{color:#f9ee98}.codeexample-base16-bespin-light .highlight .kn{color:#5ea6ea;font-weight:bold}.codeexample-base16-bespin-light .highlight .kp{color:#54be0d}.codeexample-base16-bespin-light .highlight .kr{color:#54be0d}.codeexample-base16-bespin-light .highlight .kt{color:#8a8986}.codeexample-base16-bespin-light .highlight .ld{color:#afc4db}.codeexample-base16-bespin-light .highlight .m{color:#9b859d}.codeexample-base16-bespin-light .highlight .s{color:#afc4db}.codeexample-base16-bespin-light .highlight .na{color:#54be0d}.codeexample-base16-bespin-light .highlight .nb{color:#5ea6ea}.codeexample-base16-bespin-light .highlight .nc{color:#5ea6ea}.codeexample-base16-bespin-light .highlight .no{color:#9b859d}.codeexample-base16-bespin-light .highlight .nd{color:#9b859d}.codeexample-base16-bespin-light .highlight .ni{color:#cf6a4c}.codeexample-base16-bespin-light .highlight .ne{color:#f9ee98;font-weight:bold}.codeexample-base16-bespin-light .highlight .nf{color:#5ea6ea}.codeexample-base16-bespin-light .highlight .nl{color:#9b859d}.codeexample-base16-bespin-light .highlight .nn{color:#5ea6ea}.codeexample-base16-bespin-light .highlight .nx{color:#9b859d}.codeexample-base16-bespin-light .highlight .py{color:#9b859d}.codeexample-base16-bespin-light .highlight .nt{color:#54be0d}.codeexample-base16-bespin-light .highlight .nv{color:#5e5d5c}.codeexample-base16-bespin-light .highlight .ow{color:#f9ee98}.codeexample-base16-bespin-light .highlight .w{color:#9b859d}.codeexample-base16-bespin-light .highlight .mf{color:#9b859d}.codeexample-base16-bespin-light .highlight .mh{color:#9b859d}.codeexample-base16-bespin-light .highlight .mi{color:#9b859d}.codeexample-base16-bespin-light .highlight .mo{color:#9b859d}.codeexample-base16-bespin-light .highlight .sb{color:#afc4db}.codeexample-base16-bespin-light .highlight .sc{color:#afc4db}.codeexample-base16-bespin-light .highlight .sd{color:#afc4db}.codeexample-base16-bespin-light .highlight .s2{color:#afc4db}.codeexample-base16-bespin-light .highlight .se{color:#afc4db}.codeexample-base16-bespin-light .highlight .sh{color:#afc4db}.codeexample-base16-bespin-light .highlight .si{color:#afc4db}.codeexample-base16-bespin-light .highlight .sx{color:#afc4db}.codeexample-base16-bespin-light .highlight .sr{color:#afc4db}.codeexample-base16-bespin-light .highlight .s1{color:#afc4db}.codeexample-base16-bespin-light .highlight .ss{color:#afc4db}.codeexample-base16-bespin-light .highlight .bp{color:#5ea6ea}.codeexample-base16-bespin-light .highlight .vc{color:#5ea6ea}.codeexample-base16-bespin-light .highlight .vg{color:#5e5d5c}.codeexample-base16-bespin-light .highlight .vi{color:#f9ee98}.codeexample-base16-bespin-light .highlight .il{color:#9b859d}</style><div class="codeexample codeexample-base16-bespin-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-brewer-dark">Base16 Brewer Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#b7b8b9"></div><div class="preview-color" style="background-color:#0c0d0e"></div><div class="preview-color" style="background-color:#e31a1c"></div><div class="preview-color" style="background-color:#31a354"></div><div class="preview-color" style="background-color:#dca060"></div><div class="preview-color" style="background-color:#3182bd"></div><div class="preview-color" style="background-color:#756bb1"></div><div class="preview-color" style="background-color:#80b1d3"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#0c0d0e"></div><div class="preview-color" style="background-color:#737475"></div><div class="preview-color" style="background-color:#e31a1c"></div><div class="preview-color" style="background-color:#31a354"></div><div class="preview-color" style="background-color:#dca060"></div><div class="preview-color" style="background-color:#3182bd"></div><div class="preview-color" style="background-color:#756bb1"></div><div class="preview-color" style="background-color:#80b1d3"></div></div></div><style>.codeexample-base16-brewer-dark .highlight code, .codeexample-base16-brewer-dark .highlight pre{color:#b7b8b9;background-color:#0c0d0e}.codeexample-base16-brewer-dark .highlight .hll{background-color:#737475}.codeexample-base16-brewer-dark .highlight .c{color:#b7b8b9}.codeexample-base16-brewer-dark .highlight .err{color:#31a354;background-color:#737475}.codeexample-base16-brewer-dark .highlight .g{color:#b7b8b9}.codeexample-base16-brewer-dark .highlight .k{color:#3182bd}.codeexample-base16-brewer-dark .highlight .l{color:#756bb1}.codeexample-base16-brewer-dark .highlight .n{color:#b7b8b9}.codeexample-base16-brewer-dark .highlight .o{color:#dca060}.codeexample-base16-brewer-dark .highlight .x{color:#756bb1}.codeexample-base16-brewer-dark .highlight .p{color:#fcfdfe}.codeexample-base16-brewer-dark .highlight .cm{color:#b7b8b9}.codeexample-base16-brewer-dark .highlight .cp{color:#b7b8b9}.codeexample-base16-brewer-dark .highlight .c1{color:#b7b8b9}.codeexample-base16-brewer-dark .highlight .cs{color:#31a354;font-weight:bold}.codeexample-base16-brewer-dark .highlight .gd{color:#31a354}.codeexample-base16-brewer-dark .highlight .ge{color:#756bb1;font-style:italic}.codeexample-base16-brewer-dark .highlight .gr{color:#31a354}.codeexample-base16-brewer-dark .highlight .gh{color:#b7b8b9;font-weight:bold}.codeexample-base16-brewer-dark .highlight .gi{color:#dca060}.codeexample-base16-brewer-dark .highlight .go{color:#737475}.codeexample-base16-brewer-dark .highlight .gp{color:#b7b8b9;font-weight:bold}.codeexample-base16-brewer-dark .highlight .gs{color:#756bb1;font-weight:bold}.codeexample-base16-brewer-dark .highlight .gu{color:#756bb1;font-weight:bold}.codeexample-base16-brewer-dark .highlight .gt{color:#3182bd}.codeexample-base16-brewer-dark .highlight .kc{color:#e31a1c}.codeexample-base16-brewer-dark .highlight .kd{color:#dca060}.codeexample-base16-brewer-dark .highlight .kn{color:#3182bd;font-weight:bold}.codeexample-base16-brewer-dark .highlight .kp{color:#31a354}.codeexample-base16-brewer-dark .highlight .kr{color:#31a354}.codeexample-base16-brewer-dark .highlight .kt{color:#b7b8b9}.codeexample-base16-brewer-dark .highlight .ld{color:#80b1d3}.codeexample-base16-brewer-dark .highlight .m{color:#756bb1}.codeexample-base16-brewer-dark .highlight .s{color:#80b1d3}.codeexample-base16-brewer-dark .highlight .na{color:#31a354}.codeexample-base16-brewer-dark .highlight .nb{color:#3182bd}.codeexample-base16-brewer-dark .highlight .nc{color:#3182bd}.codeexample-base16-brewer-dark .highlight .no{color:#756bb1}.codeexample-base16-brewer-dark .highlight .nd{color:#756bb1}.codeexample-base16-brewer-dark .highlight .ni{color:#e31a1c}.codeexample-base16-brewer-dark .highlight .ne{color:#dca060;font-weight:bold}.codeexample-base16-brewer-dark .highlight .nf{color:#3182bd}.codeexample-base16-brewer-dark .highlight .nl{color:#756bb1}.codeexample-base16-brewer-dark .highlight .nn{color:#3182bd}.codeexample-base16-brewer-dark .highlight .nx{color:#756bb1}.codeexample-base16-brewer-dark .highlight .py{color:#756bb1}.codeexample-base16-brewer-dark .highlight .nt{color:#31a354}.codeexample-base16-brewer-dark .highlight .nv{color:#b7b8b9}.codeexample-base16-brewer-dark .highlight .ow{color:#dca060}.codeexample-base16-brewer-dark .highlight .w{color:#756bb1}.codeexample-base16-brewer-dark .highlight .mf{color:#756bb1}.codeexample-base16-brewer-dark .highlight .mh{color:#756bb1}.codeexample-base16-brewer-dark .highlight .mi{color:#756bb1}.codeexample-base16-brewer-dark .highlight .mo{color:#756bb1}.codeexample-base16-brewer-dark .highlight .sb{color:#80b1d3}.codeexample-base16-brewer-dark .highlight .sc{color:#80b1d3}.codeexample-base16-brewer-dark .highlight .sd{color:#80b1d3}.codeexample-base16-brewer-dark .highlight .s2{color:#80b1d3}.codeexample-base16-brewer-dark .highlight .se{color:#80b1d3}.codeexample-base16-brewer-dark .highlight .sh{color:#80b1d3}.codeexample-base16-brewer-dark .highlight .si{color:#80b1d3}.codeexample-base16-brewer-dark .highlight .sx{color:#80b1d3}.codeexample-base16-brewer-dark .highlight .sr{color:#80b1d3}.codeexample-base16-brewer-dark .highlight .s1{color:#80b1d3}.codeexample-base16-brewer-dark .highlight .ss{color:#80b1d3}.codeexample-base16-brewer-dark .highlight .bp{color:#3182bd}.codeexample-base16-brewer-dark .highlight .vc{color:#3182bd}.codeexample-base16-brewer-dark .highlight .vg{color:#b7b8b9}.codeexample-base16-brewer-dark .highlight .vi{color:#dca060}.codeexample-base16-brewer-dark .highlight .il{color:#756bb1}</style><div class="codeexample codeexample-base16-brewer-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-brewer-light">Base16 Brewer Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#515253"></div><div class="preview-color" style="background-color:#0c0d0e"></div><div class="preview-color" style="background-color:#e31a1c"></div><div class="preview-color" style="background-color:#31a354"></div><div class="preview-color" style="background-color:#dca060"></div><div class="preview-color" style="background-color:#3182bd"></div><div class="preview-color" style="background-color:#756bb1"></div><div class="preview-color" style="background-color:#80b1d3"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#fcfdfe"></div><div class="preview-color" style="background-color:#737475"></div><div class="preview-color" style="background-color:#e31a1c"></div><div class="preview-color" style="background-color:#31a354"></div><div class="preview-color" style="background-color:#dca060"></div><div class="preview-color" style="background-color:#3182bd"></div><div class="preview-color" style="background-color:#756bb1"></div><div class="preview-color" style="background-color:#80b1d3"></div></div></div><style>.codeexample-base16-brewer-light .highlight code, .codeexample-base16-brewer-light .highlight pre{color:#515253;background-color:#fcfdfe}.codeexample-base16-brewer-light .highlight .hll{background-color:#737475}.codeexample-base16-brewer-light .highlight .c{color:#b7b8b9}.codeexample-base16-brewer-light .highlight .err{color:#31a354;background-color:#737475}.codeexample-base16-brewer-light .highlight .g{color:#b7b8b9}.codeexample-base16-brewer-light .highlight .k{color:#3182bd}.codeexample-base16-brewer-light .highlight .l{color:#756bb1}.codeexample-base16-brewer-light .highlight .n{color:#515253}.codeexample-base16-brewer-light .highlight .o{color:#dca060}.codeexample-base16-brewer-light .highlight .x{color:#756bb1}.codeexample-base16-brewer-light .highlight .p{color:#fcfdfe}.codeexample-base16-brewer-light .highlight .cm{color:#b7b8b9}.codeexample-base16-brewer-light .highlight .cp{color:#b7b8b9}.codeexample-base16-brewer-light .highlight .c1{color:#b7b8b9}.codeexample-base16-brewer-light .highlight .cs{color:#31a354;font-weight:bold}.codeexample-base16-brewer-light .highlight .gd{color:#31a354}.codeexample-base16-brewer-light .highlight .ge{color:#756bb1;font-style:italic}.codeexample-base16-brewer-light .highlight .gr{color:#31a354}.codeexample-base16-brewer-light .highlight .gh{color:#515253;font-weight:bold}.codeexample-base16-brewer-light .highlight .gi{color:#dca060}.codeexample-base16-brewer-light .highlight .go{color:#737475}.codeexample-base16-brewer-light .highlight .gp{color:#515253;font-weight:bold}.codeexample-base16-brewer-light .highlight .gs{color:#756bb1;font-weight:bold}.codeexample-base16-brewer-light .highlight .gu{color:#756bb1;font-weight:bold}.codeexample-base16-brewer-light .highlight .gt{color:#3182bd}.codeexample-base16-brewer-light .highlight .kc{color:#e31a1c}.codeexample-base16-brewer-light .highlight .kd{color:#dca060}.codeexample-base16-brewer-light .highlight .kn{color:#3182bd;font-weight:bold}.codeexample-base16-brewer-light .highlight .kp{color:#31a354}.codeexample-base16-brewer-light .highlight .kr{color:#31a354}.codeexample-base16-brewer-light .highlight .kt{color:#b7b8b9}.codeexample-base16-brewer-light .highlight .ld{color:#80b1d3}.codeexample-base16-brewer-light .highlight .m{color:#756bb1}.codeexample-base16-brewer-light .highlight .s{color:#80b1d3}.codeexample-base16-brewer-light .highlight .na{color:#31a354}.codeexample-base16-brewer-light .highlight .nb{color:#3182bd}.codeexample-base16-brewer-light .highlight .nc{color:#3182bd}.codeexample-base16-brewer-light .highlight .no{color:#756bb1}.codeexample-base16-brewer-light .highlight .nd{color:#756bb1}.codeexample-base16-brewer-light .highlight .ni{color:#e31a1c}.codeexample-base16-brewer-light .highlight .ne{color:#dca060;font-weight:bold}.codeexample-base16-brewer-light .highlight .nf{color:#3182bd}.codeexample-base16-brewer-light .highlight .nl{color:#756bb1}.codeexample-base16-brewer-light .highlight .nn{color:#3182bd}.codeexample-base16-brewer-light .highlight .nx{color:#756bb1}.codeexample-base16-brewer-light .highlight .py{color:#756bb1}.codeexample-base16-brewer-light .highlight .nt{color:#31a354}.codeexample-base16-brewer-light .highlight .nv{color:#515253}.codeexample-base16-brewer-light .highlight .ow{color:#dca060}.codeexample-base16-brewer-light .highlight .w{color:#756bb1}.codeexample-base16-brewer-light .highlight .mf{color:#756bb1}.codeexample-base16-brewer-light .highlight .mh{color:#756bb1}.codeexample-base16-brewer-light .highlight .mi{color:#756bb1}.codeexample-base16-brewer-light .highlight .mo{color:#756bb1}.codeexample-base16-brewer-light .highlight .sb{color:#80b1d3}.codeexample-base16-brewer-light .highlight .sc{color:#80b1d3}.codeexample-base16-brewer-light .highlight .sd{color:#80b1d3}.codeexample-base16-brewer-light .highlight .s2{color:#80b1d3}.codeexample-base16-brewer-light .highlight .se{color:#80b1d3}.codeexample-base16-brewer-light .highlight .sh{color:#80b1d3}.codeexample-base16-brewer-light .highlight .si{color:#80b1d3}.codeexample-base16-brewer-light .highlight .sx{color:#80b1d3}.codeexample-base16-brewer-light .highlight .sr{color:#80b1d3}.codeexample-base16-brewer-light .highlight .s1{color:#80b1d3}.codeexample-base16-brewer-light .highlight .ss{color:#80b1d3}.codeexample-base16-brewer-light .highlight .bp{color:#3182bd}.codeexample-base16-brewer-light .highlight .vc{color:#3182bd}.codeexample-base16-brewer-light .highlight .vg{color:#515253}.codeexample-base16-brewer-light .highlight .vi{color:#dca060}.codeexample-base16-brewer-light .highlight .il{color:#756bb1}</style><div class="codeexample codeexample-base16-brewer-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-bright-dark">Base16 Bright Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#e0e0e0"></div><div class="preview-color" style="background-color:#000000"></div><div class="preview-color" style="background-color:#fb0120"></div><div class="preview-color" style="background-color:#a1c659"></div><div class="preview-color" style="background-color:#fda331"></div><div class="preview-color" style="background-color:#6fb3d2"></div><div class="preview-color" style="background-color:#d381c3"></div><div class="preview-color" style="background-color:#76c7b7"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#000000"></div><div class="preview-color" style="background-color:#b0b0b0"></div><div class="preview-color" style="background-color:#fb0120"></div><div class="preview-color" style="background-color:#a1c659"></div><div class="preview-color" style="background-color:#fda331"></div><div class="preview-color" style="background-color:#6fb3d2"></div><div class="preview-color" style="background-color:#d381c3"></div><div class="preview-color" style="background-color:#76c7b7"></div></div></div><style>.codeexample-base16-bright-dark .highlight code, .codeexample-base16-bright-dark .highlight pre{color:#e0e0e0;background-color:#000000}.codeexample-base16-bright-dark .highlight .hll{background-color:#b0b0b0}.codeexample-base16-bright-dark .highlight .c{color:#e0e0e0}.codeexample-base16-bright-dark .highlight .err{color:#a1c659;background-color:#b0b0b0}.codeexample-base16-bright-dark .highlight .g{color:#e0e0e0}.codeexample-base16-bright-dark .highlight .k{color:#6fb3d2}.codeexample-base16-bright-dark .highlight .l{color:#d381c3}.codeexample-base16-bright-dark .highlight .n{color:#e0e0e0}.codeexample-base16-bright-dark .highlight .o{color:#fda331}.codeexample-base16-bright-dark .highlight .x{color:#d381c3}.codeexample-base16-bright-dark .highlight .p{color:#ffffff}.codeexample-base16-bright-dark .highlight .cm{color:#e0e0e0}.codeexample-base16-bright-dark .highlight .cp{color:#e0e0e0}.codeexample-base16-bright-dark .highlight .c1{color:#e0e0e0}.codeexample-base16-bright-dark .highlight .cs{color:#a1c659;font-weight:bold}.codeexample-base16-bright-dark .highlight .gd{color:#a1c659}.codeexample-base16-bright-dark .highlight .ge{color:#d381c3;font-style:italic}.codeexample-base16-bright-dark .highlight .gr{color:#a1c659}.codeexample-base16-bright-dark .highlight .gh{color:#e0e0e0;font-weight:bold}.codeexample-base16-bright-dark .highlight .gi{color:#fda331}.codeexample-base16-bright-dark .highlight .go{color:#b0b0b0}.codeexample-base16-bright-dark .highlight .gp{color:#e0e0e0;font-weight:bold}.codeexample-base16-bright-dark .highlight .gs{color:#d381c3;font-weight:bold}.codeexample-base16-bright-dark .highlight .gu{color:#d381c3;font-weight:bold}.codeexample-base16-bright-dark .highlight .gt{color:#6fb3d2}.codeexample-base16-bright-dark .highlight .kc{color:#fb0120}.codeexample-base16-bright-dark .highlight .kd{color:#fda331}.codeexample-base16-bright-dark .highlight .kn{color:#6fb3d2;font-weight:bold}.codeexample-base16-bright-dark .highlight .kp{color:#a1c659}.codeexample-base16-bright-dark .highlight .kr{color:#a1c659}.codeexample-base16-bright-dark .highlight .kt{color:#e0e0e0}.codeexample-base16-bright-dark .highlight .ld{color:#76c7b7}.codeexample-base16-bright-dark .highlight .m{color:#d381c3}.codeexample-base16-bright-dark .highlight .s{color:#76c7b7}.codeexample-base16-bright-dark .highlight .na{color:#a1c659}.codeexample-base16-bright-dark .highlight .nb{color:#6fb3d2}.codeexample-base16-bright-dark .highlight .nc{color:#6fb3d2}.codeexample-base16-bright-dark .highlight .no{color:#d381c3}.codeexample-base16-bright-dark .highlight .nd{color:#d381c3}.codeexample-base16-bright-dark .highlight .ni{color:#fb0120}.codeexample-base16-bright-dark .highlight .ne{color:#fda331;font-weight:bold}.codeexample-base16-bright-dark .highlight .nf{color:#6fb3d2}.codeexample-base16-bright-dark .highlight .nl{color:#d381c3}.codeexample-base16-bright-dark .highlight .nn{color:#6fb3d2}.codeexample-base16-bright-dark .highlight .nx{color:#d381c3}.codeexample-base16-bright-dark .highlight .py{color:#d381c3}.codeexample-base16-bright-dark .highlight .nt{color:#a1c659}.codeexample-base16-bright-dark .highlight .nv{color:#e0e0e0}.codeexample-base16-bright-dark .highlight .ow{color:#fda331}.codeexample-base16-bright-dark .highlight .w{color:#d381c3}.codeexample-base16-bright-dark .highlight .mf{color:#d381c3}.codeexample-base16-bright-dark .highlight .mh{color:#d381c3}.codeexample-base16-bright-dark .highlight .mi{color:#d381c3}.codeexample-base16-bright-dark .highlight .mo{color:#d381c3}.codeexample-base16-bright-dark .highlight .sb{color:#76c7b7}.codeexample-base16-bright-dark .highlight .sc{color:#76c7b7}.codeexample-base16-bright-dark .highlight .sd{color:#76c7b7}.codeexample-base16-bright-dark .highlight .s2{color:#76c7b7}.codeexample-base16-bright-dark .highlight .se{color:#76c7b7}.codeexample-base16-bright-dark .highlight .sh{color:#76c7b7}.codeexample-base16-bright-dark .highlight .si{color:#76c7b7}.codeexample-base16-bright-dark .highlight .sx{color:#76c7b7}.codeexample-base16-bright-dark .highlight .sr{color:#76c7b7}.codeexample-base16-bright-dark .highlight .s1{color:#76c7b7}.codeexample-base16-bright-dark .highlight .ss{color:#76c7b7}.codeexample-base16-bright-dark .highlight .bp{color:#6fb3d2}.codeexample-base16-bright-dark .highlight .vc{color:#6fb3d2}.codeexample-base16-bright-dark .highlight .vg{color:#e0e0e0}.codeexample-base16-bright-dark .highlight .vi{color:#fda331}.codeexample-base16-bright-dark .highlight .il{color:#d381c3}</style><div class="codeexample codeexample-base16-bright-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-bright-light">Base16 Bright Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#505050"></div><div class="preview-color" style="background-color:#000000"></div><div class="preview-color" style="background-color:#fb0120"></div><div class="preview-color" style="background-color:#a1c659"></div><div class="preview-color" style="background-color:#fda331"></div><div class="preview-color" style="background-color:#6fb3d2"></div><div class="preview-color" style="background-color:#d381c3"></div><div class="preview-color" style="background-color:#76c7b7"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#ffffff"></div><div class="preview-color" style="background-color:#b0b0b0"></div><div class="preview-color" style="background-color:#fb0120"></div><div class="preview-color" style="background-color:#a1c659"></div><div class="preview-color" style="background-color:#fda331"></div><div class="preview-color" style="background-color:#6fb3d2"></div><div class="preview-color" style="background-color:#d381c3"></div><div class="preview-color" style="background-color:#76c7b7"></div></div></div><style>.codeexample-base16-bright-light .highlight code, .codeexample-base16-bright-light .highlight pre{color:#505050;background-color:#ffffff}.codeexample-base16-bright-light .highlight .hll{background-color:#b0b0b0}.codeexample-base16-bright-light .highlight .c{color:#e0e0e0}.codeexample-base16-bright-light .highlight .err{color:#a1c659;background-color:#b0b0b0}.codeexample-base16-bright-light .highlight .g{color:#e0e0e0}.codeexample-base16-bright-light .highlight .k{color:#6fb3d2}.codeexample-base16-bright-light .highlight .l{color:#d381c3}.codeexample-base16-bright-light .highlight .n{color:#505050}.codeexample-base16-bright-light .highlight .o{color:#fda331}.codeexample-base16-bright-light .highlight .x{color:#d381c3}.codeexample-base16-bright-light .highlight .p{color:#ffffff}.codeexample-base16-bright-light .highlight .cm{color:#e0e0e0}.codeexample-base16-bright-light .highlight .cp{color:#e0e0e0}.codeexample-base16-bright-light .highlight .c1{color:#e0e0e0}.codeexample-base16-bright-light .highlight .cs{color:#a1c659;font-weight:bold}.codeexample-base16-bright-light .highlight .gd{color:#a1c659}.codeexample-base16-bright-light .highlight .ge{color:#d381c3;font-style:italic}.codeexample-base16-bright-light .highlight .gr{color:#a1c659}.codeexample-base16-bright-light .highlight .gh{color:#505050;font-weight:bold}.codeexample-base16-bright-light .highlight .gi{color:#fda331}.codeexample-base16-bright-light .highlight .go{color:#b0b0b0}.codeexample-base16-bright-light .highlight .gp{color:#505050;font-weight:bold}.codeexample-base16-bright-light .highlight .gs{color:#d381c3;font-weight:bold}.codeexample-base16-bright-light .highlight .gu{color:#d381c3;font-weight:bold}.codeexample-base16-bright-light .highlight .gt{color:#6fb3d2}.codeexample-base16-bright-light .highlight .kc{color:#fb0120}.codeexample-base16-bright-light .highlight .kd{color:#fda331}.codeexample-base16-bright-light .highlight .kn{color:#6fb3d2;font-weight:bold}.codeexample-base16-bright-light .highlight .kp{color:#a1c659}.codeexample-base16-bright-light .highlight .kr{color:#a1c659}.codeexample-base16-bright-light .highlight .kt{color:#e0e0e0}.codeexample-base16-bright-light .highlight .ld{color:#76c7b7}.codeexample-base16-bright-light .highlight .m{color:#d381c3}.codeexample-base16-bright-light .highlight .s{color:#76c7b7}.codeexample-base16-bright-light .highlight .na{color:#a1c659}.codeexample-base16-bright-light .highlight .nb{color:#6fb3d2}.codeexample-base16-bright-light .highlight .nc{color:#6fb3d2}.codeexample-base16-bright-light .highlight .no{color:#d381c3}.codeexample-base16-bright-light .highlight .nd{color:#d381c3}.codeexample-base16-bright-light .highlight .ni{color:#fb0120}.codeexample-base16-bright-light .highlight .ne{color:#fda331;font-weight:bold}.codeexample-base16-bright-light .highlight .nf{color:#6fb3d2}.codeexample-base16-bright-light .highlight .nl{color:#d381c3}.codeexample-base16-bright-light .highlight .nn{color:#6fb3d2}.codeexample-base16-bright-light .highlight .nx{color:#d381c3}.codeexample-base16-bright-light .highlight .py{color:#d381c3}.codeexample-base16-bright-light .highlight .nt{color:#a1c659}.codeexample-base16-bright-light .highlight .nv{color:#505050}.codeexample-base16-bright-light .highlight .ow{color:#fda331}.codeexample-base16-bright-light .highlight .w{color:#d381c3}.codeexample-base16-bright-light .highlight .mf{color:#d381c3}.codeexample-base16-bright-light .highlight .mh{color:#d381c3}.codeexample-base16-bright-light .highlight .mi{color:#d381c3}.codeexample-base16-bright-light .highlight .mo{color:#d381c3}.codeexample-base16-bright-light .highlight .sb{color:#76c7b7}.codeexample-base16-bright-light .highlight .sc{color:#76c7b7}.codeexample-base16-bright-light .highlight .sd{color:#76c7b7}.codeexample-base16-bright-light .highlight .s2{color:#76c7b7}.codeexample-base16-bright-light .highlight .se{color:#76c7b7}.codeexample-base16-bright-light .highlight .sh{color:#76c7b7}.codeexample-base16-bright-light .highlight .si{color:#76c7b7}.codeexample-base16-bright-light .highlight .sx{color:#76c7b7}.codeexample-base16-bright-light .highlight .sr{color:#76c7b7}.codeexample-base16-bright-light .highlight .s1{color:#76c7b7}.codeexample-base16-bright-light .highlight .ss{color:#76c7b7}.codeexample-base16-bright-light .highlight .bp{color:#6fb3d2}.codeexample-base16-bright-light .highlight .vc{color:#6fb3d2}.codeexample-base16-bright-light .highlight .vg{color:#505050}.codeexample-base16-bright-light .highlight .vi{color:#fda331}.codeexample-base16-bright-light .highlight .il{color:#d381c3}</style><div class="codeexample codeexample-base16-bright-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-chalk-dark">Base16 Chalk Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#d0d0d0"></div><div class="preview-color" style="background-color:#151515"></div><div class="preview-color" style="background-color:#fb9fb1"></div><div class="preview-color" style="background-color:#acc267"></div><div class="preview-color" style="background-color:#ddb26f"></div><div class="preview-color" style="background-color:#6fc2ef"></div><div class="preview-color" style="background-color:#e1a3ee"></div><div class="preview-color" style="background-color:#12cfc0"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#151515"></div><div class="preview-color" style="background-color:#505050"></div><div class="preview-color" style="background-color:#fb9fb1"></div><div class="preview-color" style="background-color:#acc267"></div><div class="preview-color" style="background-color:#ddb26f"></div><div class="preview-color" style="background-color:#6fc2ef"></div><div class="preview-color" style="background-color:#e1a3ee"></div><div class="preview-color" style="background-color:#12cfc0"></div></div></div><style>.codeexample-base16-chalk-dark .highlight code, .codeexample-base16-chalk-dark .highlight pre{color:#d0d0d0;background-color:#151515}.codeexample-base16-chalk-dark .highlight .hll{background-color:#505050}.codeexample-base16-chalk-dark .highlight .c{color:#d0d0d0}.codeexample-base16-chalk-dark .highlight .err{color:#acc267;background-color:#505050}.codeexample-base16-chalk-dark .highlight .g{color:#d0d0d0}.codeexample-base16-chalk-dark .highlight .k{color:#6fc2ef}.codeexample-base16-chalk-dark .highlight .l{color:#e1a3ee}.codeexample-base16-chalk-dark .highlight .n{color:#d0d0d0}.codeexample-base16-chalk-dark .highlight .o{color:#ddb26f}.codeexample-base16-chalk-dark .highlight .x{color:#e1a3ee}.codeexample-base16-chalk-dark .highlight .p{color:#f5f5f5}.codeexample-base16-chalk-dark .highlight .cm{color:#d0d0d0}.codeexample-base16-chalk-dark .highlight .cp{color:#d0d0d0}.codeexample-base16-chalk-dark .highlight .c1{color:#d0d0d0}.codeexample-base16-chalk-dark .highlight .cs{color:#acc267;font-weight:bold}.codeexample-base16-chalk-dark .highlight .gd{color:#acc267}.codeexample-base16-chalk-dark .highlight .ge{color:#e1a3ee;font-style:italic}.codeexample-base16-chalk-dark .highlight .gr{color:#acc267}.codeexample-base16-chalk-dark .highlight .gh{color:#d0d0d0;font-weight:bold}.codeexample-base16-chalk-dark .highlight .gi{color:#ddb26f}.codeexample-base16-chalk-dark .highlight .go{color:#505050}.codeexample-base16-chalk-dark .highlight .gp{color:#d0d0d0;font-weight:bold}.codeexample-base16-chalk-dark .highlight .gs{color:#e1a3ee;font-weight:bold}.codeexample-base16-chalk-dark .highlight .gu{color:#e1a3ee;font-weight:bold}.codeexample-base16-chalk-dark .highlight .gt{color:#6fc2ef}.codeexample-base16-chalk-dark .highlight .kc{color:#fb9fb1}.codeexample-base16-chalk-dark .highlight .kd{color:#ddb26f}.codeexample-base16-chalk-dark .highlight .kn{color:#6fc2ef;font-weight:bold}.codeexample-base16-chalk-dark .highlight .kp{color:#acc267}.codeexample-base16-chalk-dark .highlight .kr{color:#acc267}.codeexample-base16-chalk-dark .highlight .kt{color:#d0d0d0}.codeexample-base16-chalk-dark .highlight .ld{color:#12cfc0}.codeexample-base16-chalk-dark .highlight .m{color:#e1a3ee}.codeexample-base16-chalk-dark .highlight .s{color:#12cfc0}.codeexample-base16-chalk-dark .highlight .na{color:#acc267}.codeexample-base16-chalk-dark .highlight .nb{color:#6fc2ef}.codeexample-base16-chalk-dark .highlight .nc{color:#6fc2ef}.codeexample-base16-chalk-dark .highlight .no{color:#e1a3ee}.codeexample-base16-chalk-dark .highlight .nd{color:#e1a3ee}.codeexample-base16-chalk-dark .highlight .ni{color:#fb9fb1}.codeexample-base16-chalk-dark .highlight .ne{color:#ddb26f;font-weight:bold}.codeexample-base16-chalk-dark .highlight .nf{color:#6fc2ef}.codeexample-base16-chalk-dark .highlight .nl{color:#e1a3ee}.codeexample-base16-chalk-dark .highlight .nn{color:#6fc2ef}.codeexample-base16-chalk-dark .highlight .nx{color:#e1a3ee}.codeexample-base16-chalk-dark .highlight .py{color:#e1a3ee}.codeexample-base16-chalk-dark .highlight .nt{color:#acc267}.codeexample-base16-chalk-dark .highlight .nv{color:#d0d0d0}.codeexample-base16-chalk-dark .highlight .ow{color:#ddb26f}.codeexample-base16-chalk-dark .highlight .w{color:#e1a3ee}.codeexample-base16-chalk-dark .highlight .mf{color:#e1a3ee}.codeexample-base16-chalk-dark .highlight .mh{color:#e1a3ee}.codeexample-base16-chalk-dark .highlight .mi{color:#e1a3ee}.codeexample-base16-chalk-dark .highlight .mo{color:#e1a3ee}.codeexample-base16-chalk-dark .highlight .sb{color:#12cfc0}.codeexample-base16-chalk-dark .highlight .sc{color:#12cfc0}.codeexample-base16-chalk-dark .highlight .sd{color:#12cfc0}.codeexample-base16-chalk-dark .highlight .s2{color:#12cfc0}.codeexample-base16-chalk-dark .highlight .se{color:#12cfc0}.codeexample-base16-chalk-dark .highlight .sh{color:#12cfc0}.codeexample-base16-chalk-dark .highlight .si{color:#12cfc0}.codeexample-base16-chalk-dark .highlight .sx{color:#12cfc0}.codeexample-base16-chalk-dark .highlight .sr{color:#12cfc0}.codeexample-base16-chalk-dark .highlight .s1{color:#12cfc0}.codeexample-base16-chalk-dark .highlight .ss{color:#12cfc0}.codeexample-base16-chalk-dark .highlight .bp{color:#6fc2ef}.codeexample-base16-chalk-dark .highlight .vc{color:#6fc2ef}.codeexample-base16-chalk-dark .highlight .vg{color:#d0d0d0}.codeexample-base16-chalk-dark .highlight .vi{color:#ddb26f}.codeexample-base16-chalk-dark .highlight .il{color:#e1a3ee}</style><div class="codeexample codeexample-base16-chalk-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-chalk-light">Base16 Chalk Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#303030"></div><div class="preview-color" style="background-color:#151515"></div><div class="preview-color" style="background-color:#fb9fb1"></div><div class="preview-color" style="background-color:#acc267"></div><div class="preview-color" style="background-color:#ddb26f"></div><div class="preview-color" style="background-color:#6fc2ef"></div><div class="preview-color" style="background-color:#e1a3ee"></div><div class="preview-color" style="background-color:#12cfc0"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#f5f5f5"></div><div class="preview-color" style="background-color:#505050"></div><div class="preview-color" style="background-color:#fb9fb1"></div><div class="preview-color" style="background-color:#acc267"></div><div class="preview-color" style="background-color:#ddb26f"></div><div class="preview-color" style="background-color:#6fc2ef"></div><div class="preview-color" style="background-color:#e1a3ee"></div><div class="preview-color" style="background-color:#12cfc0"></div></div></div><style>.codeexample-base16-chalk-light .highlight code, .codeexample-base16-chalk-light .highlight pre{color:#303030;background-color:#f5f5f5}.codeexample-base16-chalk-light .highlight .hll{background-color:#505050}.codeexample-base16-chalk-light .highlight .c{color:#d0d0d0}.codeexample-base16-chalk-light .highlight .err{color:#acc267;background-color:#505050}.codeexample-base16-chalk-light .highlight .g{color:#d0d0d0}.codeexample-base16-chalk-light .highlight .k{color:#6fc2ef}.codeexample-base16-chalk-light .highlight .l{color:#e1a3ee}.codeexample-base16-chalk-light .highlight .n{color:#303030}.codeexample-base16-chalk-light .highlight .o{color:#ddb26f}.codeexample-base16-chalk-light .highlight .x{color:#e1a3ee}.codeexample-base16-chalk-light .highlight .p{color:#f5f5f5}.codeexample-base16-chalk-light .highlight .cm{color:#d0d0d0}.codeexample-base16-chalk-light .highlight .cp{color:#d0d0d0}.codeexample-base16-chalk-light .highlight .c1{color:#d0d0d0}.codeexample-base16-chalk-light .highlight .cs{color:#acc267;font-weight:bold}.codeexample-base16-chalk-light .highlight .gd{color:#acc267}.codeexample-base16-chalk-light .highlight .ge{color:#e1a3ee;font-style:italic}.codeexample-base16-chalk-light .highlight .gr{color:#acc267}.codeexample-base16-chalk-light .highlight .gh{color:#303030;font-weight:bold}.codeexample-base16-chalk-light .highlight .gi{color:#ddb26f}.codeexample-base16-chalk-light .highlight .go{color:#505050}.codeexample-base16-chalk-light .highlight .gp{color:#303030;font-weight:bold}.codeexample-base16-chalk-light .highlight .gs{color:#e1a3ee;font-weight:bold}.codeexample-base16-chalk-light .highlight .gu{color:#e1a3ee;font-weight:bold}.codeexample-base16-chalk-light .highlight .gt{color:#6fc2ef}.codeexample-base16-chalk-light .highlight .kc{color:#fb9fb1}.codeexample-base16-chalk-light .highlight .kd{color:#ddb26f}.codeexample-base16-chalk-light .highlight .kn{color:#6fc2ef;font-weight:bold}.codeexample-base16-chalk-light .highlight .kp{color:#acc267}.codeexample-base16-chalk-light .highlight .kr{color:#acc267}.codeexample-base16-chalk-light .highlight .kt{color:#d0d0d0}.codeexample-base16-chalk-light .highlight .ld{color:#12cfc0}.codeexample-base16-chalk-light .highlight .m{color:#e1a3ee}.codeexample-base16-chalk-light .highlight .s{color:#12cfc0}.codeexample-base16-chalk-light .highlight .na{color:#acc267}.codeexample-base16-chalk-light .highlight .nb{color:#6fc2ef}.codeexample-base16-chalk-light .highlight .nc{color:#6fc2ef}.codeexample-base16-chalk-light .highlight .no{color:#e1a3ee}.codeexample-base16-chalk-light .highlight .nd{color:#e1a3ee}.codeexample-base16-chalk-light .highlight .ni{color:#fb9fb1}.codeexample-base16-chalk-light .highlight .ne{color:#ddb26f;font-weight:bold}.codeexample-base16-chalk-light .highlight .nf{color:#6fc2ef}.codeexample-base16-chalk-light .highlight .nl{color:#e1a3ee}.codeexample-base16-chalk-light .highlight .nn{color:#6fc2ef}.codeexample-base16-chalk-light .highlight .nx{color:#e1a3ee}.codeexample-base16-chalk-light .highlight .py{color:#e1a3ee}.codeexample-base16-chalk-light .highlight .nt{color:#acc267}.codeexample-base16-chalk-light .highlight .nv{color:#303030}.codeexample-base16-chalk-light .highlight .ow{color:#ddb26f}.codeexample-base16-chalk-light .highlight .w{color:#e1a3ee}.codeexample-base16-chalk-light .highlight .mf{color:#e1a3ee}.codeexample-base16-chalk-light .highlight .mh{color:#e1a3ee}.codeexample-base16-chalk-light .highlight .mi{color:#e1a3ee}.codeexample-base16-chalk-light .highlight .mo{color:#e1a3ee}.codeexample-base16-chalk-light .highlight .sb{color:#12cfc0}.codeexample-base16-chalk-light .highlight .sc{color:#12cfc0}.codeexample-base16-chalk-light .highlight .sd{color:#12cfc0}.codeexample-base16-chalk-light .highlight .s2{color:#12cfc0}.codeexample-base16-chalk-light .highlight .se{color:#12cfc0}.codeexample-base16-chalk-light .highlight .sh{color:#12cfc0}.codeexample-base16-chalk-light .highlight .si{color:#12cfc0}.codeexample-base16-chalk-light .highlight .sx{color:#12cfc0}.codeexample-base16-chalk-light .highlight .sr{color:#12cfc0}.codeexample-base16-chalk-light .highlight .s1{color:#12cfc0}.codeexample-base16-chalk-light .highlight .ss{color:#12cfc0}.codeexample-base16-chalk-light .highlight .bp{color:#6fc2ef}.codeexample-base16-chalk-light .highlight .vc{color:#6fc2ef}.codeexample-base16-chalk-light .highlight .vg{color:#303030}.codeexample-base16-chalk-light .highlight .vi{color:#ddb26f}.codeexample-base16-chalk-light .highlight .il{color:#e1a3ee}</style><div class="codeexample codeexample-base16-chalk-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-codeschool-dark">Base16 Codeschool Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#9ea7a6"></div><div class="preview-color" style="background-color:#232c31"></div><div class="preview-color" style="background-color:#2a5491"></div><div class="preview-color" style="background-color:#237986"></div><div class="preview-color" style="background-color:#a03b1e"></div><div class="preview-color" style="background-color:#484d79"></div><div class="preview-color" style="background-color:#c59820"></div><div class="preview-color" style="background-color:#b02f30"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#232c31"></div><div class="preview-color" style="background-color:#3f4944"></div><div class="preview-color" style="background-color:#2a5491"></div><div class="preview-color" style="background-color:#237986"></div><div class="preview-color" style="background-color:#a03b1e"></div><div class="preview-color" style="background-color:#484d79"></div><div class="preview-color" style="background-color:#c59820"></div><div class="preview-color" style="background-color:#b02f30"></div></div></div><style>.codeexample-base16-codeschool-dark .highlight code, .codeexample-base16-codeschool-dark .highlight pre{color:#9ea7a6;background-color:#232c31}.codeexample-base16-codeschool-dark .highlight .hll{background-color:#3f4944}.codeexample-base16-codeschool-dark .highlight .c{color:#9ea7a6}.codeexample-base16-codeschool-dark .highlight .err{color:#237986;background-color:#3f4944}.codeexample-base16-codeschool-dark .highlight .g{color:#9ea7a6}.codeexample-base16-codeschool-dark .highlight .k{color:#484d79}.codeexample-base16-codeschool-dark .highlight .l{color:#c59820}.codeexample-base16-codeschool-dark .highlight .n{color:#9ea7a6}.codeexample-base16-codeschool-dark .highlight .o{color:#a03b1e}.codeexample-base16-codeschool-dark .highlight .x{color:#c59820}.codeexample-base16-codeschool-dark .highlight .p{color:#b5d8f6}.codeexample-base16-codeschool-dark .highlight .cm{color:#9ea7a6}.codeexample-base16-codeschool-dark .highlight .cp{color:#9ea7a6}.codeexample-base16-codeschool-dark .highlight .c1{color:#9ea7a6}.codeexample-base16-codeschool-dark .highlight .cs{color:#237986;font-weight:bold}.codeexample-base16-codeschool-dark .highlight .gd{color:#237986}.codeexample-base16-codeschool-dark .highlight .ge{color:#c59820;font-style:italic}.codeexample-base16-codeschool-dark .highlight .gr{color:#237986}.codeexample-base16-codeschool-dark .highlight .gh{color:#9ea7a6;font-weight:bold}.codeexample-base16-codeschool-dark .highlight .gi{color:#a03b1e}.codeexample-base16-codeschool-dark .highlight .go{color:#3f4944}.codeexample-base16-codeschool-dark .highlight .gp{color:#9ea7a6;font-weight:bold}.codeexample-base16-codeschool-dark .highlight .gs{color:#c59820;font-weight:bold}.codeexample-base16-codeschool-dark .highlight .gu{color:#c59820;font-weight:bold}.codeexample-base16-codeschool-dark .highlight .gt{color:#484d79}.codeexample-base16-codeschool-dark .highlight .kc{color:#2a5491}.codeexample-base16-codeschool-dark .highlight .kd{color:#a03b1e}.codeexample-base16-codeschool-dark .highlight .kn{color:#484d79;font-weight:bold}.codeexample-base16-codeschool-dark .highlight .kp{color:#237986}.codeexample-base16-codeschool-dark .highlight .kr{color:#237986}.codeexample-base16-codeschool-dark .highlight .kt{color:#9ea7a6}.codeexample-base16-codeschool-dark .highlight .ld{color:#b02f30}.codeexample-base16-codeschool-dark .highlight .m{color:#c59820}.codeexample-base16-codeschool-dark .highlight .s{color:#b02f30}.codeexample-base16-codeschool-dark .highlight .na{color:#237986}.codeexample-base16-codeschool-dark .highlight .nb{color:#484d79}.codeexample-base16-codeschool-dark .highlight .nc{color:#484d79}.codeexample-base16-codeschool-dark .highlight .no{color:#c59820}.codeexample-base16-codeschool-dark .highlight .nd{color:#c59820}.codeexample-base16-codeschool-dark .highlight .ni{color:#2a5491}.codeexample-base16-codeschool-dark .highlight .ne{color:#a03b1e;font-weight:bold}.codeexample-base16-codeschool-dark .highlight .nf{color:#484d79}.codeexample-base16-codeschool-dark .highlight .nl{color:#c59820}.codeexample-base16-codeschool-dark .highlight .nn{color:#484d79}.codeexample-base16-codeschool-dark .highlight .nx{color:#c59820}.codeexample-base16-codeschool-dark .highlight .py{color:#c59820}.codeexample-base16-codeschool-dark .highlight .nt{color:#237986}.codeexample-base16-codeschool-dark .highlight .nv{color:#9ea7a6}.codeexample-base16-codeschool-dark .highlight .ow{color:#a03b1e}.codeexample-base16-codeschool-dark .highlight .w{color:#c59820}.codeexample-base16-codeschool-dark .highlight .mf{color:#c59820}.codeexample-base16-codeschool-dark .highlight .mh{color:#c59820}.codeexample-base16-codeschool-dark .highlight .mi{color:#c59820}.codeexample-base16-codeschool-dark .highlight .mo{color:#c59820}.codeexample-base16-codeschool-dark .highlight .sb{color:#b02f30}.codeexample-base16-codeschool-dark .highlight .sc{color:#b02f30}.codeexample-base16-codeschool-dark .highlight .sd{color:#b02f30}.codeexample-base16-codeschool-dark .highlight .s2{color:#b02f30}.codeexample-base16-codeschool-dark .highlight .se{color:#b02f30}.codeexample-base16-codeschool-dark .highlight .sh{color:#b02f30}.codeexample-base16-codeschool-dark .highlight .si{color:#b02f30}.codeexample-base16-codeschool-dark .highlight .sx{color:#b02f30}.codeexample-base16-codeschool-dark .highlight .sr{color:#b02f30}.codeexample-base16-codeschool-dark .highlight .s1{color:#b02f30}.codeexample-base16-codeschool-dark .highlight .ss{color:#b02f30}.codeexample-base16-codeschool-dark .highlight .bp{color:#484d79}.codeexample-base16-codeschool-dark .highlight .vc{color:#484d79}.codeexample-base16-codeschool-dark .highlight .vg{color:#9ea7a6}.codeexample-base16-codeschool-dark .highlight .vi{color:#a03b1e}.codeexample-base16-codeschool-dark .highlight .il{color:#c59820}</style><div class="codeexample codeexample-base16-codeschool-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-codeschool-light">Base16 Codeschool Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#2a343a"></div><div class="preview-color" style="background-color:#232c31"></div><div class="preview-color" style="background-color:#2a5491"></div><div class="preview-color" style="background-color:#237986"></div><div class="preview-color" style="background-color:#a03b1e"></div><div class="preview-color" style="background-color:#484d79"></div><div class="preview-color" style="background-color:#c59820"></div><div class="preview-color" style="background-color:#b02f30"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#b5d8f6"></div><div class="preview-color" style="background-color:#3f4944"></div><div class="preview-color" style="background-color:#2a5491"></div><div class="preview-color" style="background-color:#237986"></div><div class="preview-color" style="background-color:#a03b1e"></div><div class="preview-color" style="background-color:#484d79"></div><div class="preview-color" style="background-color:#c59820"></div><div class="preview-color" style="background-color:#b02f30"></div></div></div><style>.codeexample-base16-codeschool-light .highlight code, .codeexample-base16-codeschool-light .highlight pre{color:#2a343a;background-color:#b5d8f6}.codeexample-base16-codeschool-light .highlight .hll{background-color:#3f4944}.codeexample-base16-codeschool-light .highlight .c{color:#9ea7a6}.codeexample-base16-codeschool-light .highlight .err{color:#237986;background-color:#3f4944}.codeexample-base16-codeschool-light .highlight .g{color:#9ea7a6}.codeexample-base16-codeschool-light .highlight .k{color:#484d79}.codeexample-base16-codeschool-light .highlight .l{color:#c59820}.codeexample-base16-codeschool-light .highlight .n{color:#2a343a}.codeexample-base16-codeschool-light .highlight .o{color:#a03b1e}.codeexample-base16-codeschool-light .highlight .x{color:#c59820}.codeexample-base16-codeschool-light .highlight .p{color:#b5d8f6}.codeexample-base16-codeschool-light .highlight .cm{color:#9ea7a6}.codeexample-base16-codeschool-light .highlight .cp{color:#9ea7a6}.codeexample-base16-codeschool-light .highlight .c1{color:#9ea7a6}.codeexample-base16-codeschool-light .highlight .cs{color:#237986;font-weight:bold}.codeexample-base16-codeschool-light .highlight .gd{color:#237986}.codeexample-base16-codeschool-light .highlight .ge{color:#c59820;font-style:italic}.codeexample-base16-codeschool-light .highlight .gr{color:#237986}.codeexample-base16-codeschool-light .highlight .gh{color:#2a343a;font-weight:bold}.codeexample-base16-codeschool-light .highlight .gi{color:#a03b1e}.codeexample-base16-codeschool-light .highlight .go{color:#3f4944}.codeexample-base16-codeschool-light .highlight .gp{color:#2a343a;font-weight:bold}.codeexample-base16-codeschool-light .highlight .gs{color:#c59820;font-weight:bold}.codeexample-base16-codeschool-light .highlight .gu{color:#c59820;font-weight:bold}.codeexample-base16-codeschool-light .highlight .gt{color:#484d79}.codeexample-base16-codeschool-light .highlight .kc{color:#2a5491}.codeexample-base16-codeschool-light .highlight .kd{color:#a03b1e}.codeexample-base16-codeschool-light .highlight .kn{color:#484d79;font-weight:bold}.codeexample-base16-codeschool-light .highlight .kp{color:#237986}.codeexample-base16-codeschool-light .highlight .kr{color:#237986}.codeexample-base16-codeschool-light .highlight .kt{color:#9ea7a6}.codeexample-base16-codeschool-light .highlight .ld{color:#b02f30}.codeexample-base16-codeschool-light .highlight .m{color:#c59820}.codeexample-base16-codeschool-light .highlight .s{color:#b02f30}.codeexample-base16-codeschool-light .highlight .na{color:#237986}.codeexample-base16-codeschool-light .highlight .nb{color:#484d79}.codeexample-base16-codeschool-light .highlight .nc{color:#484d79}.codeexample-base16-codeschool-light .highlight .no{color:#c59820}.codeexample-base16-codeschool-light .highlight .nd{color:#c59820}.codeexample-base16-codeschool-light .highlight .ni{color:#2a5491}.codeexample-base16-codeschool-light .highlight .ne{color:#a03b1e;font-weight:bold}.codeexample-base16-codeschool-light .highlight .nf{color:#484d79}.codeexample-base16-codeschool-light .highlight .nl{color:#c59820}.codeexample-base16-codeschool-light .highlight .nn{color:#484d79}.codeexample-base16-codeschool-light .highlight .nx{color:#c59820}.codeexample-base16-codeschool-light .highlight .py{color:#c59820}.codeexample-base16-codeschool-light .highlight .nt{color:#237986}.codeexample-base16-codeschool-light .highlight .nv{color:#2a343a}.codeexample-base16-codeschool-light .highlight .ow{color:#a03b1e}.codeexample-base16-codeschool-light .highlight .w{color:#c59820}.codeexample-base16-codeschool-light .highlight .mf{color:#c59820}.codeexample-base16-codeschool-light .highlight .mh{color:#c59820}.codeexample-base16-codeschool-light .highlight .mi{color:#c59820}.codeexample-base16-codeschool-light .highlight .mo{color:#c59820}.codeexample-base16-codeschool-light .highlight .sb{color:#b02f30}.codeexample-base16-codeschool-light .highlight .sc{color:#b02f30}.codeexample-base16-codeschool-light .highlight .sd{color:#b02f30}.codeexample-base16-codeschool-light .highlight .s2{color:#b02f30}.codeexample-base16-codeschool-light .highlight .se{color:#b02f30}.codeexample-base16-codeschool-light .highlight .sh{color:#b02f30}.codeexample-base16-codeschool-light .highlight .si{color:#b02f30}.codeexample-base16-codeschool-light .highlight .sx{color:#b02f30}.codeexample-base16-codeschool-light .highlight .sr{color:#b02f30}.codeexample-base16-codeschool-light .highlight .s1{color:#b02f30}.codeexample-base16-codeschool-light .highlight .ss{color:#b02f30}.codeexample-base16-codeschool-light .highlight .bp{color:#484d79}.codeexample-base16-codeschool-light .highlight .vc{color:#484d79}.codeexample-base16-codeschool-light .highlight .vg{color:#2a343a}.codeexample-base16-codeschool-light .highlight .vi{color:#a03b1e}.codeexample-base16-codeschool-light .highlight .il{color:#c59820}</style><div class="codeexample codeexample-base16-codeschool-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-colors-dark">Base16 Colors Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#bbbbbb"></div><div class="preview-color" style="background-color:#111111"></div><div class="preview-color" style="background-color:#ff4136"></div><div class="preview-color" style="background-color:#2ecc40"></div><div class="preview-color" style="background-color:#ffdc00"></div><div class="preview-color" style="background-color:#0074d9"></div><div class="preview-color" style="background-color:#b10dc9"></div><div class="preview-color" style="background-color:#7fdbff"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#111111"></div><div class="preview-color" style="background-color:#777777"></div><div class="preview-color" style="background-color:#ff4136"></div><div class="preview-color" style="background-color:#2ecc40"></div><div class="preview-color" style="background-color:#ffdc00"></div><div class="preview-color" style="background-color:#0074d9"></div><div class="preview-color" style="background-color:#b10dc9"></div><div class="preview-color" style="background-color:#7fdbff"></div></div></div><style>.codeexample-base16-colors-dark .highlight code, .codeexample-base16-colors-dark .highlight pre{color:#bbbbbb;background-color:#111111}.codeexample-base16-colors-dark .highlight .hll{background-color:#777777}.codeexample-base16-colors-dark .highlight .c{color:#bbbbbb}.codeexample-base16-colors-dark .highlight .err{color:#2ecc40;background-color:#777777}.codeexample-base16-colors-dark .highlight .g{color:#bbbbbb}.codeexample-base16-colors-dark .highlight .k{color:#0074d9}.codeexample-base16-colors-dark .highlight .l{color:#b10dc9}.codeexample-base16-colors-dark .highlight .n{color:#bbbbbb}.codeexample-base16-colors-dark .highlight .o{color:#ffdc00}.codeexample-base16-colors-dark .highlight .x{color:#b10dc9}.codeexample-base16-colors-dark .highlight .p{color:#ffffff}.codeexample-base16-colors-dark .highlight .cm{color:#bbbbbb}.codeexample-base16-colors-dark .highlight .cp{color:#bbbbbb}.codeexample-base16-colors-dark .highlight .c1{color:#bbbbbb}.codeexample-base16-colors-dark .highlight .cs{color:#2ecc40;font-weight:bold}.codeexample-base16-colors-dark .highlight .gd{color:#2ecc40}.codeexample-base16-colors-dark .highlight .ge{color:#b10dc9;font-style:italic}.codeexample-base16-colors-dark .highlight .gr{color:#2ecc40}.codeexample-base16-colors-dark .highlight .gh{color:#bbbbbb;font-weight:bold}.codeexample-base16-colors-dark .highlight .gi{color:#ffdc00}.codeexample-base16-colors-dark .highlight .go{color:#777777}.codeexample-base16-colors-dark .highlight .gp{color:#bbbbbb;font-weight:bold}.codeexample-base16-colors-dark .highlight .gs{color:#b10dc9;font-weight:bold}.codeexample-base16-colors-dark .highlight .gu{color:#b10dc9;font-weight:bold}.codeexample-base16-colors-dark .highlight .gt{color:#0074d9}.codeexample-base16-colors-dark .highlight .kc{color:#ff4136}.codeexample-base16-colors-dark .highlight .kd{color:#ffdc00}.codeexample-base16-colors-dark .highlight .kn{color:#0074d9;font-weight:bold}.codeexample-base16-colors-dark .highlight .kp{color:#2ecc40}.codeexample-base16-colors-dark .highlight .kr{color:#2ecc40}.codeexample-base16-colors-dark .highlight .kt{color:#bbbbbb}.codeexample-base16-colors-dark .highlight .ld{color:#7fdbff}.codeexample-base16-colors-dark .highlight .m{color:#b10dc9}.codeexample-base16-colors-dark .highlight .s{color:#7fdbff}.codeexample-base16-colors-dark .highlight .na{color:#2ecc40}.codeexample-base16-colors-dark .highlight .nb{color:#0074d9}.codeexample-base16-colors-dark .highlight .nc{color:#0074d9}.codeexample-base16-colors-dark .highlight .no{color:#b10dc9}.codeexample-base16-colors-dark .highlight .nd{color:#b10dc9}.codeexample-base16-colors-dark .highlight .ni{color:#ff4136}.codeexample-base16-colors-dark .highlight .ne{color:#ffdc00;font-weight:bold}.codeexample-base16-colors-dark .highlight .nf{color:#0074d9}.codeexample-base16-colors-dark .highlight .nl{color:#b10dc9}.codeexample-base16-colors-dark .highlight .nn{color:#0074d9}.codeexample-base16-colors-dark .highlight .nx{color:#b10dc9}.codeexample-base16-colors-dark .highlight .py{color:#b10dc9}.codeexample-base16-colors-dark .highlight .nt{color:#2ecc40}.codeexample-base16-colors-dark .highlight .nv{color:#bbbbbb}.codeexample-base16-colors-dark .highlight .ow{color:#ffdc00}.codeexample-base16-colors-dark .highlight .w{color:#b10dc9}.codeexample-base16-colors-dark .highlight .mf{color:#b10dc9}.codeexample-base16-colors-dark .highlight .mh{color:#b10dc9}.codeexample-base16-colors-dark .highlight .mi{color:#b10dc9}.codeexample-base16-colors-dark .highlight .mo{color:#b10dc9}.codeexample-base16-colors-dark .highlight .sb{color:#7fdbff}.codeexample-base16-colors-dark .highlight .sc{color:#7fdbff}.codeexample-base16-colors-dark .highlight .sd{color:#7fdbff}.codeexample-base16-colors-dark .highlight .s2{color:#7fdbff}.codeexample-base16-colors-dark .highlight .se{color:#7fdbff}.codeexample-base16-colors-dark .highlight .sh{color:#7fdbff}.codeexample-base16-colors-dark .highlight .si{color:#7fdbff}.codeexample-base16-colors-dark .highlight .sx{color:#7fdbff}.codeexample-base16-colors-dark .highlight .sr{color:#7fdbff}.codeexample-base16-colors-dark .highlight .s1{color:#7fdbff}.codeexample-base16-colors-dark .highlight .ss{color:#7fdbff}.codeexample-base16-colors-dark .highlight .bp{color:#0074d9}.codeexample-base16-colors-dark .highlight .vc{color:#0074d9}.codeexample-base16-colors-dark .highlight .vg{color:#bbbbbb}.codeexample-base16-colors-dark .highlight .vi{color:#ffdc00}.codeexample-base16-colors-dark .highlight .il{color:#b10dc9}</style><div class="codeexample codeexample-base16-colors-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-colors-light">Base16 Colors Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#555555"></div><div class="preview-color" style="background-color:#111111"></div><div class="preview-color" style="background-color:#ff4136"></div><div class="preview-color" style="background-color:#2ecc40"></div><div class="preview-color" style="background-color:#ffdc00"></div><div class="preview-color" style="background-color:#0074d9"></div><div class="preview-color" style="background-color:#b10dc9"></div><div class="preview-color" style="background-color:#7fdbff"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#ffffff"></div><div class="preview-color" style="background-color:#777777"></div><div class="preview-color" style="background-color:#ff4136"></div><div class="preview-color" style="background-color:#2ecc40"></div><div class="preview-color" style="background-color:#ffdc00"></div><div class="preview-color" style="background-color:#0074d9"></div><div class="preview-color" style="background-color:#b10dc9"></div><div class="preview-color" style="background-color:#7fdbff"></div></div></div><style>.codeexample-base16-colors-light .highlight code, .codeexample-base16-colors-light .highlight pre{color:#555555;background-color:#ffffff}.codeexample-base16-colors-light .highlight .hll{background-color:#777777}.codeexample-base16-colors-light .highlight .c{color:#bbbbbb}.codeexample-base16-colors-light .highlight .err{color:#2ecc40;background-color:#777777}.codeexample-base16-colors-light .highlight .g{color:#bbbbbb}.codeexample-base16-colors-light .highlight .k{color:#0074d9}.codeexample-base16-colors-light .highlight .l{color:#b10dc9}.codeexample-base16-colors-light .highlight .n{color:#555555}.codeexample-base16-colors-light .highlight .o{color:#ffdc00}.codeexample-base16-colors-light .highlight .x{color:#b10dc9}.codeexample-base16-colors-light .highlight .p{color:#ffffff}.codeexample-base16-colors-light .highlight .cm{color:#bbbbbb}.codeexample-base16-colors-light .highlight .cp{color:#bbbbbb}.codeexample-base16-colors-light .highlight .c1{color:#bbbbbb}.codeexample-base16-colors-light .highlight .cs{color:#2ecc40;font-weight:bold}.codeexample-base16-colors-light .highlight .gd{color:#2ecc40}.codeexample-base16-colors-light .highlight .ge{color:#b10dc9;font-style:italic}.codeexample-base16-colors-light .highlight .gr{color:#2ecc40}.codeexample-base16-colors-light .highlight .gh{color:#555555;font-weight:bold}.codeexample-base16-colors-light .highlight .gi{color:#ffdc00}.codeexample-base16-colors-light .highlight .go{color:#777777}.codeexample-base16-colors-light .highlight .gp{color:#555555;font-weight:bold}.codeexample-base16-colors-light .highlight .gs{color:#b10dc9;font-weight:bold}.codeexample-base16-colors-light .highlight .gu{color:#b10dc9;font-weight:bold}.codeexample-base16-colors-light .highlight .gt{color:#0074d9}.codeexample-base16-colors-light .highlight .kc{color:#ff4136}.codeexample-base16-colors-light .highlight .kd{color:#ffdc00}.codeexample-base16-colors-light .highlight .kn{color:#0074d9;font-weight:bold}.codeexample-base16-colors-light .highlight .kp{color:#2ecc40}.codeexample-base16-colors-light .highlight .kr{color:#2ecc40}.codeexample-base16-colors-light .highlight .kt{color:#bbbbbb}.codeexample-base16-colors-light .highlight .ld{color:#7fdbff}.codeexample-base16-colors-light .highlight .m{color:#b10dc9}.codeexample-base16-colors-light .highlight .s{color:#7fdbff}.codeexample-base16-colors-light .highlight .na{color:#2ecc40}.codeexample-base16-colors-light .highlight .nb{color:#0074d9}.codeexample-base16-colors-light .highlight .nc{color:#0074d9}.codeexample-base16-colors-light .highlight .no{color:#b10dc9}.codeexample-base16-colors-light .highlight .nd{color:#b10dc9}.codeexample-base16-colors-light .highlight .ni{color:#ff4136}.codeexample-base16-colors-light .highlight .ne{color:#ffdc00;font-weight:bold}.codeexample-base16-colors-light .highlight .nf{color:#0074d9}.codeexample-base16-colors-light .highlight .nl{color:#b10dc9}.codeexample-base16-colors-light .highlight .nn{color:#0074d9}.codeexample-base16-colors-light .highlight .nx{color:#b10dc9}.codeexample-base16-colors-light .highlight .py{color:#b10dc9}.codeexample-base16-colors-light .highlight .nt{color:#2ecc40}.codeexample-base16-colors-light .highlight .nv{color:#555555}.codeexample-base16-colors-light .highlight .ow{color:#ffdc00}.codeexample-base16-colors-light .highlight .w{color:#b10dc9}.codeexample-base16-colors-light .highlight .mf{color:#b10dc9}.codeexample-base16-colors-light .highlight .mh{color:#b10dc9}.codeexample-base16-colors-light .highlight .mi{color:#b10dc9}.codeexample-base16-colors-light .highlight .mo{color:#b10dc9}.codeexample-base16-colors-light .highlight .sb{color:#7fdbff}.codeexample-base16-colors-light .highlight .sc{color:#7fdbff}.codeexample-base16-colors-light .highlight .sd{color:#7fdbff}.codeexample-base16-colors-light .highlight .s2{color:#7fdbff}.codeexample-base16-colors-light .highlight .se{color:#7fdbff}.codeexample-base16-colors-light .highlight .sh{color:#7fdbff}.codeexample-base16-colors-light .highlight .si{color:#7fdbff}.codeexample-base16-colors-light .highlight .sx{color:#7fdbff}.codeexample-base16-colors-light .highlight .sr{color:#7fdbff}.codeexample-base16-colors-light .highlight .s1{color:#7fdbff}.codeexample-base16-colors-light .highlight .ss{color:#7fdbff}.codeexample-base16-colors-light .highlight .bp{color:#0074d9}.codeexample-base16-colors-light .highlight .vc{color:#0074d9}.codeexample-base16-colors-light .highlight .vg{color:#555555}.codeexample-base16-colors-light .highlight .vi{color:#ffdc00}.codeexample-base16-colors-light .highlight .il{color:#b10dc9}</style><div class="codeexample codeexample-base16-colors-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-default-dark">Base16 Default Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#d8d8d8"></div><div class="preview-color" style="background-color:#181818"></div><div class="preview-color" style="background-color:#ab4642"></div><div class="preview-color" style="background-color:#a1b56c"></div><div class="preview-color" style="background-color:#f7ca88"></div><div class="preview-color" style="background-color:#7cafc2"></div><div class="preview-color" style="background-color:#ba8baf"></div><div class="preview-color" style="background-color:#86c1b9"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#181818"></div><div class="preview-color" style="background-color:#585858"></div><div class="preview-color" style="background-color:#ab4642"></div><div class="preview-color" style="background-color:#a1b56c"></div><div class="preview-color" style="background-color:#f7ca88"></div><div class="preview-color" style="background-color:#7cafc2"></div><div class="preview-color" style="background-color:#ba8baf"></div><div class="preview-color" style="background-color:#86c1b9"></div></div></div><style>.codeexample-base16-default-dark .highlight code, .codeexample-base16-default-dark .highlight pre{color:#d8d8d8;background-color:#181818}.codeexample-base16-default-dark .highlight .hll{background-color:#585858}.codeexample-base16-default-dark .highlight .c{color:#d8d8d8}.codeexample-base16-default-dark .highlight .err{color:#a1b56c;background-color:#585858}.codeexample-base16-default-dark .highlight .g{color:#d8d8d8}.codeexample-base16-default-dark .highlight .k{color:#7cafc2}.codeexample-base16-default-dark .highlight .l{color:#ba8baf}.codeexample-base16-default-dark .highlight .n{color:#d8d8d8}.codeexample-base16-default-dark .highlight .o{color:#f7ca88}.codeexample-base16-default-dark .highlight .x{color:#ba8baf}.codeexample-base16-default-dark .highlight .p{color:#f8f8f8}.codeexample-base16-default-dark .highlight .cm{color:#d8d8d8}.codeexample-base16-default-dark .highlight .cp{color:#d8d8d8}.codeexample-base16-default-dark .highlight .c1{color:#d8d8d8}.codeexample-base16-default-dark .highlight .cs{color:#a1b56c;font-weight:bold}.codeexample-base16-default-dark .highlight .gd{color:#a1b56c}.codeexample-base16-default-dark .highlight .ge{color:#ba8baf;font-style:italic}.codeexample-base16-default-dark .highlight .gr{color:#a1b56c}.codeexample-base16-default-dark .highlight .gh{color:#d8d8d8;font-weight:bold}.codeexample-base16-default-dark .highlight .gi{color:#f7ca88}.codeexample-base16-default-dark .highlight .go{color:#585858}.codeexample-base16-default-dark .highlight .gp{color:#d8d8d8;font-weight:bold}.codeexample-base16-default-dark .highlight .gs{color:#ba8baf;font-weight:bold}.codeexample-base16-default-dark .highlight .gu{color:#ba8baf;font-weight:bold}.codeexample-base16-default-dark .highlight .gt{color:#7cafc2}.codeexample-base16-default-dark .highlight .kc{color:#ab4642}.codeexample-base16-default-dark .highlight .kd{color:#f7ca88}.codeexample-base16-default-dark .highlight .kn{color:#7cafc2;font-weight:bold}.codeexample-base16-default-dark .highlight .kp{color:#a1b56c}.codeexample-base16-default-dark .highlight .kr{color:#a1b56c}.codeexample-base16-default-dark .highlight .kt{color:#d8d8d8}.codeexample-base16-default-dark .highlight .ld{color:#86c1b9}.codeexample-base16-default-dark .highlight .m{color:#ba8baf}.codeexample-base16-default-dark .highlight .s{color:#86c1b9}.codeexample-base16-default-dark .highlight .na{color:#a1b56c}.codeexample-base16-default-dark .highlight .nb{color:#7cafc2}.codeexample-base16-default-dark .highlight .nc{color:#7cafc2}.codeexample-base16-default-dark .highlight .no{color:#ba8baf}.codeexample-base16-default-dark .highlight .nd{color:#ba8baf}.codeexample-base16-default-dark .highlight .ni{color:#ab4642}.codeexample-base16-default-dark .highlight .ne{color:#f7ca88;font-weight:bold}.codeexample-base16-default-dark .highlight .nf{color:#7cafc2}.codeexample-base16-default-dark .highlight .nl{color:#ba8baf}.codeexample-base16-default-dark .highlight .nn{color:#7cafc2}.codeexample-base16-default-dark .highlight .nx{color:#ba8baf}.codeexample-base16-default-dark .highlight .py{color:#ba8baf}.codeexample-base16-default-dark .highlight .nt{color:#a1b56c}.codeexample-base16-default-dark .highlight .nv{color:#d8d8d8}.codeexample-base16-default-dark .highlight .ow{color:#f7ca88}.codeexample-base16-default-dark .highlight .w{color:#ba8baf}.codeexample-base16-default-dark .highlight .mf{color:#ba8baf}.codeexample-base16-default-dark .highlight .mh{color:#ba8baf}.codeexample-base16-default-dark .highlight .mi{color:#ba8baf}.codeexample-base16-default-dark .highlight .mo{color:#ba8baf}.codeexample-base16-default-dark .highlight .sb{color:#86c1b9}.codeexample-base16-default-dark .highlight .sc{color:#86c1b9}.codeexample-base16-default-dark .highlight .sd{color:#86c1b9}.codeexample-base16-default-dark .highlight .s2{color:#86c1b9}.codeexample-base16-default-dark .highlight .se{color:#86c1b9}.codeexample-base16-default-dark .highlight .sh{color:#86c1b9}.codeexample-base16-default-dark .highlight .si{color:#86c1b9}.codeexample-base16-default-dark .highlight .sx{color:#86c1b9}.codeexample-base16-default-dark .highlight .sr{color:#86c1b9}.codeexample-base16-default-dark .highlight .s1{color:#86c1b9}.codeexample-base16-default-dark .highlight .ss{color:#86c1b9}.codeexample-base16-default-dark .highlight .bp{color:#7cafc2}.codeexample-base16-default-dark .highlight .vc{color:#7cafc2}.codeexample-base16-default-dark .highlight .vg{color:#d8d8d8}.codeexample-base16-default-dark .highlight .vi{color:#f7ca88}.codeexample-base16-default-dark .highlight .il{color:#ba8baf}</style><div class="codeexample codeexample-base16-default-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-default-light">Base16 Default Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#383838"></div><div class="preview-color" style="background-color:#181818"></div><div class="preview-color" style="background-color:#ab4642"></div><div class="preview-color" style="background-color:#a1b56c"></div><div class="preview-color" style="background-color:#f7ca88"></div><div class="preview-color" style="background-color:#7cafc2"></div><div class="preview-color" style="background-color:#ba8baf"></div><div class="preview-color" style="background-color:#86c1b9"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#f8f8f8"></div><div class="preview-color" style="background-color:#585858"></div><div class="preview-color" style="background-color:#ab4642"></div><div class="preview-color" style="background-color:#a1b56c"></div><div class="preview-color" style="background-color:#f7ca88"></div><div class="preview-color" style="background-color:#7cafc2"></div><div class="preview-color" style="background-color:#ba8baf"></div><div class="preview-color" style="background-color:#86c1b9"></div></div></div><style>.codeexample-base16-default-light .highlight code, .codeexample-base16-default-light .highlight pre{color:#383838;background-color:#f8f8f8}.codeexample-base16-default-light .highlight .hll{background-color:#585858}.codeexample-base16-default-light .highlight .c{color:#d8d8d8}.codeexample-base16-default-light .highlight .err{color:#a1b56c;background-color:#585858}.codeexample-base16-default-light .highlight .g{color:#d8d8d8}.codeexample-base16-default-light .highlight .k{color:#7cafc2}.codeexample-base16-default-light .highlight .l{color:#ba8baf}.codeexample-base16-default-light .highlight .n{color:#383838}.codeexample-base16-default-light .highlight .o{color:#f7ca88}.codeexample-base16-default-light .highlight .x{color:#ba8baf}.codeexample-base16-default-light .highlight .p{color:#f8f8f8}.codeexample-base16-default-light .highlight .cm{color:#d8d8d8}.codeexample-base16-default-light .highlight .cp{color:#d8d8d8}.codeexample-base16-default-light .highlight .c1{color:#d8d8d8}.codeexample-base16-default-light .highlight .cs{color:#a1b56c;font-weight:bold}.codeexample-base16-default-light .highlight .gd{color:#a1b56c}.codeexample-base16-default-light .highlight .ge{color:#ba8baf;font-style:italic}.codeexample-base16-default-light .highlight .gr{color:#a1b56c}.codeexample-base16-default-light .highlight .gh{color:#383838;font-weight:bold}.codeexample-base16-default-light .highlight .gi{color:#f7ca88}.codeexample-base16-default-light .highlight .go{color:#585858}.codeexample-base16-default-light .highlight .gp{color:#383838;font-weight:bold}.codeexample-base16-default-light .highlight .gs{color:#ba8baf;font-weight:bold}.codeexample-base16-default-light .highlight .gu{color:#ba8baf;font-weight:bold}.codeexample-base16-default-light .highlight .gt{color:#7cafc2}.codeexample-base16-default-light .highlight .kc{color:#ab4642}.codeexample-base16-default-light .highlight .kd{color:#f7ca88}.codeexample-base16-default-light .highlight .kn{color:#7cafc2;font-weight:bold}.codeexample-base16-default-light .highlight .kp{color:#a1b56c}.codeexample-base16-default-light .highlight .kr{color:#a1b56c}.codeexample-base16-default-light .highlight .kt{color:#d8d8d8}.codeexample-base16-default-light .highlight .ld{color:#86c1b9}.codeexample-base16-default-light .highlight .m{color:#ba8baf}.codeexample-base16-default-light .highlight .s{color:#86c1b9}.codeexample-base16-default-light .highlight .na{color:#a1b56c}.codeexample-base16-default-light .highlight .nb{color:#7cafc2}.codeexample-base16-default-light .highlight .nc{color:#7cafc2}.codeexample-base16-default-light .highlight .no{color:#ba8baf}.codeexample-base16-default-light .highlight .nd{color:#ba8baf}.codeexample-base16-default-light .highlight .ni{color:#ab4642}.codeexample-base16-default-light .highlight .ne{color:#f7ca88;font-weight:bold}.codeexample-base16-default-light .highlight .nf{color:#7cafc2}.codeexample-base16-default-light .highlight .nl{color:#ba8baf}.codeexample-base16-default-light .highlight .nn{color:#7cafc2}.codeexample-base16-default-light .highlight .nx{color:#ba8baf}.codeexample-base16-default-light .highlight .py{color:#ba8baf}.codeexample-base16-default-light .highlight .nt{color:#a1b56c}.codeexample-base16-default-light .highlight .nv{color:#383838}.codeexample-base16-default-light .highlight .ow{color:#f7ca88}.codeexample-base16-default-light .highlight .w{color:#ba8baf}.codeexample-base16-default-light .highlight .mf{color:#ba8baf}.codeexample-base16-default-light .highlight .mh{color:#ba8baf}.codeexample-base16-default-light .highlight .mi{color:#ba8baf}.codeexample-base16-default-light .highlight .mo{color:#ba8baf}.codeexample-base16-default-light .highlight .sb{color:#86c1b9}.codeexample-base16-default-light .highlight .sc{color:#86c1b9}.codeexample-base16-default-light .highlight .sd{color:#86c1b9}.codeexample-base16-default-light .highlight .s2{color:#86c1b9}.codeexample-base16-default-light .highlight .se{color:#86c1b9}.codeexample-base16-default-light .highlight .sh{color:#86c1b9}.codeexample-base16-default-light .highlight .si{color:#86c1b9}.codeexample-base16-default-light .highlight .sx{color:#86c1b9}.codeexample-base16-default-light .highlight .sr{color:#86c1b9}.codeexample-base16-default-light .highlight .s1{color:#86c1b9}.codeexample-base16-default-light .highlight .ss{color:#86c1b9}.codeexample-base16-default-light .highlight .bp{color:#7cafc2}.codeexample-base16-default-light .highlight .vc{color:#7cafc2}.codeexample-base16-default-light .highlight .vg{color:#383838}.codeexample-base16-default-light .highlight .vi{color:#f7ca88}.codeexample-base16-default-light .highlight .il{color:#ba8baf}</style><div class="codeexample codeexample-base16-default-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-eighties-dark">Base16 Eighties Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#d3d0c8"></div><div class="preview-color" style="background-color:#2d2d2d"></div><div class="preview-color" style="background-color:#f2777a"></div><div class="preview-color" style="background-color:#99cc99"></div><div class="preview-color" style="background-color:#ffcc66"></div><div class="preview-color" style="background-color:#6699cc"></div><div class="preview-color" style="background-color:#cc99cc"></div><div class="preview-color" style="background-color:#66cccc"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#2d2d2d"></div><div class="preview-color" style="background-color:#747369"></div><div class="preview-color" style="background-color:#f2777a"></div><div class="preview-color" style="background-color:#99cc99"></div><div class="preview-color" style="background-color:#ffcc66"></div><div class="preview-color" style="background-color:#6699cc"></div><div class="preview-color" style="background-color:#cc99cc"></div><div class="preview-color" style="background-color:#66cccc"></div></div></div><style>.codeexample-base16-eighties-dark .highlight code, .codeexample-base16-eighties-dark .highlight pre{color:#d3d0c8;background-color:#2d2d2d}.codeexample-base16-eighties-dark .highlight .hll{background-color:#747369}.codeexample-base16-eighties-dark .highlight .c{color:#d3d0c8}.codeexample-base16-eighties-dark .highlight .err{color:#99cc99;background-color:#747369}.codeexample-base16-eighties-dark .highlight .g{color:#d3d0c8}.codeexample-base16-eighties-dark .highlight .k{color:#6699cc}.codeexample-base16-eighties-dark .highlight .l{color:#cc99cc}.codeexample-base16-eighties-dark .highlight .n{color:#d3d0c8}.codeexample-base16-eighties-dark .highlight .o{color:#ffcc66}.codeexample-base16-eighties-dark .highlight .x{color:#cc99cc}.codeexample-base16-eighties-dark .highlight .p{color:#f2f0ec}.codeexample-base16-eighties-dark .highlight .cm{color:#d3d0c8}.codeexample-base16-eighties-dark .highlight .cp{color:#d3d0c8}.codeexample-base16-eighties-dark .highlight .c1{color:#d3d0c8}.codeexample-base16-eighties-dark .highlight .cs{color:#99cc99;font-weight:bold}.codeexample-base16-eighties-dark .highlight .gd{color:#99cc99}.codeexample-base16-eighties-dark .highlight .ge{color:#cc99cc;font-style:italic}.codeexample-base16-eighties-dark .highlight .gr{color:#99cc99}.codeexample-base16-eighties-dark .highlight .gh{color:#d3d0c8;font-weight:bold}.codeexample-base16-eighties-dark .highlight .gi{color:#ffcc66}.codeexample-base16-eighties-dark .highlight .go{color:#747369}.codeexample-base16-eighties-dark .highlight .gp{color:#d3d0c8;font-weight:bold}.codeexample-base16-eighties-dark .highlight .gs{color:#cc99cc;font-weight:bold}.codeexample-base16-eighties-dark .highlight .gu{color:#cc99cc;font-weight:bold}.codeexample-base16-eighties-dark .highlight .gt{color:#6699cc}.codeexample-base16-eighties-dark .highlight .kc{color:#f2777a}.codeexample-base16-eighties-dark .highlight .kd{color:#ffcc66}.codeexample-base16-eighties-dark .highlight .kn{color:#6699cc;font-weight:bold}.codeexample-base16-eighties-dark .highlight .kp{color:#99cc99}.codeexample-base16-eighties-dark .highlight .kr{color:#99cc99}.codeexample-base16-eighties-dark .highlight .kt{color:#d3d0c8}.codeexample-base16-eighties-dark .highlight .ld{color:#66cccc}.codeexample-base16-eighties-dark .highlight .m{color:#cc99cc}.codeexample-base16-eighties-dark .highlight .s{color:#66cccc}.codeexample-base16-eighties-dark .highlight .na{color:#99cc99}.codeexample-base16-eighties-dark .highlight .nb{color:#6699cc}.codeexample-base16-eighties-dark .highlight .nc{color:#6699cc}.codeexample-base16-eighties-dark .highlight .no{color:#cc99cc}.codeexample-base16-eighties-dark .highlight .nd{color:#cc99cc}.codeexample-base16-eighties-dark .highlight .ni{color:#f2777a}.codeexample-base16-eighties-dark .highlight .ne{color:#ffcc66;font-weight:bold}.codeexample-base16-eighties-dark .highlight .nf{color:#6699cc}.codeexample-base16-eighties-dark .highlight .nl{color:#cc99cc}.codeexample-base16-eighties-dark .highlight .nn{color:#6699cc}.codeexample-base16-eighties-dark .highlight .nx{color:#cc99cc}.codeexample-base16-eighties-dark .highlight .py{color:#cc99cc}.codeexample-base16-eighties-dark .highlight .nt{color:#99cc99}.codeexample-base16-eighties-dark .highlight .nv{color:#d3d0c8}.codeexample-base16-eighties-dark .highlight .ow{color:#ffcc66}.codeexample-base16-eighties-dark .highlight .w{color:#cc99cc}.codeexample-base16-eighties-dark .highlight .mf{color:#cc99cc}.codeexample-base16-eighties-dark .highlight .mh{color:#cc99cc}.codeexample-base16-eighties-dark .highlight .mi{color:#cc99cc}.codeexample-base16-eighties-dark .highlight .mo{color:#cc99cc}.codeexample-base16-eighties-dark .highlight .sb{color:#66cccc}.codeexample-base16-eighties-dark .highlight .sc{color:#66cccc}.codeexample-base16-eighties-dark .highlight .sd{color:#66cccc}.codeexample-base16-eighties-dark .highlight .s2{color:#66cccc}.codeexample-base16-eighties-dark .highlight .se{color:#66cccc}.codeexample-base16-eighties-dark .highlight .sh{color:#66cccc}.codeexample-base16-eighties-dark .highlight .si{color:#66cccc}.codeexample-base16-eighties-dark .highlight .sx{color:#66cccc}.codeexample-base16-eighties-dark .highlight .sr{color:#66cccc}.codeexample-base16-eighties-dark .highlight .s1{color:#66cccc}.codeexample-base16-eighties-dark .highlight .ss{color:#66cccc}.codeexample-base16-eighties-dark .highlight .bp{color:#6699cc}.codeexample-base16-eighties-dark .highlight .vc{color:#6699cc}.codeexample-base16-eighties-dark .highlight .vg{color:#d3d0c8}.codeexample-base16-eighties-dark .highlight .vi{color:#ffcc66}.codeexample-base16-eighties-dark .highlight .il{color:#cc99cc}</style><div class="codeexample codeexample-base16-eighties-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-eighties-light">Base16 Eighties Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#515151"></div><div class="preview-color" style="background-color:#2d2d2d"></div><div class="preview-color" style="background-color:#f2777a"></div><div class="preview-color" style="background-color:#99cc99"></div><div class="preview-color" style="background-color:#ffcc66"></div><div class="preview-color" style="background-color:#6699cc"></div><div class="preview-color" style="background-color:#cc99cc"></div><div class="preview-color" style="background-color:#66cccc"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#f2f0ec"></div><div class="preview-color" style="background-color:#747369"></div><div class="preview-color" style="background-color:#f2777a"></div><div class="preview-color" style="background-color:#99cc99"></div><div class="preview-color" style="background-color:#ffcc66"></div><div class="preview-color" style="background-color:#6699cc"></div><div class="preview-color" style="background-color:#cc99cc"></div><div class="preview-color" style="background-color:#66cccc"></div></div></div><style>.codeexample-base16-eighties-light .highlight code, .codeexample-base16-eighties-light .highlight pre{color:#515151;background-color:#f2f0ec}.codeexample-base16-eighties-light .highlight .hll{background-color:#747369}.codeexample-base16-eighties-light .highlight .c{color:#d3d0c8}.codeexample-base16-eighties-light .highlight .err{color:#99cc99;background-color:#747369}.codeexample-base16-eighties-light .highlight .g{color:#d3d0c8}.codeexample-base16-eighties-light .highlight .k{color:#6699cc}.codeexample-base16-eighties-light .highlight .l{color:#cc99cc}.codeexample-base16-eighties-light .highlight .n{color:#515151}.codeexample-base16-eighties-light .highlight .o{color:#ffcc66}.codeexample-base16-eighties-light .highlight .x{color:#cc99cc}.codeexample-base16-eighties-light .highlight .p{color:#f2f0ec}.codeexample-base16-eighties-light .highlight .cm{color:#d3d0c8}.codeexample-base16-eighties-light .highlight .cp{color:#d3d0c8}.codeexample-base16-eighties-light .highlight .c1{color:#d3d0c8}.codeexample-base16-eighties-light .highlight .cs{color:#99cc99;font-weight:bold}.codeexample-base16-eighties-light .highlight .gd{color:#99cc99}.codeexample-base16-eighties-light .highlight .ge{color:#cc99cc;font-style:italic}.codeexample-base16-eighties-light .highlight .gr{color:#99cc99}.codeexample-base16-eighties-light .highlight .gh{color:#515151;font-weight:bold}.codeexample-base16-eighties-light .highlight .gi{color:#ffcc66}.codeexample-base16-eighties-light .highlight .go{color:#747369}.codeexample-base16-eighties-light .highlight .gp{color:#515151;font-weight:bold}.codeexample-base16-eighties-light .highlight .gs{color:#cc99cc;font-weight:bold}.codeexample-base16-eighties-light .highlight .gu{color:#cc99cc;font-weight:bold}.codeexample-base16-eighties-light .highlight .gt{color:#6699cc}.codeexample-base16-eighties-light .highlight .kc{color:#f2777a}.codeexample-base16-eighties-light .highlight .kd{color:#ffcc66}.codeexample-base16-eighties-light .highlight .kn{color:#6699cc;font-weight:bold}.codeexample-base16-eighties-light .highlight .kp{color:#99cc99}.codeexample-base16-eighties-light .highlight .kr{color:#99cc99}.codeexample-base16-eighties-light .highlight .kt{color:#d3d0c8}.codeexample-base16-eighties-light .highlight .ld{color:#66cccc}.codeexample-base16-eighties-light .highlight .m{color:#cc99cc}.codeexample-base16-eighties-light .highlight .s{color:#66cccc}.codeexample-base16-eighties-light .highlight .na{color:#99cc99}.codeexample-base16-eighties-light .highlight .nb{color:#6699cc}.codeexample-base16-eighties-light .highlight .nc{color:#6699cc}.codeexample-base16-eighties-light .highlight .no{color:#cc99cc}.codeexample-base16-eighties-light .highlight .nd{color:#cc99cc}.codeexample-base16-eighties-light .highlight .ni{color:#f2777a}.codeexample-base16-eighties-light .highlight .ne{color:#ffcc66;font-weight:bold}.codeexample-base16-eighties-light .highlight .nf{color:#6699cc}.codeexample-base16-eighties-light .highlight .nl{color:#cc99cc}.codeexample-base16-eighties-light .highlight .nn{color:#6699cc}.codeexample-base16-eighties-light .highlight .nx{color:#cc99cc}.codeexample-base16-eighties-light .highlight .py{color:#cc99cc}.codeexample-base16-eighties-light .highlight .nt{color:#99cc99}.codeexample-base16-eighties-light .highlight .nv{color:#515151}.codeexample-base16-eighties-light .highlight .ow{color:#ffcc66}.codeexample-base16-eighties-light .highlight .w{color:#cc99cc}.codeexample-base16-eighties-light .highlight .mf{color:#cc99cc}.codeexample-base16-eighties-light .highlight .mh{color:#cc99cc}.codeexample-base16-eighties-light .highlight .mi{color:#cc99cc}.codeexample-base16-eighties-light .highlight .mo{color:#cc99cc}.codeexample-base16-eighties-light .highlight .sb{color:#66cccc}.codeexample-base16-eighties-light .highlight .sc{color:#66cccc}.codeexample-base16-eighties-light .highlight .sd{color:#66cccc}.codeexample-base16-eighties-light .highlight .s2{color:#66cccc}.codeexample-base16-eighties-light .highlight .se{color:#66cccc}.codeexample-base16-eighties-light .highlight .sh{color:#66cccc}.codeexample-base16-eighties-light .highlight .si{color:#66cccc}.codeexample-base16-eighties-light .highlight .sx{color:#66cccc}.codeexample-base16-eighties-light .highlight .sr{color:#66cccc}.codeexample-base16-eighties-light .highlight .s1{color:#66cccc}.codeexample-base16-eighties-light .highlight .ss{color:#66cccc}.codeexample-base16-eighties-light .highlight .bp{color:#6699cc}.codeexample-base16-eighties-light .highlight .vc{color:#6699cc}.codeexample-base16-eighties-light .highlight .vg{color:#515151}.codeexample-base16-eighties-light .highlight .vi{color:#ffcc66}.codeexample-base16-eighties-light .highlight .il{color:#cc99cc}</style><div class="codeexample codeexample-base16-eighties-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-embers-dark">Base16 Embers Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#A39A90"></div><div class="preview-color" style="background-color:#16130F"></div><div class="preview-color" style="background-color:#826D57"></div><div class="preview-color" style="background-color:#57826D"></div><div class="preview-color" style="background-color:#6D8257"></div><div class="preview-color" style="background-color:#6D5782"></div><div class="preview-color" style="background-color:#82576D"></div><div class="preview-color" style="background-color:#576D82"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#16130F"></div><div class="preview-color" style="background-color:#5A5047"></div><div class="preview-color" style="background-color:#826D57"></div><div class="preview-color" style="background-color:#57826D"></div><div class="preview-color" style="background-color:#6D8257"></div><div class="preview-color" style="background-color:#6D5782"></div><div class="preview-color" style="background-color:#82576D"></div><div class="preview-color" style="background-color:#576D82"></div></div></div><style>.codeexample-base16-embers-dark .highlight code, .codeexample-base16-embers-dark .highlight pre{color:#A39A90;background-color:#16130F}.codeexample-base16-embers-dark .highlight .hll{background-color:#5A5047}.codeexample-base16-embers-dark .highlight .c{color:#A39A90}.codeexample-base16-embers-dark .highlight .err{color:#57826D;background-color:#5A5047}.codeexample-base16-embers-dark .highlight .g{color:#A39A90}.codeexample-base16-embers-dark .highlight .k{color:#6D5782}.codeexample-base16-embers-dark .highlight .l{color:#82576D}.codeexample-base16-embers-dark .highlight .n{color:#A39A90}.codeexample-base16-embers-dark .highlight .o{color:#6D8257}.codeexample-base16-embers-dark .highlight .x{color:#82576D}.codeexample-base16-embers-dark .highlight .p{color:#DBD6D1}.codeexample-base16-embers-dark .highlight .cm{color:#A39A90}.codeexample-base16-embers-dark .highlight .cp{color:#A39A90}.codeexample-base16-embers-dark .highlight .c1{color:#A39A90}.codeexample-base16-embers-dark .highlight .cs{color:#57826D;font-weight:bold}.codeexample-base16-embers-dark .highlight .gd{color:#57826D}.codeexample-base16-embers-dark .highlight .ge{color:#82576D;font-style:italic}.codeexample-base16-embers-dark .highlight .gr{color:#57826D}.codeexample-base16-embers-dark .highlight .gh{color:#A39A90;font-weight:bold}.codeexample-base16-embers-dark .highlight .gi{color:#6D8257}.codeexample-base16-embers-dark .highlight .go{color:#5A5047}.codeexample-base16-embers-dark .highlight .gp{color:#A39A90;font-weight:bold}.codeexample-base16-embers-dark .highlight .gs{color:#82576D;font-weight:bold}.codeexample-base16-embers-dark .highlight .gu{color:#82576D;font-weight:bold}.codeexample-base16-embers-dark .highlight .gt{color:#6D5782}.codeexample-base16-embers-dark .highlight .kc{color:#826D57}.codeexample-base16-embers-dark .highlight .kd{color:#6D8257}.codeexample-base16-embers-dark .highlight .kn{color:#6D5782;font-weight:bold}.codeexample-base16-embers-dark .highlight .kp{color:#57826D}.codeexample-base16-embers-dark .highlight .kr{color:#57826D}.codeexample-base16-embers-dark .highlight .kt{color:#A39A90}.codeexample-base16-embers-dark .highlight .ld{color:#576D82}.codeexample-base16-embers-dark .highlight .m{color:#82576D}.codeexample-base16-embers-dark .highlight .s{color:#576D82}.codeexample-base16-embers-dark .highlight .na{color:#57826D}.codeexample-base16-embers-dark .highlight .nb{color:#6D5782}.codeexample-base16-embers-dark .highlight .nc{color:#6D5782}.codeexample-base16-embers-dark .highlight .no{color:#82576D}.codeexample-base16-embers-dark .highlight .nd{color:#82576D}.codeexample-base16-embers-dark .highlight .ni{color:#826D57}.codeexample-base16-embers-dark .highlight .ne{color:#6D8257;font-weight:bold}.codeexample-base16-embers-dark .highlight .nf{color:#6D5782}.codeexample-base16-embers-dark .highlight .nl{color:#82576D}.codeexample-base16-embers-dark .highlight .nn{color:#6D5782}.codeexample-base16-embers-dark .highlight .nx{color:#82576D}.codeexample-base16-embers-dark .highlight .py{color:#82576D}.codeexample-base16-embers-dark .highlight .nt{color:#57826D}.codeexample-base16-embers-dark .highlight .nv{color:#A39A90}.codeexample-base16-embers-dark .highlight .ow{color:#6D8257}.codeexample-base16-embers-dark .highlight .w{color:#82576D}.codeexample-base16-embers-dark .highlight .mf{color:#82576D}.codeexample-base16-embers-dark .highlight .mh{color:#82576D}.codeexample-base16-embers-dark .highlight .mi{color:#82576D}.codeexample-base16-embers-dark .highlight .mo{color:#82576D}.codeexample-base16-embers-dark .highlight .sb{color:#576D82}.codeexample-base16-embers-dark .highlight .sc{color:#576D82}.codeexample-base16-embers-dark .highlight .sd{color:#576D82}.codeexample-base16-embers-dark .highlight .s2{color:#576D82}.codeexample-base16-embers-dark .highlight .se{color:#576D82}.codeexample-base16-embers-dark .highlight .sh{color:#576D82}.codeexample-base16-embers-dark .highlight .si{color:#576D82}.codeexample-base16-embers-dark .highlight .sx{color:#576D82}.codeexample-base16-embers-dark .highlight .sr{color:#576D82}.codeexample-base16-embers-dark .highlight .s1{color:#576D82}.codeexample-base16-embers-dark .highlight .ss{color:#576D82}.codeexample-base16-embers-dark .highlight .bp{color:#6D5782}.codeexample-base16-embers-dark .highlight .vc{color:#6D5782}.codeexample-base16-embers-dark .highlight .vg{color:#A39A90}.codeexample-base16-embers-dark .highlight .vi{color:#6D8257}.codeexample-base16-embers-dark .highlight .il{color:#82576D}</style><div class="codeexample codeexample-base16-embers-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-embers-light">Base16 Embers Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#433B32"></div><div class="preview-color" style="background-color:#16130F"></div><div class="preview-color" style="background-color:#826D57"></div><div class="preview-color" style="background-color:#57826D"></div><div class="preview-color" style="background-color:#6D8257"></div><div class="preview-color" style="background-color:#6D5782"></div><div class="preview-color" style="background-color:#82576D"></div><div class="preview-color" style="background-color:#576D82"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#DBD6D1"></div><div class="preview-color" style="background-color:#5A5047"></div><div class="preview-color" style="background-color:#826D57"></div><div class="preview-color" style="background-color:#57826D"></div><div class="preview-color" style="background-color:#6D8257"></div><div class="preview-color" style="background-color:#6D5782"></div><div class="preview-color" style="background-color:#82576D"></div><div class="preview-color" style="background-color:#576D82"></div></div></div><style>.codeexample-base16-embers-light .highlight code, .codeexample-base16-embers-light .highlight pre{color:#433B32;background-color:#DBD6D1}.codeexample-base16-embers-light .highlight .hll{background-color:#5A5047}.codeexample-base16-embers-light .highlight .c{color:#A39A90}.codeexample-base16-embers-light .highlight .err{color:#57826D;background-color:#5A5047}.codeexample-base16-embers-light .highlight .g{color:#A39A90}.codeexample-base16-embers-light .highlight .k{color:#6D5782}.codeexample-base16-embers-light .highlight .l{color:#82576D}.codeexample-base16-embers-light .highlight .n{color:#433B32}.codeexample-base16-embers-light .highlight .o{color:#6D8257}.codeexample-base16-embers-light .highlight .x{color:#82576D}.codeexample-base16-embers-light .highlight .p{color:#DBD6D1}.codeexample-base16-embers-light .highlight .cm{color:#A39A90}.codeexample-base16-embers-light .highlight .cp{color:#A39A90}.codeexample-base16-embers-light .highlight .c1{color:#A39A90}.codeexample-base16-embers-light .highlight .cs{color:#57826D;font-weight:bold}.codeexample-base16-embers-light .highlight .gd{color:#57826D}.codeexample-base16-embers-light .highlight .ge{color:#82576D;font-style:italic}.codeexample-base16-embers-light .highlight .gr{color:#57826D}.codeexample-base16-embers-light .highlight .gh{color:#433B32;font-weight:bold}.codeexample-base16-embers-light .highlight .gi{color:#6D8257}.codeexample-base16-embers-light .highlight .go{color:#5A5047}.codeexample-base16-embers-light .highlight .gp{color:#433B32;font-weight:bold}.codeexample-base16-embers-light .highlight .gs{color:#82576D;font-weight:bold}.codeexample-base16-embers-light .highlight .gu{color:#82576D;font-weight:bold}.codeexample-base16-embers-light .highlight .gt{color:#6D5782}.codeexample-base16-embers-light .highlight .kc{color:#826D57}.codeexample-base16-embers-light .highlight .kd{color:#6D8257}.codeexample-base16-embers-light .highlight .kn{color:#6D5782;font-weight:bold}.codeexample-base16-embers-light .highlight .kp{color:#57826D}.codeexample-base16-embers-light .highlight .kr{color:#57826D}.codeexample-base16-embers-light .highlight .kt{color:#A39A90}.codeexample-base16-embers-light .highlight .ld{color:#576D82}.codeexample-base16-embers-light .highlight .m{color:#82576D}.codeexample-base16-embers-light .highlight .s{color:#576D82}.codeexample-base16-embers-light .highlight .na{color:#57826D}.codeexample-base16-embers-light .highlight .nb{color:#6D5782}.codeexample-base16-embers-light .highlight .nc{color:#6D5782}.codeexample-base16-embers-light .highlight .no{color:#82576D}.codeexample-base16-embers-light .highlight .nd{color:#82576D}.codeexample-base16-embers-light .highlight .ni{color:#826D57}.codeexample-base16-embers-light .highlight .ne{color:#6D8257;font-weight:bold}.codeexample-base16-embers-light .highlight .nf{color:#6D5782}.codeexample-base16-embers-light .highlight .nl{color:#82576D}.codeexample-base16-embers-light .highlight .nn{color:#6D5782}.codeexample-base16-embers-light .highlight .nx{color:#82576D}.codeexample-base16-embers-light .highlight .py{color:#82576D}.codeexample-base16-embers-light .highlight .nt{color:#57826D}.codeexample-base16-embers-light .highlight .nv{color:#433B32}.codeexample-base16-embers-light .highlight .ow{color:#6D8257}.codeexample-base16-embers-light .highlight .w{color:#82576D}.codeexample-base16-embers-light .highlight .mf{color:#82576D}.codeexample-base16-embers-light .highlight .mh{color:#82576D}.codeexample-base16-embers-light .highlight .mi{color:#82576D}.codeexample-base16-embers-light .highlight .mo{color:#82576D}.codeexample-base16-embers-light .highlight .sb{color:#576D82}.codeexample-base16-embers-light .highlight .sc{color:#576D82}.codeexample-base16-embers-light .highlight .sd{color:#576D82}.codeexample-base16-embers-light .highlight .s2{color:#576D82}.codeexample-base16-embers-light .highlight .se{color:#576D82}.codeexample-base16-embers-light .highlight .sh{color:#576D82}.codeexample-base16-embers-light .highlight .si{color:#576D82}.codeexample-base16-embers-light .highlight .sx{color:#576D82}.codeexample-base16-embers-light .highlight .sr{color:#576D82}.codeexample-base16-embers-light .highlight .s1{color:#576D82}.codeexample-base16-embers-light .highlight .ss{color:#576D82}.codeexample-base16-embers-light .highlight .bp{color:#6D5782}.codeexample-base16-embers-light .highlight .vc{color:#6D5782}.codeexample-base16-embers-light .highlight .vg{color:#433B32}.codeexample-base16-embers-light .highlight .vi{color:#6D8257}.codeexample-base16-embers-light .highlight .il{color:#82576D}</style><div class="codeexample codeexample-base16-embers-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-flat-dark">Base16 Flat Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#e0e0e0"></div><div class="preview-color" style="background-color:#2C3E50"></div><div class="preview-color" style="background-color:#E74C3C"></div><div class="preview-color" style="background-color:#2ECC71"></div><div class="preview-color" style="background-color:#F1C40F"></div><div class="preview-color" style="background-color:#3498DB"></div><div class="preview-color" style="background-color:#9B59B6"></div><div class="preview-color" style="background-color:#1ABC9C"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#2C3E50"></div><div class="preview-color" style="background-color:#95A5A6"></div><div class="preview-color" style="background-color:#E74C3C"></div><div class="preview-color" style="background-color:#2ECC71"></div><div class="preview-color" style="background-color:#F1C40F"></div><div class="preview-color" style="background-color:#3498DB"></div><div class="preview-color" style="background-color:#9B59B6"></div><div class="preview-color" style="background-color:#1ABC9C"></div></div></div><style>.codeexample-base16-flat-dark .highlight code, .codeexample-base16-flat-dark .highlight pre{color:#e0e0e0;background-color:#2C3E50}.codeexample-base16-flat-dark .highlight .hll{background-color:#95A5A6}.codeexample-base16-flat-dark .highlight .c{color:#e0e0e0}.codeexample-base16-flat-dark .highlight .err{color:#2ECC71;background-color:#95A5A6}.codeexample-base16-flat-dark .highlight .g{color:#e0e0e0}.codeexample-base16-flat-dark .highlight .k{color:#3498DB}.codeexample-base16-flat-dark .highlight .l{color:#9B59B6}.codeexample-base16-flat-dark .highlight .n{color:#e0e0e0}.codeexample-base16-flat-dark .highlight .o{color:#F1C40F}.codeexample-base16-flat-dark .highlight .x{color:#9B59B6}.codeexample-base16-flat-dark .highlight .p{color:#ECF0F1}.codeexample-base16-flat-dark .highlight .cm{color:#e0e0e0}.codeexample-base16-flat-dark .highlight .cp{color:#e0e0e0}.codeexample-base16-flat-dark .highlight .c1{color:#e0e0e0}.codeexample-base16-flat-dark .highlight .cs{color:#2ECC71;font-weight:bold}.codeexample-base16-flat-dark .highlight .gd{color:#2ECC71}.codeexample-base16-flat-dark .highlight .ge{color:#9B59B6;font-style:italic}.codeexample-base16-flat-dark .highlight .gr{color:#2ECC71}.codeexample-base16-flat-dark .highlight .gh{color:#e0e0e0;font-weight:bold}.codeexample-base16-flat-dark .highlight .gi{color:#F1C40F}.codeexample-base16-flat-dark .highlight .go{color:#95A5A6}.codeexample-base16-flat-dark .highlight .gp{color:#e0e0e0;font-weight:bold}.codeexample-base16-flat-dark .highlight .gs{color:#9B59B6;font-weight:bold}.codeexample-base16-flat-dark .highlight .gu{color:#9B59B6;font-weight:bold}.codeexample-base16-flat-dark .highlight .gt{color:#3498DB}.codeexample-base16-flat-dark .highlight .kc{color:#E74C3C}.codeexample-base16-flat-dark .highlight .kd{color:#F1C40F}.codeexample-base16-flat-dark .highlight .kn{color:#3498DB;font-weight:bold}.codeexample-base16-flat-dark .highlight .kp{color:#2ECC71}.codeexample-base16-flat-dark .highlight .kr{color:#2ECC71}.codeexample-base16-flat-dark .highlight .kt{color:#e0e0e0}.codeexample-base16-flat-dark .highlight .ld{color:#1ABC9C}.codeexample-base16-flat-dark .highlight .m{color:#9B59B6}.codeexample-base16-flat-dark .highlight .s{color:#1ABC9C}.codeexample-base16-flat-dark .highlight .na{color:#2ECC71}.codeexample-base16-flat-dark .highlight .nb{color:#3498DB}.codeexample-base16-flat-dark .highlight .nc{color:#3498DB}.codeexample-base16-flat-dark .highlight .no{color:#9B59B6}.codeexample-base16-flat-dark .highlight .nd{color:#9B59B6}.codeexample-base16-flat-dark .highlight .ni{color:#E74C3C}.codeexample-base16-flat-dark .highlight .ne{color:#F1C40F;font-weight:bold}.codeexample-base16-flat-dark .highlight .nf{color:#3498DB}.codeexample-base16-flat-dark .highlight .nl{color:#9B59B6}.codeexample-base16-flat-dark .highlight .nn{color:#3498DB}.codeexample-base16-flat-dark .highlight .nx{color:#9B59B6}.codeexample-base16-flat-dark .highlight .py{color:#9B59B6}.codeexample-base16-flat-dark .highlight .nt{color:#2ECC71}.codeexample-base16-flat-dark .highlight .nv{color:#e0e0e0}.codeexample-base16-flat-dark .highlight .ow{color:#F1C40F}.codeexample-base16-flat-dark .highlight .w{color:#9B59B6}.codeexample-base16-flat-dark .highlight .mf{color:#9B59B6}.codeexample-base16-flat-dark .highlight .mh{color:#9B59B6}.codeexample-base16-flat-dark .highlight .mi{color:#9B59B6}.codeexample-base16-flat-dark .highlight .mo{color:#9B59B6}.codeexample-base16-flat-dark .highlight .sb{color:#1ABC9C}.codeexample-base16-flat-dark .highlight .sc{color:#1ABC9C}.codeexample-base16-flat-dark .highlight .sd{color:#1ABC9C}.codeexample-base16-flat-dark .highlight .s2{color:#1ABC9C}.codeexample-base16-flat-dark .highlight .se{color:#1ABC9C}.codeexample-base16-flat-dark .highlight .sh{color:#1ABC9C}.codeexample-base16-flat-dark .highlight .si{color:#1ABC9C}.codeexample-base16-flat-dark .highlight .sx{color:#1ABC9C}.codeexample-base16-flat-dark .highlight .sr{color:#1ABC9C}.codeexample-base16-flat-dark .highlight .s1{color:#1ABC9C}.codeexample-base16-flat-dark .highlight .ss{color:#1ABC9C}.codeexample-base16-flat-dark .highlight .bp{color:#3498DB}.codeexample-base16-flat-dark .highlight .vc{color:#3498DB}.codeexample-base16-flat-dark .highlight .vg{color:#e0e0e0}.codeexample-base16-flat-dark .highlight .vi{color:#F1C40F}.codeexample-base16-flat-dark .highlight .il{color:#9B59B6}</style><div class="codeexample codeexample-base16-flat-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-flat-light">Base16 Flat Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#7F8C8D"></div><div class="preview-color" style="background-color:#2C3E50"></div><div class="preview-color" style="background-color:#E74C3C"></div><div class="preview-color" style="background-color:#2ECC71"></div><div class="preview-color" style="background-color:#F1C40F"></div><div class="preview-color" style="background-color:#3498DB"></div><div class="preview-color" style="background-color:#9B59B6"></div><div class="preview-color" style="background-color:#1ABC9C"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#ECF0F1"></div><div class="preview-color" style="background-color:#95A5A6"></div><div class="preview-color" style="background-color:#E74C3C"></div><div class="preview-color" style="background-color:#2ECC71"></div><div class="preview-color" style="background-color:#F1C40F"></div><div class="preview-color" style="background-color:#3498DB"></div><div class="preview-color" style="background-color:#9B59B6"></div><div class="preview-color" style="background-color:#1ABC9C"></div></div></div><style>.codeexample-base16-flat-light .highlight code, .codeexample-base16-flat-light .highlight pre{color:#7F8C8D;background-color:#ECF0F1}.codeexample-base16-flat-light .highlight .hll{background-color:#95A5A6}.codeexample-base16-flat-light .highlight .c{color:#e0e0e0}.codeexample-base16-flat-light .highlight .err{color:#2ECC71;background-color:#95A5A6}.codeexample-base16-flat-light .highlight .g{color:#e0e0e0}.codeexample-base16-flat-light .highlight .k{color:#3498DB}.codeexample-base16-flat-light .highlight .l{color:#9B59B6}.codeexample-base16-flat-light .highlight .n{color:#7F8C8D}.codeexample-base16-flat-light .highlight .o{color:#F1C40F}.codeexample-base16-flat-light .highlight .x{color:#9B59B6}.codeexample-base16-flat-light .highlight .p{color:#ECF0F1}.codeexample-base16-flat-light .highlight .cm{color:#e0e0e0}.codeexample-base16-flat-light .highlight .cp{color:#e0e0e0}.codeexample-base16-flat-light .highlight .c1{color:#e0e0e0}.codeexample-base16-flat-light .highlight .cs{color:#2ECC71;font-weight:bold}.codeexample-base16-flat-light .highlight .gd{color:#2ECC71}.codeexample-base16-flat-light .highlight .ge{color:#9B59B6;font-style:italic}.codeexample-base16-flat-light .highlight .gr{color:#2ECC71}.codeexample-base16-flat-light .highlight .gh{color:#7F8C8D;font-weight:bold}.codeexample-base16-flat-light .highlight .gi{color:#F1C40F}.codeexample-base16-flat-light .highlight .go{color:#95A5A6}.codeexample-base16-flat-light .highlight .gp{color:#7F8C8D;font-weight:bold}.codeexample-base16-flat-light .highlight .gs{color:#9B59B6;font-weight:bold}.codeexample-base16-flat-light .highlight .gu{color:#9B59B6;font-weight:bold}.codeexample-base16-flat-light .highlight .gt{color:#3498DB}.codeexample-base16-flat-light .highlight .kc{color:#E74C3C}.codeexample-base16-flat-light .highlight .kd{color:#F1C40F}.codeexample-base16-flat-light .highlight .kn{color:#3498DB;font-weight:bold}.codeexample-base16-flat-light .highlight .kp{color:#2ECC71}.codeexample-base16-flat-light .highlight .kr{color:#2ECC71}.codeexample-base16-flat-light .highlight .kt{color:#e0e0e0}.codeexample-base16-flat-light .highlight .ld{color:#1ABC9C}.codeexample-base16-flat-light .highlight .m{color:#9B59B6}.codeexample-base16-flat-light .highlight .s{color:#1ABC9C}.codeexample-base16-flat-light .highlight .na{color:#2ECC71}.codeexample-base16-flat-light .highlight .nb{color:#3498DB}.codeexample-base16-flat-light .highlight .nc{color:#3498DB}.codeexample-base16-flat-light .highlight .no{color:#9B59B6}.codeexample-base16-flat-light .highlight .nd{color:#9B59B6}.codeexample-base16-flat-light .highlight .ni{color:#E74C3C}.codeexample-base16-flat-light .highlight .ne{color:#F1C40F;font-weight:bold}.codeexample-base16-flat-light .highlight .nf{color:#3498DB}.codeexample-base16-flat-light .highlight .nl{color:#9B59B6}.codeexample-base16-flat-light .highlight .nn{color:#3498DB}.codeexample-base16-flat-light .highlight .nx{color:#9B59B6}.codeexample-base16-flat-light .highlight .py{color:#9B59B6}.codeexample-base16-flat-light .highlight .nt{color:#2ECC71}.codeexample-base16-flat-light .highlight .nv{color:#7F8C8D}.codeexample-base16-flat-light .highlight .ow{color:#F1C40F}.codeexample-base16-flat-light .highlight .w{color:#9B59B6}.codeexample-base16-flat-light .highlight .mf{color:#9B59B6}.codeexample-base16-flat-light .highlight .mh{color:#9B59B6}.codeexample-base16-flat-light .highlight .mi{color:#9B59B6}.codeexample-base16-flat-light .highlight .mo{color:#9B59B6}.codeexample-base16-flat-light .highlight .sb{color:#1ABC9C}.codeexample-base16-flat-light .highlight .sc{color:#1ABC9C}.codeexample-base16-flat-light .highlight .sd{color:#1ABC9C}.codeexample-base16-flat-light .highlight .s2{color:#1ABC9C}.codeexample-base16-flat-light .highlight .se{color:#1ABC9C}.codeexample-base16-flat-light .highlight .sh{color:#1ABC9C}.codeexample-base16-flat-light .highlight .si{color:#1ABC9C}.codeexample-base16-flat-light .highlight .sx{color:#1ABC9C}.codeexample-base16-flat-light .highlight .sr{color:#1ABC9C}.codeexample-base16-flat-light .highlight .s1{color:#1ABC9C}.codeexample-base16-flat-light .highlight .ss{color:#1ABC9C}.codeexample-base16-flat-light .highlight .bp{color:#3498DB}.codeexample-base16-flat-light .highlight .vc{color:#3498DB}.codeexample-base16-flat-light .highlight .vg{color:#7F8C8D}.codeexample-base16-flat-light .highlight .vi{color:#F1C40F}.codeexample-base16-flat-light .highlight .il{color:#9B59B6}</style><div class="codeexample codeexample-base16-flat-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-google-dark">Base16 Google Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#c5c8c6"></div><div class="preview-color" style="background-color:#1d1f21"></div><div class="preview-color" style="background-color:#CC342B"></div><div class="preview-color" style="background-color:#198844"></div><div class="preview-color" style="background-color:#FBA922"></div><div class="preview-color" style="background-color:#3971ED"></div><div class="preview-color" style="background-color:#A36AC7"></div><div class="preview-color" style="background-color:#3971ED"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#1d1f21"></div><div class="preview-color" style="background-color:#969896"></div><div class="preview-color" style="background-color:#CC342B"></div><div class="preview-color" style="background-color:#198844"></div><div class="preview-color" style="background-color:#FBA922"></div><div class="preview-color" style="background-color:#3971ED"></div><div class="preview-color" style="background-color:#A36AC7"></div><div class="preview-color" style="background-color:#3971ED"></div></div></div><style>.codeexample-base16-google-dark .highlight code, .codeexample-base16-google-dark .highlight pre{color:#c5c8c6;background-color:#1d1f21}.codeexample-base16-google-dark .highlight .hll{background-color:#969896}.codeexample-base16-google-dark .highlight .c{color:#c5c8c6}.codeexample-base16-google-dark .highlight .err{color:#198844;background-color:#969896}.codeexample-base16-google-dark .highlight .g{color:#c5c8c6}.codeexample-base16-google-dark .highlight .k{color:#3971ED}.codeexample-base16-google-dark .highlight .l{color:#A36AC7}.codeexample-base16-google-dark .highlight .n{color:#c5c8c6}.codeexample-base16-google-dark .highlight .o{color:#FBA922}.codeexample-base16-google-dark .highlight .x{color:#A36AC7}.codeexample-base16-google-dark .highlight .p{color:#ffffff}.codeexample-base16-google-dark .highlight .cm{color:#c5c8c6}.codeexample-base16-google-dark .highlight .cp{color:#c5c8c6}.codeexample-base16-google-dark .highlight .c1{color:#c5c8c6}.codeexample-base16-google-dark .highlight .cs{color:#198844;font-weight:bold}.codeexample-base16-google-dark .highlight .gd{color:#198844}.codeexample-base16-google-dark .highlight .ge{color:#A36AC7;font-style:italic}.codeexample-base16-google-dark .highlight .gr{color:#198844}.codeexample-base16-google-dark .highlight .gh{color:#c5c8c6;font-weight:bold}.codeexample-base16-google-dark .highlight .gi{color:#FBA922}.codeexample-base16-google-dark .highlight .go{color:#969896}.codeexample-base16-google-dark .highlight .gp{color:#c5c8c6;font-weight:bold}.codeexample-base16-google-dark .highlight .gs{color:#A36AC7;font-weight:bold}.codeexample-base16-google-dark .highlight .gu{color:#A36AC7;font-weight:bold}.codeexample-base16-google-dark .highlight .gt{color:#3971ED}.codeexample-base16-google-dark .highlight .kc{color:#CC342B}.codeexample-base16-google-dark .highlight .kd{color:#FBA922}.codeexample-base16-google-dark .highlight .kn{color:#3971ED;font-weight:bold}.codeexample-base16-google-dark .highlight .kp{color:#198844}.codeexample-base16-google-dark .highlight .kr{color:#198844}.codeexample-base16-google-dark .highlight .kt{color:#c5c8c6}.codeexample-base16-google-dark .highlight .ld{color:#3971ED}.codeexample-base16-google-dark .highlight .m{color:#A36AC7}.codeexample-base16-google-dark .highlight .s{color:#3971ED}.codeexample-base16-google-dark .highlight .na{color:#198844}.codeexample-base16-google-dark .highlight .nb{color:#3971ED}.codeexample-base16-google-dark .highlight .nc{color:#3971ED}.codeexample-base16-google-dark .highlight .no{color:#A36AC7}.codeexample-base16-google-dark .highlight .nd{color:#A36AC7}.codeexample-base16-google-dark .highlight .ni{color:#CC342B}.codeexample-base16-google-dark .highlight .ne{color:#FBA922;font-weight:bold}.codeexample-base16-google-dark .highlight .nf{color:#3971ED}.codeexample-base16-google-dark .highlight .nl{color:#A36AC7}.codeexample-base16-google-dark .highlight .nn{color:#3971ED}.codeexample-base16-google-dark .highlight .nx{color:#A36AC7}.codeexample-base16-google-dark .highlight .py{color:#A36AC7}.codeexample-base16-google-dark .highlight .nt{color:#198844}.codeexample-base16-google-dark .highlight .nv{color:#c5c8c6}.codeexample-base16-google-dark .highlight .ow{color:#FBA922}.codeexample-base16-google-dark .highlight .w{color:#A36AC7}.codeexample-base16-google-dark .highlight .mf{color:#A36AC7}.codeexample-base16-google-dark .highlight .mh{color:#A36AC7}.codeexample-base16-google-dark .highlight .mi{color:#A36AC7}.codeexample-base16-google-dark .highlight .mo{color:#A36AC7}.codeexample-base16-google-dark .highlight .sb{color:#3971ED}.codeexample-base16-google-dark .highlight .sc{color:#3971ED}.codeexample-base16-google-dark .highlight .sd{color:#3971ED}.codeexample-base16-google-dark .highlight .s2{color:#3971ED}.codeexample-base16-google-dark .highlight .se{color:#3971ED}.codeexample-base16-google-dark .highlight .sh{color:#3971ED}.codeexample-base16-google-dark .highlight .si{color:#3971ED}.codeexample-base16-google-dark .highlight .sx{color:#3971ED}.codeexample-base16-google-dark .highlight .sr{color:#3971ED}.codeexample-base16-google-dark .highlight .s1{color:#3971ED}.codeexample-base16-google-dark .highlight .ss{color:#3971ED}.codeexample-base16-google-dark .highlight .bp{color:#3971ED}.codeexample-base16-google-dark .highlight .vc{color:#3971ED}.codeexample-base16-google-dark .highlight .vg{color:#c5c8c6}.codeexample-base16-google-dark .highlight .vi{color:#FBA922}.codeexample-base16-google-dark .highlight .il{color:#A36AC7}</style><div class="codeexample codeexample-base16-google-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-google-light">Base16 Google Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#373b41"></div><div class="preview-color" style="background-color:#1d1f21"></div><div class="preview-color" style="background-color:#CC342B"></div><div class="preview-color" style="background-color:#198844"></div><div class="preview-color" style="background-color:#FBA922"></div><div class="preview-color" style="background-color:#3971ED"></div><div class="preview-color" style="background-color:#A36AC7"></div><div class="preview-color" style="background-color:#3971ED"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#ffffff"></div><div class="preview-color" style="background-color:#969896"></div><div class="preview-color" style="background-color:#CC342B"></div><div class="preview-color" style="background-color:#198844"></div><div class="preview-color" style="background-color:#FBA922"></div><div class="preview-color" style="background-color:#3971ED"></div><div class="preview-color" style="background-color:#A36AC7"></div><div class="preview-color" style="background-color:#3971ED"></div></div></div><style>.codeexample-base16-google-light .highlight code, .codeexample-base16-google-light .highlight pre{color:#373b41;background-color:#ffffff}.codeexample-base16-google-light .highlight .hll{background-color:#969896}.codeexample-base16-google-light .highlight .c{color:#c5c8c6}.codeexample-base16-google-light .highlight .err{color:#198844;background-color:#969896}.codeexample-base16-google-light .highlight .g{color:#c5c8c6}.codeexample-base16-google-light .highlight .k{color:#3971ED}.codeexample-base16-google-light .highlight .l{color:#A36AC7}.codeexample-base16-google-light .highlight .n{color:#373b41}.codeexample-base16-google-light .highlight .o{color:#FBA922}.codeexample-base16-google-light .highlight .x{color:#A36AC7}.codeexample-base16-google-light .highlight .p{color:#ffffff}.codeexample-base16-google-light .highlight .cm{color:#c5c8c6}.codeexample-base16-google-light .highlight .cp{color:#c5c8c6}.codeexample-base16-google-light .highlight .c1{color:#c5c8c6}.codeexample-base16-google-light .highlight .cs{color:#198844;font-weight:bold}.codeexample-base16-google-light .highlight .gd{color:#198844}.codeexample-base16-google-light .highlight .ge{color:#A36AC7;font-style:italic}.codeexample-base16-google-light .highlight .gr{color:#198844}.codeexample-base16-google-light .highlight .gh{color:#373b41;font-weight:bold}.codeexample-base16-google-light .highlight .gi{color:#FBA922}.codeexample-base16-google-light .highlight .go{color:#969896}.codeexample-base16-google-light .highlight .gp{color:#373b41;font-weight:bold}.codeexample-base16-google-light .highlight .gs{color:#A36AC7;font-weight:bold}.codeexample-base16-google-light .highlight .gu{color:#A36AC7;font-weight:bold}.codeexample-base16-google-light .highlight .gt{color:#3971ED}.codeexample-base16-google-light .highlight .kc{color:#CC342B}.codeexample-base16-google-light .highlight .kd{color:#FBA922}.codeexample-base16-google-light .highlight .kn{color:#3971ED;font-weight:bold}.codeexample-base16-google-light .highlight .kp{color:#198844}.codeexample-base16-google-light .highlight .kr{color:#198844}.codeexample-base16-google-light .highlight .kt{color:#c5c8c6}.codeexample-base16-google-light .highlight .ld{color:#3971ED}.codeexample-base16-google-light .highlight .m{color:#A36AC7}.codeexample-base16-google-light .highlight .s{color:#3971ED}.codeexample-base16-google-light .highlight .na{color:#198844}.codeexample-base16-google-light .highlight .nb{color:#3971ED}.codeexample-base16-google-light .highlight .nc{color:#3971ED}.codeexample-base16-google-light .highlight .no{color:#A36AC7}.codeexample-base16-google-light .highlight .nd{color:#A36AC7}.codeexample-base16-google-light .highlight .ni{color:#CC342B}.codeexample-base16-google-light .highlight .ne{color:#FBA922;font-weight:bold}.codeexample-base16-google-light .highlight .nf{color:#3971ED}.codeexample-base16-google-light .highlight .nl{color:#A36AC7}.codeexample-base16-google-light .highlight .nn{color:#3971ED}.codeexample-base16-google-light .highlight .nx{color:#A36AC7}.codeexample-base16-google-light .highlight .py{color:#A36AC7}.codeexample-base16-google-light .highlight .nt{color:#198844}.codeexample-base16-google-light .highlight .nv{color:#373b41}.codeexample-base16-google-light .highlight .ow{color:#FBA922}.codeexample-base16-google-light .highlight .w{color:#A36AC7}.codeexample-base16-google-light .highlight .mf{color:#A36AC7}.codeexample-base16-google-light .highlight .mh{color:#A36AC7}.codeexample-base16-google-light .highlight .mi{color:#A36AC7}.codeexample-base16-google-light .highlight .mo{color:#A36AC7}.codeexample-base16-google-light .highlight .sb{color:#3971ED}.codeexample-base16-google-light .highlight .sc{color:#3971ED}.codeexample-base16-google-light .highlight .sd{color:#3971ED}.codeexample-base16-google-light .highlight .s2{color:#3971ED}.codeexample-base16-google-light .highlight .se{color:#3971ED}.codeexample-base16-google-light .highlight .sh{color:#3971ED}.codeexample-base16-google-light .highlight .si{color:#3971ED}.codeexample-base16-google-light .highlight .sx{color:#3971ED}.codeexample-base16-google-light .highlight .sr{color:#3971ED}.codeexample-base16-google-light .highlight .s1{color:#3971ED}.codeexample-base16-google-light .highlight .ss{color:#3971ED}.codeexample-base16-google-light .highlight .bp{color:#3971ED}.codeexample-base16-google-light .highlight .vc{color:#3971ED}.codeexample-base16-google-light .highlight .vg{color:#373b41}.codeexample-base16-google-light .highlight .vi{color:#FBA922}.codeexample-base16-google-light .highlight .il{color:#A36AC7}</style><div class="codeexample codeexample-base16-google-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-grayscale-dark">Base16 Grayscale Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#b9b9b9"></div><div class="preview-color" style="background-color:#101010"></div><div class="preview-color" style="background-color:#7c7c7c"></div><div class="preview-color" style="background-color:#8e8e8e"></div><div class="preview-color" style="background-color:#a0a0a0"></div><div class="preview-color" style="background-color:#686868"></div><div class="preview-color" style="background-color:#747474"></div><div class="preview-color" style="background-color:#868686"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#101010"></div><div class="preview-color" style="background-color:#525252"></div><div class="preview-color" style="background-color:#7c7c7c"></div><div class="preview-color" style="background-color:#8e8e8e"></div><div class="preview-color" style="background-color:#a0a0a0"></div><div class="preview-color" style="background-color:#686868"></div><div class="preview-color" style="background-color:#747474"></div><div class="preview-color" style="background-color:#868686"></div></div></div><style>.codeexample-base16-grayscale-dark .highlight code, .codeexample-base16-grayscale-dark .highlight pre{color:#b9b9b9;background-color:#101010}.codeexample-base16-grayscale-dark .highlight .hll{background-color:#525252}.codeexample-base16-grayscale-dark .highlight .c{color:#b9b9b9}.codeexample-base16-grayscale-dark .highlight .err{color:#8e8e8e;background-color:#525252}.codeexample-base16-grayscale-dark .highlight .g{color:#b9b9b9}.codeexample-base16-grayscale-dark .highlight .k{color:#686868}.codeexample-base16-grayscale-dark .highlight .l{color:#747474}.codeexample-base16-grayscale-dark .highlight .n{color:#b9b9b9}.codeexample-base16-grayscale-dark .highlight .o{color:#a0a0a0}.codeexample-base16-grayscale-dark .highlight .x{color:#747474}.codeexample-base16-grayscale-dark .highlight .p{color:#f7f7f7}.codeexample-base16-grayscale-dark .highlight .cm{color:#b9b9b9}.codeexample-base16-grayscale-dark .highlight .cp{color:#b9b9b9}.codeexample-base16-grayscale-dark .highlight .c1{color:#b9b9b9}.codeexample-base16-grayscale-dark .highlight .cs{color:#8e8e8e;font-weight:bold}.codeexample-base16-grayscale-dark .highlight .gd{color:#8e8e8e}.codeexample-base16-grayscale-dark .highlight .ge{color:#747474;font-style:italic}.codeexample-base16-grayscale-dark .highlight .gr{color:#8e8e8e}.codeexample-base16-grayscale-dark .highlight .gh{color:#b9b9b9;font-weight:bold}.codeexample-base16-grayscale-dark .highlight .gi{color:#a0a0a0}.codeexample-base16-grayscale-dark .highlight .go{color:#525252}.codeexample-base16-grayscale-dark .highlight .gp{color:#b9b9b9;font-weight:bold}.codeexample-base16-grayscale-dark .highlight .gs{color:#747474;font-weight:bold}.codeexample-base16-grayscale-dark .highlight .gu{color:#747474;font-weight:bold}.codeexample-base16-grayscale-dark .highlight .gt{color:#686868}.codeexample-base16-grayscale-dark .highlight .kc{color:#7c7c7c}.codeexample-base16-grayscale-dark .highlight .kd{color:#a0a0a0}.codeexample-base16-grayscale-dark .highlight .kn{color:#686868;font-weight:bold}.codeexample-base16-grayscale-dark .highlight .kp{color:#8e8e8e}.codeexample-base16-grayscale-dark .highlight .kr{color:#8e8e8e}.codeexample-base16-grayscale-dark .highlight .kt{color:#b9b9b9}.codeexample-base16-grayscale-dark .highlight .ld{color:#868686}.codeexample-base16-grayscale-dark .highlight .m{color:#747474}.codeexample-base16-grayscale-dark .highlight .s{color:#868686}.codeexample-base16-grayscale-dark .highlight .na{color:#8e8e8e}.codeexample-base16-grayscale-dark .highlight .nb{color:#686868}.codeexample-base16-grayscale-dark .highlight .nc{color:#686868}.codeexample-base16-grayscale-dark .highlight .no{color:#747474}.codeexample-base16-grayscale-dark .highlight .nd{color:#747474}.codeexample-base16-grayscale-dark .highlight .ni{color:#7c7c7c}.codeexample-base16-grayscale-dark .highlight .ne{color:#a0a0a0;font-weight:bold}.codeexample-base16-grayscale-dark .highlight .nf{color:#686868}.codeexample-base16-grayscale-dark .highlight .nl{color:#747474}.codeexample-base16-grayscale-dark .highlight .nn{color:#686868}.codeexample-base16-grayscale-dark .highlight .nx{color:#747474}.codeexample-base16-grayscale-dark .highlight .py{color:#747474}.codeexample-base16-grayscale-dark .highlight .nt{color:#8e8e8e}.codeexample-base16-grayscale-dark .highlight .nv{color:#b9b9b9}.codeexample-base16-grayscale-dark .highlight .ow{color:#a0a0a0}.codeexample-base16-grayscale-dark .highlight .w{color:#747474}.codeexample-base16-grayscale-dark .highlight .mf{color:#747474}.codeexample-base16-grayscale-dark .highlight .mh{color:#747474}.codeexample-base16-grayscale-dark .highlight .mi{color:#747474}.codeexample-base16-grayscale-dark .highlight .mo{color:#747474}.codeexample-base16-grayscale-dark .highlight .sb{color:#868686}.codeexample-base16-grayscale-dark .highlight .sc{color:#868686}.codeexample-base16-grayscale-dark .highlight .sd{color:#868686}.codeexample-base16-grayscale-dark .highlight .s2{color:#868686}.codeexample-base16-grayscale-dark .highlight .se{color:#868686}.codeexample-base16-grayscale-dark .highlight .sh{color:#868686}.codeexample-base16-grayscale-dark .highlight .si{color:#868686}.codeexample-base16-grayscale-dark .highlight .sx{color:#868686}.codeexample-base16-grayscale-dark .highlight .sr{color:#868686}.codeexample-base16-grayscale-dark .highlight .s1{color:#868686}.codeexample-base16-grayscale-dark .highlight .ss{color:#868686}.codeexample-base16-grayscale-dark .highlight .bp{color:#686868}.codeexample-base16-grayscale-dark .highlight .vc{color:#686868}.codeexample-base16-grayscale-dark .highlight .vg{color:#b9b9b9}.codeexample-base16-grayscale-dark .highlight .vi{color:#a0a0a0}.codeexample-base16-grayscale-dark .highlight .il{color:#747474}</style><div class="codeexample codeexample-base16-grayscale-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-grayscale-light">Base16 Grayscale Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#464646"></div><div class="preview-color" style="background-color:#101010"></div><div class="preview-color" style="background-color:#7c7c7c"></div><div class="preview-color" style="background-color:#8e8e8e"></div><div class="preview-color" style="background-color:#a0a0a0"></div><div class="preview-color" style="background-color:#686868"></div><div class="preview-color" style="background-color:#747474"></div><div class="preview-color" style="background-color:#868686"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#f7f7f7"></div><div class="preview-color" style="background-color:#525252"></div><div class="preview-color" style="background-color:#7c7c7c"></div><div class="preview-color" style="background-color:#8e8e8e"></div><div class="preview-color" style="background-color:#a0a0a0"></div><div class="preview-color" style="background-color:#686868"></div><div class="preview-color" style="background-color:#747474"></div><div class="preview-color" style="background-color:#868686"></div></div></div><style>.codeexample-base16-grayscale-light .highlight code, .codeexample-base16-grayscale-light .highlight pre{color:#464646;background-color:#f7f7f7}.codeexample-base16-grayscale-light .highlight .hll{background-color:#525252}.codeexample-base16-grayscale-light .highlight .c{color:#b9b9b9}.codeexample-base16-grayscale-light .highlight .err{color:#8e8e8e;background-color:#525252}.codeexample-base16-grayscale-light .highlight .g{color:#b9b9b9}.codeexample-base16-grayscale-light .highlight .k{color:#686868}.codeexample-base16-grayscale-light .highlight .l{color:#747474}.codeexample-base16-grayscale-light .highlight .n{color:#464646}.codeexample-base16-grayscale-light .highlight .o{color:#a0a0a0}.codeexample-base16-grayscale-light .highlight .x{color:#747474}.codeexample-base16-grayscale-light .highlight .p{color:#f7f7f7}.codeexample-base16-grayscale-light .highlight .cm{color:#b9b9b9}.codeexample-base16-grayscale-light .highlight .cp{color:#b9b9b9}.codeexample-base16-grayscale-light .highlight .c1{color:#b9b9b9}.codeexample-base16-grayscale-light .highlight .cs{color:#8e8e8e;font-weight:bold}.codeexample-base16-grayscale-light .highlight .gd{color:#8e8e8e}.codeexample-base16-grayscale-light .highlight .ge{color:#747474;font-style:italic}.codeexample-base16-grayscale-light .highlight .gr{color:#8e8e8e}.codeexample-base16-grayscale-light .highlight .gh{color:#464646;font-weight:bold}.codeexample-base16-grayscale-light .highlight .gi{color:#a0a0a0}.codeexample-base16-grayscale-light .highlight .go{color:#525252}.codeexample-base16-grayscale-light .highlight .gp{color:#464646;font-weight:bold}.codeexample-base16-grayscale-light .highlight .gs{color:#747474;font-weight:bold}.codeexample-base16-grayscale-light .highlight .gu{color:#747474;font-weight:bold}.codeexample-base16-grayscale-light .highlight .gt{color:#686868}.codeexample-base16-grayscale-light .highlight .kc{color:#7c7c7c}.codeexample-base16-grayscale-light .highlight .kd{color:#a0a0a0}.codeexample-base16-grayscale-light .highlight .kn{color:#686868;font-weight:bold}.codeexample-base16-grayscale-light .highlight .kp{color:#8e8e8e}.codeexample-base16-grayscale-light .highlight .kr{color:#8e8e8e}.codeexample-base16-grayscale-light .highlight .kt{color:#b9b9b9}.codeexample-base16-grayscale-light .highlight .ld{color:#868686}.codeexample-base16-grayscale-light .highlight .m{color:#747474}.codeexample-base16-grayscale-light .highlight .s{color:#868686}.codeexample-base16-grayscale-light .highlight .na{color:#8e8e8e}.codeexample-base16-grayscale-light .highlight .nb{color:#686868}.codeexample-base16-grayscale-light .highlight .nc{color:#686868}.codeexample-base16-grayscale-light .highlight .no{color:#747474}.codeexample-base16-grayscale-light .highlight .nd{color:#747474}.codeexample-base16-grayscale-light .highlight .ni{color:#7c7c7c}.codeexample-base16-grayscale-light .highlight .ne{color:#a0a0a0;font-weight:bold}.codeexample-base16-grayscale-light .highlight .nf{color:#686868}.codeexample-base16-grayscale-light .highlight .nl{color:#747474}.codeexample-base16-grayscale-light .highlight .nn{color:#686868}.codeexample-base16-grayscale-light .highlight .nx{color:#747474}.codeexample-base16-grayscale-light .highlight .py{color:#747474}.codeexample-base16-grayscale-light .highlight .nt{color:#8e8e8e}.codeexample-base16-grayscale-light .highlight .nv{color:#464646}.codeexample-base16-grayscale-light .highlight .ow{color:#a0a0a0}.codeexample-base16-grayscale-light .highlight .w{color:#747474}.codeexample-base16-grayscale-light .highlight .mf{color:#747474}.codeexample-base16-grayscale-light .highlight .mh{color:#747474}.codeexample-base16-grayscale-light .highlight .mi{color:#747474}.codeexample-base16-grayscale-light .highlight .mo{color:#747474}.codeexample-base16-grayscale-light .highlight .sb{color:#868686}.codeexample-base16-grayscale-light .highlight .sc{color:#868686}.codeexample-base16-grayscale-light .highlight .sd{color:#868686}.codeexample-base16-grayscale-light .highlight .s2{color:#868686}.codeexample-base16-grayscale-light .highlight .se{color:#868686}.codeexample-base16-grayscale-light .highlight .sh{color:#868686}.codeexample-base16-grayscale-light .highlight .si{color:#868686}.codeexample-base16-grayscale-light .highlight .sx{color:#868686}.codeexample-base16-grayscale-light .highlight .sr{color:#868686}.codeexample-base16-grayscale-light .highlight .s1{color:#868686}.codeexample-base16-grayscale-light .highlight .ss{color:#868686}.codeexample-base16-grayscale-light .highlight .bp{color:#686868}.codeexample-base16-grayscale-light .highlight .vc{color:#686868}.codeexample-base16-grayscale-light .highlight .vg{color:#464646}.codeexample-base16-grayscale-light .highlight .vi{color:#a0a0a0}.codeexample-base16-grayscale-light .highlight .il{color:#747474}</style><div class="codeexample codeexample-base16-grayscale-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-greenscreen-dark">Base16 Greenscreen Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#00bb00"></div><div class="preview-color" style="background-color:#001100"></div><div class="preview-color" style="background-color:#007700"></div><div class="preview-color" style="background-color:#00bb00"></div><div class="preview-color" style="background-color:#007700"></div><div class="preview-color" style="background-color:#009900"></div><div class="preview-color" style="background-color:#00bb00"></div><div class="preview-color" style="background-color:#005500"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#001100"></div><div class="preview-color" style="background-color:#007700"></div><div class="preview-color" style="background-color:#007700"></div><div class="preview-color" style="background-color:#00bb00"></div><div class="preview-color" style="background-color:#007700"></div><div class="preview-color" style="background-color:#009900"></div><div class="preview-color" style="background-color:#00bb00"></div><div class="preview-color" style="background-color:#005500"></div></div></div><style>.codeexample-base16-greenscreen-dark .highlight code, .codeexample-base16-greenscreen-dark .highlight pre{color:#00bb00;background-color:#001100}.codeexample-base16-greenscreen-dark .highlight .hll{background-color:#007700}.codeexample-base16-greenscreen-dark .highlight .c{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .err{color:#00bb00;background-color:#007700}.codeexample-base16-greenscreen-dark .highlight .g{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .k{color:#009900}.codeexample-base16-greenscreen-dark .highlight .l{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .n{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .o{color:#007700}.codeexample-base16-greenscreen-dark .highlight .x{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .p{color:#00ff00}.codeexample-base16-greenscreen-dark .highlight .cm{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .cp{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .c1{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .cs{color:#00bb00;font-weight:bold}.codeexample-base16-greenscreen-dark .highlight .gd{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .ge{color:#00bb00;font-style:italic}.codeexample-base16-greenscreen-dark .highlight .gr{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .gh{color:#00bb00;font-weight:bold}.codeexample-base16-greenscreen-dark .highlight .gi{color:#007700}.codeexample-base16-greenscreen-dark .highlight .go{color:#007700}.codeexample-base16-greenscreen-dark .highlight .gp{color:#00bb00;font-weight:bold}.codeexample-base16-greenscreen-dark .highlight .gs{color:#00bb00;font-weight:bold}.codeexample-base16-greenscreen-dark .highlight .gu{color:#00bb00;font-weight:bold}.codeexample-base16-greenscreen-dark .highlight .gt{color:#009900}.codeexample-base16-greenscreen-dark .highlight .kc{color:#007700}.codeexample-base16-greenscreen-dark .highlight .kd{color:#007700}.codeexample-base16-greenscreen-dark .highlight .kn{color:#009900;font-weight:bold}.codeexample-base16-greenscreen-dark .highlight .kp{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .kr{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .kt{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .ld{color:#005500}.codeexample-base16-greenscreen-dark .highlight .m{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .s{color:#005500}.codeexample-base16-greenscreen-dark .highlight .na{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .nb{color:#009900}.codeexample-base16-greenscreen-dark .highlight .nc{color:#009900}.codeexample-base16-greenscreen-dark .highlight .no{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .nd{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .ni{color:#007700}.codeexample-base16-greenscreen-dark .highlight .ne{color:#007700;font-weight:bold}.codeexample-base16-greenscreen-dark .highlight .nf{color:#009900}.codeexample-base16-greenscreen-dark .highlight .nl{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .nn{color:#009900}.codeexample-base16-greenscreen-dark .highlight .nx{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .py{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .nt{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .nv{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .ow{color:#007700}.codeexample-base16-greenscreen-dark .highlight .w{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .mf{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .mh{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .mi{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .mo{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .sb{color:#005500}.codeexample-base16-greenscreen-dark .highlight .sc{color:#005500}.codeexample-base16-greenscreen-dark .highlight .sd{color:#005500}.codeexample-base16-greenscreen-dark .highlight .s2{color:#005500}.codeexample-base16-greenscreen-dark .highlight .se{color:#005500}.codeexample-base16-greenscreen-dark .highlight .sh{color:#005500}.codeexample-base16-greenscreen-dark .highlight .si{color:#005500}.codeexample-base16-greenscreen-dark .highlight .sx{color:#005500}.codeexample-base16-greenscreen-dark .highlight .sr{color:#005500}.codeexample-base16-greenscreen-dark .highlight .s1{color:#005500}.codeexample-base16-greenscreen-dark .highlight .ss{color:#005500}.codeexample-base16-greenscreen-dark .highlight .bp{color:#009900}.codeexample-base16-greenscreen-dark .highlight .vc{color:#009900}.codeexample-base16-greenscreen-dark .highlight .vg{color:#00bb00}.codeexample-base16-greenscreen-dark .highlight .vi{color:#007700}.codeexample-base16-greenscreen-dark .highlight .il{color:#00bb00}</style><div class="codeexample codeexample-base16-greenscreen-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-greenscreen-light">Base16 Greenscreen Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#005500"></div><div class="preview-color" style="background-color:#001100"></div><div class="preview-color" style="background-color:#007700"></div><div class="preview-color" style="background-color:#00bb00"></div><div class="preview-color" style="background-color:#007700"></div><div class="preview-color" style="background-color:#009900"></div><div class="preview-color" style="background-color:#00bb00"></div><div class="preview-color" style="background-color:#005500"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#00ff00"></div><div class="preview-color" style="background-color:#007700"></div><div class="preview-color" style="background-color:#007700"></div><div class="preview-color" style="background-color:#00bb00"></div><div class="preview-color" style="background-color:#007700"></div><div class="preview-color" style="background-color:#009900"></div><div class="preview-color" style="background-color:#00bb00"></div><div class="preview-color" style="background-color:#005500"></div></div></div><style>.codeexample-base16-greenscreen-light .highlight code, .codeexample-base16-greenscreen-light .highlight pre{color:#005500;background-color:#00ff00}.codeexample-base16-greenscreen-light .highlight .hll{background-color:#007700}.codeexample-base16-greenscreen-light .highlight .c{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .err{color:#00bb00;background-color:#007700}.codeexample-base16-greenscreen-light .highlight .g{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .k{color:#009900}.codeexample-base16-greenscreen-light .highlight .l{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .n{color:#005500}.codeexample-base16-greenscreen-light .highlight .o{color:#007700}.codeexample-base16-greenscreen-light .highlight .x{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .p{color:#00ff00}.codeexample-base16-greenscreen-light .highlight .cm{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .cp{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .c1{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .cs{color:#00bb00;font-weight:bold}.codeexample-base16-greenscreen-light .highlight .gd{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .ge{color:#00bb00;font-style:italic}.codeexample-base16-greenscreen-light .highlight .gr{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .gh{color:#005500;font-weight:bold}.codeexample-base16-greenscreen-light .highlight .gi{color:#007700}.codeexample-base16-greenscreen-light .highlight .go{color:#007700}.codeexample-base16-greenscreen-light .highlight .gp{color:#005500;font-weight:bold}.codeexample-base16-greenscreen-light .highlight .gs{color:#00bb00;font-weight:bold}.codeexample-base16-greenscreen-light .highlight .gu{color:#00bb00;font-weight:bold}.codeexample-base16-greenscreen-light .highlight .gt{color:#009900}.codeexample-base16-greenscreen-light .highlight .kc{color:#007700}.codeexample-base16-greenscreen-light .highlight .kd{color:#007700}.codeexample-base16-greenscreen-light .highlight .kn{color:#009900;font-weight:bold}.codeexample-base16-greenscreen-light .highlight .kp{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .kr{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .kt{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .ld{color:#005500}.codeexample-base16-greenscreen-light .highlight .m{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .s{color:#005500}.codeexample-base16-greenscreen-light .highlight .na{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .nb{color:#009900}.codeexample-base16-greenscreen-light .highlight .nc{color:#009900}.codeexample-base16-greenscreen-light .highlight .no{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .nd{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .ni{color:#007700}.codeexample-base16-greenscreen-light .highlight .ne{color:#007700;font-weight:bold}.codeexample-base16-greenscreen-light .highlight .nf{color:#009900}.codeexample-base16-greenscreen-light .highlight .nl{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .nn{color:#009900}.codeexample-base16-greenscreen-light .highlight .nx{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .py{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .nt{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .nv{color:#005500}.codeexample-base16-greenscreen-light .highlight .ow{color:#007700}.codeexample-base16-greenscreen-light .highlight .w{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .mf{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .mh{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .mi{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .mo{color:#00bb00}.codeexample-base16-greenscreen-light .highlight .sb{color:#005500}.codeexample-base16-greenscreen-light .highlight .sc{color:#005500}.codeexample-base16-greenscreen-light .highlight .sd{color:#005500}.codeexample-base16-greenscreen-light .highlight .s2{color:#005500}.codeexample-base16-greenscreen-light .highlight .se{color:#005500}.codeexample-base16-greenscreen-light .highlight .sh{color:#005500}.codeexample-base16-greenscreen-light .highlight .si{color:#005500}.codeexample-base16-greenscreen-light .highlight .sx{color:#005500}.codeexample-base16-greenscreen-light .highlight .sr{color:#005500}.codeexample-base16-greenscreen-light .highlight .s1{color:#005500}.codeexample-base16-greenscreen-light .highlight .ss{color:#005500}.codeexample-base16-greenscreen-light .highlight .bp{color:#009900}.codeexample-base16-greenscreen-light .highlight .vc{color:#009900}.codeexample-base16-greenscreen-light .highlight .vg{color:#005500}.codeexample-base16-greenscreen-light .highlight .vi{color:#007700}.codeexample-base16-greenscreen-light .highlight .il{color:#00bb00}</style><div class="codeexample codeexample-base16-greenscreen-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-harmonic16-dark">Base16 Harmonic16 Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#cbd6e2"></div><div class="preview-color" style="background-color:#0b1c2c"></div><div class="preview-color" style="background-color:#bf8b56"></div><div class="preview-color" style="background-color:#56bf8b"></div><div class="preview-color" style="background-color:#8bbf56"></div><div class="preview-color" style="background-color:#8b56bf"></div><div class="preview-color" style="background-color:#bf568b"></div><div class="preview-color" style="background-color:#568bbf"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#0b1c2c"></div><div class="preview-color" style="background-color:#627e99"></div><div class="preview-color" style="background-color:#bf8b56"></div><div class="preview-color" style="background-color:#56bf8b"></div><div class="preview-color" style="background-color:#8bbf56"></div><div class="preview-color" style="background-color:#8b56bf"></div><div class="preview-color" style="background-color:#bf568b"></div><div class="preview-color" style="background-color:#568bbf"></div></div></div><style>.codeexample-base16-harmonic16-dark .highlight code, .codeexample-base16-harmonic16-dark .highlight pre{color:#cbd6e2;background-color:#0b1c2c}.codeexample-base16-harmonic16-dark .highlight .hll{background-color:#627e99}.codeexample-base16-harmonic16-dark .highlight .c{color:#cbd6e2}.codeexample-base16-harmonic16-dark .highlight .err{color:#56bf8b;background-color:#627e99}.codeexample-base16-harmonic16-dark .highlight .g{color:#cbd6e2}.codeexample-base16-harmonic16-dark .highlight .k{color:#8b56bf}.codeexample-base16-harmonic16-dark .highlight .l{color:#bf568b}.codeexample-base16-harmonic16-dark .highlight .n{color:#cbd6e2}.codeexample-base16-harmonic16-dark .highlight .o{color:#8bbf56}.codeexample-base16-harmonic16-dark .highlight .x{color:#bf568b}.codeexample-base16-harmonic16-dark .highlight .p{color:#f7f9fb}.codeexample-base16-harmonic16-dark .highlight .cm{color:#cbd6e2}.codeexample-base16-harmonic16-dark .highlight .cp{color:#cbd6e2}.codeexample-base16-harmonic16-dark .highlight .c1{color:#cbd6e2}.codeexample-base16-harmonic16-dark .highlight .cs{color:#56bf8b;font-weight:bold}.codeexample-base16-harmonic16-dark .highlight .gd{color:#56bf8b}.codeexample-base16-harmonic16-dark .highlight .ge{color:#bf568b;font-style:italic}.codeexample-base16-harmonic16-dark .highlight .gr{color:#56bf8b}.codeexample-base16-harmonic16-dark .highlight .gh{color:#cbd6e2;font-weight:bold}.codeexample-base16-harmonic16-dark .highlight .gi{color:#8bbf56}.codeexample-base16-harmonic16-dark .highlight .go{color:#627e99}.codeexample-base16-harmonic16-dark .highlight .gp{color:#cbd6e2;font-weight:bold}.codeexample-base16-harmonic16-dark .highlight .gs{color:#bf568b;font-weight:bold}.codeexample-base16-harmonic16-dark .highlight .gu{color:#bf568b;font-weight:bold}.codeexample-base16-harmonic16-dark .highlight .gt{color:#8b56bf}.codeexample-base16-harmonic16-dark .highlight .kc{color:#bf8b56}.codeexample-base16-harmonic16-dark .highlight .kd{color:#8bbf56}.codeexample-base16-harmonic16-dark .highlight .kn{color:#8b56bf;font-weight:bold}.codeexample-base16-harmonic16-dark .highlight .kp{color:#56bf8b}.codeexample-base16-harmonic16-dark .highlight .kr{color:#56bf8b}.codeexample-base16-harmonic16-dark .highlight .kt{color:#cbd6e2}.codeexample-base16-harmonic16-dark .highlight .ld{color:#568bbf}.codeexample-base16-harmonic16-dark .highlight .m{color:#bf568b}.codeexample-base16-harmonic16-dark .highlight .s{color:#568bbf}.codeexample-base16-harmonic16-dark .highlight .na{color:#56bf8b}.codeexample-base16-harmonic16-dark .highlight .nb{color:#8b56bf}.codeexample-base16-harmonic16-dark .highlight .nc{color:#8b56bf}.codeexample-base16-harmonic16-dark .highlight .no{color:#bf568b}.codeexample-base16-harmonic16-dark .highlight .nd{color:#bf568b}.codeexample-base16-harmonic16-dark .highlight .ni{color:#bf8b56}.codeexample-base16-harmonic16-dark .highlight .ne{color:#8bbf56;font-weight:bold}.codeexample-base16-harmonic16-dark .highlight .nf{color:#8b56bf}.codeexample-base16-harmonic16-dark .highlight .nl{color:#bf568b}.codeexample-base16-harmonic16-dark .highlight .nn{color:#8b56bf}.codeexample-base16-harmonic16-dark .highlight .nx{color:#bf568b}.codeexample-base16-harmonic16-dark .highlight .py{color:#bf568b}.codeexample-base16-harmonic16-dark .highlight .nt{color:#56bf8b}.codeexample-base16-harmonic16-dark .highlight .nv{color:#cbd6e2}.codeexample-base16-harmonic16-dark .highlight .ow{color:#8bbf56}.codeexample-base16-harmonic16-dark .highlight .w{color:#bf568b}.codeexample-base16-harmonic16-dark .highlight .mf{color:#bf568b}.codeexample-base16-harmonic16-dark .highlight .mh{color:#bf568b}.codeexample-base16-harmonic16-dark .highlight .mi{color:#bf568b}.codeexample-base16-harmonic16-dark .highlight .mo{color:#bf568b}.codeexample-base16-harmonic16-dark .highlight .sb{color:#568bbf}.codeexample-base16-harmonic16-dark .highlight .sc{color:#568bbf}.codeexample-base16-harmonic16-dark .highlight .sd{color:#568bbf}.codeexample-base16-harmonic16-dark .highlight .s2{color:#568bbf}.codeexample-base16-harmonic16-dark .highlight .se{color:#568bbf}.codeexample-base16-harmonic16-dark .highlight .sh{color:#568bbf}.codeexample-base16-harmonic16-dark .highlight .si{color:#568bbf}.codeexample-base16-harmonic16-dark .highlight .sx{color:#568bbf}.codeexample-base16-harmonic16-dark .highlight .sr{color:#568bbf}.codeexample-base16-harmonic16-dark .highlight .s1{color:#568bbf}.codeexample-base16-harmonic16-dark .highlight .ss{color:#568bbf}.codeexample-base16-harmonic16-dark .highlight .bp{color:#8b56bf}.codeexample-base16-harmonic16-dark .highlight .vc{color:#8b56bf}.codeexample-base16-harmonic16-dark .highlight .vg{color:#cbd6e2}.codeexample-base16-harmonic16-dark .highlight .vi{color:#8bbf56}.codeexample-base16-harmonic16-dark .highlight .il{color:#bf568b}</style><div class="codeexample codeexample-base16-harmonic16-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-harmonic16-light">Base16 Harmonic16 Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#405c79"></div><div class="preview-color" style="background-color:#0b1c2c"></div><div class="preview-color" style="background-color:#bf8b56"></div><div class="preview-color" style="background-color:#56bf8b"></div><div class="preview-color" style="background-color:#8bbf56"></div><div class="preview-color" style="background-color:#8b56bf"></div><div class="preview-color" style="background-color:#bf568b"></div><div class="preview-color" style="background-color:#568bbf"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#f7f9fb"></div><div class="preview-color" style="background-color:#627e99"></div><div class="preview-color" style="background-color:#bf8b56"></div><div class="preview-color" style="background-color:#56bf8b"></div><div class="preview-color" style="background-color:#8bbf56"></div><div class="preview-color" style="background-color:#8b56bf"></div><div class="preview-color" style="background-color:#bf568b"></div><div class="preview-color" style="background-color:#568bbf"></div></div></div><style>.codeexample-base16-harmonic16-light .highlight code, .codeexample-base16-harmonic16-light .highlight pre{color:#405c79;background-color:#f7f9fb}.codeexample-base16-harmonic16-light .highlight .hll{background-color:#627e99}.codeexample-base16-harmonic16-light .highlight .c{color:#cbd6e2}.codeexample-base16-harmonic16-light .highlight .err{color:#56bf8b;background-color:#627e99}.codeexample-base16-harmonic16-light .highlight .g{color:#cbd6e2}.codeexample-base16-harmonic16-light .highlight .k{color:#8b56bf}.codeexample-base16-harmonic16-light .highlight .l{color:#bf568b}.codeexample-base16-harmonic16-light .highlight .n{color:#405c79}.codeexample-base16-harmonic16-light .highlight .o{color:#8bbf56}.codeexample-base16-harmonic16-light .highlight .x{color:#bf568b}.codeexample-base16-harmonic16-light .highlight .p{color:#f7f9fb}.codeexample-base16-harmonic16-light .highlight .cm{color:#cbd6e2}.codeexample-base16-harmonic16-light .highlight .cp{color:#cbd6e2}.codeexample-base16-harmonic16-light .highlight .c1{color:#cbd6e2}.codeexample-base16-harmonic16-light .highlight .cs{color:#56bf8b;font-weight:bold}.codeexample-base16-harmonic16-light .highlight .gd{color:#56bf8b}.codeexample-base16-harmonic16-light .highlight .ge{color:#bf568b;font-style:italic}.codeexample-base16-harmonic16-light .highlight .gr{color:#56bf8b}.codeexample-base16-harmonic16-light .highlight .gh{color:#405c79;font-weight:bold}.codeexample-base16-harmonic16-light .highlight .gi{color:#8bbf56}.codeexample-base16-harmonic16-light .highlight .go{color:#627e99}.codeexample-base16-harmonic16-light .highlight .gp{color:#405c79;font-weight:bold}.codeexample-base16-harmonic16-light .highlight .gs{color:#bf568b;font-weight:bold}.codeexample-base16-harmonic16-light .highlight .gu{color:#bf568b;font-weight:bold}.codeexample-base16-harmonic16-light .highlight .gt{color:#8b56bf}.codeexample-base16-harmonic16-light .highlight .kc{color:#bf8b56}.codeexample-base16-harmonic16-light .highlight .kd{color:#8bbf56}.codeexample-base16-harmonic16-light .highlight .kn{color:#8b56bf;font-weight:bold}.codeexample-base16-harmonic16-light .highlight .kp{color:#56bf8b}.codeexample-base16-harmonic16-light .highlight .kr{color:#56bf8b}.codeexample-base16-harmonic16-light .highlight .kt{color:#cbd6e2}.codeexample-base16-harmonic16-light .highlight .ld{color:#568bbf}.codeexample-base16-harmonic16-light .highlight .m{color:#bf568b}.codeexample-base16-harmonic16-light .highlight .s{color:#568bbf}.codeexample-base16-harmonic16-light .highlight .na{color:#56bf8b}.codeexample-base16-harmonic16-light .highlight .nb{color:#8b56bf}.codeexample-base16-harmonic16-light .highlight .nc{color:#8b56bf}.codeexample-base16-harmonic16-light .highlight .no{color:#bf568b}.codeexample-base16-harmonic16-light .highlight .nd{color:#bf568b}.codeexample-base16-harmonic16-light .highlight .ni{color:#bf8b56}.codeexample-base16-harmonic16-light .highlight .ne{color:#8bbf56;font-weight:bold}.codeexample-base16-harmonic16-light .highlight .nf{color:#8b56bf}.codeexample-base16-harmonic16-light .highlight .nl{color:#bf568b}.codeexample-base16-harmonic16-light .highlight .nn{color:#8b56bf}.codeexample-base16-harmonic16-light .highlight .nx{color:#bf568b}.codeexample-base16-harmonic16-light .highlight .py{color:#bf568b}.codeexample-base16-harmonic16-light .highlight .nt{color:#56bf8b}.codeexample-base16-harmonic16-light .highlight .nv{color:#405c79}.codeexample-base16-harmonic16-light .highlight .ow{color:#8bbf56}.codeexample-base16-harmonic16-light .highlight .w{color:#bf568b}.codeexample-base16-harmonic16-light .highlight .mf{color:#bf568b}.codeexample-base16-harmonic16-light .highlight .mh{color:#bf568b}.codeexample-base16-harmonic16-light .highlight .mi{color:#bf568b}.codeexample-base16-harmonic16-light .highlight .mo{color:#bf568b}.codeexample-base16-harmonic16-light .highlight .sb{color:#568bbf}.codeexample-base16-harmonic16-light .highlight .sc{color:#568bbf}.codeexample-base16-harmonic16-light .highlight .sd{color:#568bbf}.codeexample-base16-harmonic16-light .highlight .s2{color:#568bbf}.codeexample-base16-harmonic16-light .highlight .se{color:#568bbf}.codeexample-base16-harmonic16-light .highlight .sh{color:#568bbf}.codeexample-base16-harmonic16-light .highlight .si{color:#568bbf}.codeexample-base16-harmonic16-light .highlight .sx{color:#568bbf}.codeexample-base16-harmonic16-light .highlight .sr{color:#568bbf}.codeexample-base16-harmonic16-light .highlight .s1{color:#568bbf}.codeexample-base16-harmonic16-light .highlight .ss{color:#568bbf}.codeexample-base16-harmonic16-light .highlight .bp{color:#8b56bf}.codeexample-base16-harmonic16-light .highlight .vc{color:#8b56bf}.codeexample-base16-harmonic16-light .highlight .vg{color:#405c79}.codeexample-base16-harmonic16-light .highlight .vi{color:#8bbf56}.codeexample-base16-harmonic16-light .highlight .il{color:#bf568b}</style><div class="codeexample codeexample-base16-harmonic16-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-isotope-dark">Base16 Isotope Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#d0d0d0"></div><div class="preview-color" style="background-color:#000000"></div><div class="preview-color" style="background-color:#ff0000"></div><div class="preview-color" style="background-color:#33ff00"></div><div class="preview-color" style="background-color:#ff0099"></div><div class="preview-color" style="background-color:#0066ff"></div><div class="preview-color" style="background-color:#cc00ff"></div><div class="preview-color" style="background-color:#00ffff"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#000000"></div><div class="preview-color" style="background-color:#808080"></div><div class="preview-color" style="background-color:#ff0000"></div><div class="preview-color" style="background-color:#33ff00"></div><div class="preview-color" style="background-color:#ff0099"></div><div class="preview-color" style="background-color:#0066ff"></div><div class="preview-color" style="background-color:#cc00ff"></div><div class="preview-color" style="background-color:#00ffff"></div></div></div><style>.codeexample-base16-isotope-dark .highlight code, .codeexample-base16-isotope-dark .highlight pre{color:#d0d0d0;background-color:#000000}.codeexample-base16-isotope-dark .highlight .hll{background-color:#808080}.codeexample-base16-isotope-dark .highlight .c{color:#d0d0d0}.codeexample-base16-isotope-dark .highlight .err{color:#33ff00;background-color:#808080}.codeexample-base16-isotope-dark .highlight .g{color:#d0d0d0}.codeexample-base16-isotope-dark .highlight .k{color:#0066ff}.codeexample-base16-isotope-dark .highlight .l{color:#cc00ff}.codeexample-base16-isotope-dark .highlight .n{color:#d0d0d0}.codeexample-base16-isotope-dark .highlight .o{color:#ff0099}.codeexample-base16-isotope-dark .highlight .x{color:#cc00ff}.codeexample-base16-isotope-dark .highlight .p{color:#ffffff}.codeexample-base16-isotope-dark .highlight .cm{color:#d0d0d0}.codeexample-base16-isotope-dark .highlight .cp{color:#d0d0d0}.codeexample-base16-isotope-dark .highlight .c1{color:#d0d0d0}.codeexample-base16-isotope-dark .highlight .cs{color:#33ff00;font-weight:bold}.codeexample-base16-isotope-dark .highlight .gd{color:#33ff00}.codeexample-base16-isotope-dark .highlight .ge{color:#cc00ff;font-style:italic}.codeexample-base16-isotope-dark .highlight .gr{color:#33ff00}.codeexample-base16-isotope-dark .highlight .gh{color:#d0d0d0;font-weight:bold}.codeexample-base16-isotope-dark .highlight .gi{color:#ff0099}.codeexample-base16-isotope-dark .highlight .go{color:#808080}.codeexample-base16-isotope-dark .highlight .gp{color:#d0d0d0;font-weight:bold}.codeexample-base16-isotope-dark .highlight .gs{color:#cc00ff;font-weight:bold}.codeexample-base16-isotope-dark .highlight .gu{color:#cc00ff;font-weight:bold}.codeexample-base16-isotope-dark .highlight .gt{color:#0066ff}.codeexample-base16-isotope-dark .highlight .kc{color:#ff0000}.codeexample-base16-isotope-dark .highlight .kd{color:#ff0099}.codeexample-base16-isotope-dark .highlight .kn{color:#0066ff;font-weight:bold}.codeexample-base16-isotope-dark .highlight .kp{color:#33ff00}.codeexample-base16-isotope-dark .highlight .kr{color:#33ff00}.codeexample-base16-isotope-dark .highlight .kt{color:#d0d0d0}.codeexample-base16-isotope-dark .highlight .ld{color:#00ffff}.codeexample-base16-isotope-dark .highlight .m{color:#cc00ff}.codeexample-base16-isotope-dark .highlight .s{color:#00ffff}.codeexample-base16-isotope-dark .highlight .na{color:#33ff00}.codeexample-base16-isotope-dark .highlight .nb{color:#0066ff}.codeexample-base16-isotope-dark .highlight .nc{color:#0066ff}.codeexample-base16-isotope-dark .highlight .no{color:#cc00ff}.codeexample-base16-isotope-dark .highlight .nd{color:#cc00ff}.codeexample-base16-isotope-dark .highlight .ni{color:#ff0000}.codeexample-base16-isotope-dark .highlight .ne{color:#ff0099;font-weight:bold}.codeexample-base16-isotope-dark .highlight .nf{color:#0066ff}.codeexample-base16-isotope-dark .highlight .nl{color:#cc00ff}.codeexample-base16-isotope-dark .highlight .nn{color:#0066ff}.codeexample-base16-isotope-dark .highlight .nx{color:#cc00ff}.codeexample-base16-isotope-dark .highlight .py{color:#cc00ff}.codeexample-base16-isotope-dark .highlight .nt{color:#33ff00}.codeexample-base16-isotope-dark .highlight .nv{color:#d0d0d0}.codeexample-base16-isotope-dark .highlight .ow{color:#ff0099}.codeexample-base16-isotope-dark .highlight .w{color:#cc00ff}.codeexample-base16-isotope-dark .highlight .mf{color:#cc00ff}.codeexample-base16-isotope-dark .highlight .mh{color:#cc00ff}.codeexample-base16-isotope-dark .highlight .mi{color:#cc00ff}.codeexample-base16-isotope-dark .highlight .mo{color:#cc00ff}.codeexample-base16-isotope-dark .highlight .sb{color:#00ffff}.codeexample-base16-isotope-dark .highlight .sc{color:#00ffff}.codeexample-base16-isotope-dark .highlight .sd{color:#00ffff}.codeexample-base16-isotope-dark .highlight .s2{color:#00ffff}.codeexample-base16-isotope-dark .highlight .se{color:#00ffff}.codeexample-base16-isotope-dark .highlight .sh{color:#00ffff}.codeexample-base16-isotope-dark .highlight .si{color:#00ffff}.codeexample-base16-isotope-dark .highlight .sx{color:#00ffff}.codeexample-base16-isotope-dark .highlight .sr{color:#00ffff}.codeexample-base16-isotope-dark .highlight .s1{color:#00ffff}.codeexample-base16-isotope-dark .highlight .ss{color:#00ffff}.codeexample-base16-isotope-dark .highlight .bp{color:#0066ff}.codeexample-base16-isotope-dark .highlight .vc{color:#0066ff}.codeexample-base16-isotope-dark .highlight .vg{color:#d0d0d0}.codeexample-base16-isotope-dark .highlight .vi{color:#ff0099}.codeexample-base16-isotope-dark .highlight .il{color:#cc00ff}</style><div class="codeexample codeexample-base16-isotope-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-isotope-light">Base16 Isotope Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#606060"></div><div class="preview-color" style="background-color:#000000"></div><div class="preview-color" style="background-color:#ff0000"></div><div class="preview-color" style="background-color:#33ff00"></div><div class="preview-color" style="background-color:#ff0099"></div><div class="preview-color" style="background-color:#0066ff"></div><div class="preview-color" style="background-color:#cc00ff"></div><div class="preview-color" style="background-color:#00ffff"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#ffffff"></div><div class="preview-color" style="background-color:#808080"></div><div class="preview-color" style="background-color:#ff0000"></div><div class="preview-color" style="background-color:#33ff00"></div><div class="preview-color" style="background-color:#ff0099"></div><div class="preview-color" style="background-color:#0066ff"></div><div class="preview-color" style="background-color:#cc00ff"></div><div class="preview-color" style="background-color:#00ffff"></div></div></div><style>.codeexample-base16-isotope-light .highlight code, .codeexample-base16-isotope-light .highlight pre{color:#606060;background-color:#ffffff}.codeexample-base16-isotope-light .highlight .hll{background-color:#808080}.codeexample-base16-isotope-light .highlight .c{color:#d0d0d0}.codeexample-base16-isotope-light .highlight .err{color:#33ff00;background-color:#808080}.codeexample-base16-isotope-light .highlight .g{color:#d0d0d0}.codeexample-base16-isotope-light .highlight .k{color:#0066ff}.codeexample-base16-isotope-light .highlight .l{color:#cc00ff}.codeexample-base16-isotope-light .highlight .n{color:#606060}.codeexample-base16-isotope-light .highlight .o{color:#ff0099}.codeexample-base16-isotope-light .highlight .x{color:#cc00ff}.codeexample-base16-isotope-light .highlight .p{color:#ffffff}.codeexample-base16-isotope-light .highlight .cm{color:#d0d0d0}.codeexample-base16-isotope-light .highlight .cp{color:#d0d0d0}.codeexample-base16-isotope-light .highlight .c1{color:#d0d0d0}.codeexample-base16-isotope-light .highlight .cs{color:#33ff00;font-weight:bold}.codeexample-base16-isotope-light .highlight .gd{color:#33ff00}.codeexample-base16-isotope-light .highlight .ge{color:#cc00ff;font-style:italic}.codeexample-base16-isotope-light .highlight .gr{color:#33ff00}.codeexample-base16-isotope-light .highlight .gh{color:#606060;font-weight:bold}.codeexample-base16-isotope-light .highlight .gi{color:#ff0099}.codeexample-base16-isotope-light .highlight .go{color:#808080}.codeexample-base16-isotope-light .highlight .gp{color:#606060;font-weight:bold}.codeexample-base16-isotope-light .highlight .gs{color:#cc00ff;font-weight:bold}.codeexample-base16-isotope-light .highlight .gu{color:#cc00ff;font-weight:bold}.codeexample-base16-isotope-light .highlight .gt{color:#0066ff}.codeexample-base16-isotope-light .highlight .kc{color:#ff0000}.codeexample-base16-isotope-light .highlight .kd{color:#ff0099}.codeexample-base16-isotope-light .highlight .kn{color:#0066ff;font-weight:bold}.codeexample-base16-isotope-light .highlight .kp{color:#33ff00}.codeexample-base16-isotope-light .highlight .kr{color:#33ff00}.codeexample-base16-isotope-light .highlight .kt{color:#d0d0d0}.codeexample-base16-isotope-light .highlight .ld{color:#00ffff}.codeexample-base16-isotope-light .highlight .m{color:#cc00ff}.codeexample-base16-isotope-light .highlight .s{color:#00ffff}.codeexample-base16-isotope-light .highlight .na{color:#33ff00}.codeexample-base16-isotope-light .highlight .nb{color:#0066ff}.codeexample-base16-isotope-light .highlight .nc{color:#0066ff}.codeexample-base16-isotope-light .highlight .no{color:#cc00ff}.codeexample-base16-isotope-light .highlight .nd{color:#cc00ff}.codeexample-base16-isotope-light .highlight .ni{color:#ff0000}.codeexample-base16-isotope-light .highlight .ne{color:#ff0099;font-weight:bold}.codeexample-base16-isotope-light .highlight .nf{color:#0066ff}.codeexample-base16-isotope-light .highlight .nl{color:#cc00ff}.codeexample-base16-isotope-light .highlight .nn{color:#0066ff}.codeexample-base16-isotope-light .highlight .nx{color:#cc00ff}.codeexample-base16-isotope-light .highlight .py{color:#cc00ff}.codeexample-base16-isotope-light .highlight .nt{color:#33ff00}.codeexample-base16-isotope-light .highlight .nv{color:#606060}.codeexample-base16-isotope-light .highlight .ow{color:#ff0099}.codeexample-base16-isotope-light .highlight .w{color:#cc00ff}.codeexample-base16-isotope-light .highlight .mf{color:#cc00ff}.codeexample-base16-isotope-light .highlight .mh{color:#cc00ff}.codeexample-base16-isotope-light .highlight .mi{color:#cc00ff}.codeexample-base16-isotope-light .highlight .mo{color:#cc00ff}.codeexample-base16-isotope-light .highlight .sb{color:#00ffff}.codeexample-base16-isotope-light .highlight .sc{color:#00ffff}.codeexample-base16-isotope-light .highlight .sd{color:#00ffff}.codeexample-base16-isotope-light .highlight .s2{color:#00ffff}.codeexample-base16-isotope-light .highlight .se{color:#00ffff}.codeexample-base16-isotope-light .highlight .sh{color:#00ffff}.codeexample-base16-isotope-light .highlight .si{color:#00ffff}.codeexample-base16-isotope-light .highlight .sx{color:#00ffff}.codeexample-base16-isotope-light .highlight .sr{color:#00ffff}.codeexample-base16-isotope-light .highlight .s1{color:#00ffff}.codeexample-base16-isotope-light .highlight .ss{color:#00ffff}.codeexample-base16-isotope-light .highlight .bp{color:#0066ff}.codeexample-base16-isotope-light .highlight .vc{color:#0066ff}.codeexample-base16-isotope-light .highlight .vg{color:#606060}.codeexample-base16-isotope-light .highlight .vi{color:#ff0099}.codeexample-base16-isotope-light .highlight .il{color:#cc00ff}</style><div class="codeexample codeexample-base16-isotope-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-londontube-dark">Base16 Londontube Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#d9d8d8"></div><div class="preview-color" style="background-color:#231f20"></div><div class="preview-color" style="background-color:#ee2e24"></div><div class="preview-color" style="background-color:#00853e"></div><div class="preview-color" style="background-color:#ffd204"></div><div class="preview-color" style="background-color:#009ddc"></div><div class="preview-color" style="background-color:#98005d"></div><div class="preview-color" style="background-color:#85cebc"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#231f20"></div><div class="preview-color" style="background-color:#737171"></div><div class="preview-color" style="background-color:#ee2e24"></div><div class="preview-color" style="background-color:#00853e"></div><div class="preview-color" style="background-color:#ffd204"></div><div class="preview-color" style="background-color:#009ddc"></div><div class="preview-color" style="background-color:#98005d"></div><div class="preview-color" style="background-color:#85cebc"></div></div></div><style>.codeexample-base16-londontube-dark .highlight code, .codeexample-base16-londontube-dark .highlight pre{color:#d9d8d8;background-color:#231f20}.codeexample-base16-londontube-dark .highlight .hll{background-color:#737171}.codeexample-base16-londontube-dark .highlight .c{color:#d9d8d8}.codeexample-base16-londontube-dark .highlight .err{color:#00853e;background-color:#737171}.codeexample-base16-londontube-dark .highlight .g{color:#d9d8d8}.codeexample-base16-londontube-dark .highlight .k{color:#009ddc}.codeexample-base16-londontube-dark .highlight .l{color:#98005d}.codeexample-base16-londontube-dark .highlight .n{color:#d9d8d8}.codeexample-base16-londontube-dark .highlight .o{color:#ffd204}.codeexample-base16-londontube-dark .highlight .x{color:#98005d}.codeexample-base16-londontube-dark .highlight .p{color:#ffffff}.codeexample-base16-londontube-dark .highlight .cm{color:#d9d8d8}.codeexample-base16-londontube-dark .highlight .cp{color:#d9d8d8}.codeexample-base16-londontube-dark .highlight .c1{color:#d9d8d8}.codeexample-base16-londontube-dark .highlight .cs{color:#00853e;font-weight:bold}.codeexample-base16-londontube-dark .highlight .gd{color:#00853e}.codeexample-base16-londontube-dark .highlight .ge{color:#98005d;font-style:italic}.codeexample-base16-londontube-dark .highlight .gr{color:#00853e}.codeexample-base16-londontube-dark .highlight .gh{color:#d9d8d8;font-weight:bold}.codeexample-base16-londontube-dark .highlight .gi{color:#ffd204}.codeexample-base16-londontube-dark .highlight .go{color:#737171}.codeexample-base16-londontube-dark .highlight .gp{color:#d9d8d8;font-weight:bold}.codeexample-base16-londontube-dark .highlight .gs{color:#98005d;font-weight:bold}.codeexample-base16-londontube-dark .highlight .gu{color:#98005d;font-weight:bold}.codeexample-base16-londontube-dark .highlight .gt{color:#009ddc}.codeexample-base16-londontube-dark .highlight .kc{color:#ee2e24}.codeexample-base16-londontube-dark .highlight .kd{color:#ffd204}.codeexample-base16-londontube-dark .highlight .kn{color:#009ddc;font-weight:bold}.codeexample-base16-londontube-dark .highlight .kp{color:#00853e}.codeexample-base16-londontube-dark .highlight .kr{color:#00853e}.codeexample-base16-londontube-dark .highlight .kt{color:#d9d8d8}.codeexample-base16-londontube-dark .highlight .ld{color:#85cebc}.codeexample-base16-londontube-dark .highlight .m{color:#98005d}.codeexample-base16-londontube-dark .highlight .s{color:#85cebc}.codeexample-base16-londontube-dark .highlight .na{color:#00853e}.codeexample-base16-londontube-dark .highlight .nb{color:#009ddc}.codeexample-base16-londontube-dark .highlight .nc{color:#009ddc}.codeexample-base16-londontube-dark .highlight .no{color:#98005d}.codeexample-base16-londontube-dark .highlight .nd{color:#98005d}.codeexample-base16-londontube-dark .highlight .ni{color:#ee2e24}.codeexample-base16-londontube-dark .highlight .ne{color:#ffd204;font-weight:bold}.codeexample-base16-londontube-dark .highlight .nf{color:#009ddc}.codeexample-base16-londontube-dark .highlight .nl{color:#98005d}.codeexample-base16-londontube-dark .highlight .nn{color:#009ddc}.codeexample-base16-londontube-dark .highlight .nx{color:#98005d}.codeexample-base16-londontube-dark .highlight .py{color:#98005d}.codeexample-base16-londontube-dark .highlight .nt{color:#00853e}.codeexample-base16-londontube-dark .highlight .nv{color:#d9d8d8}.codeexample-base16-londontube-dark .highlight .ow{color:#ffd204}.codeexample-base16-londontube-dark .highlight .w{color:#98005d}.codeexample-base16-londontube-dark .highlight .mf{color:#98005d}.codeexample-base16-londontube-dark .highlight .mh{color:#98005d}.codeexample-base16-londontube-dark .highlight .mi{color:#98005d}.codeexample-base16-londontube-dark .highlight .mo{color:#98005d}.codeexample-base16-londontube-dark .highlight .sb{color:#85cebc}.codeexample-base16-londontube-dark .highlight .sc{color:#85cebc}.codeexample-base16-londontube-dark .highlight .sd{color:#85cebc}.codeexample-base16-londontube-dark .highlight .s2{color:#85cebc}.codeexample-base16-londontube-dark .highlight .se{color:#85cebc}.codeexample-base16-londontube-dark .highlight .sh{color:#85cebc}.codeexample-base16-londontube-dark .highlight .si{color:#85cebc}.codeexample-base16-londontube-dark .highlight .sx{color:#85cebc}.codeexample-base16-londontube-dark .highlight .sr{color:#85cebc}.codeexample-base16-londontube-dark .highlight .s1{color:#85cebc}.codeexample-base16-londontube-dark .highlight .ss{color:#85cebc}.codeexample-base16-londontube-dark .highlight .bp{color:#009ddc}.codeexample-base16-londontube-dark .highlight .vc{color:#009ddc}.codeexample-base16-londontube-dark .highlight .vg{color:#d9d8d8}.codeexample-base16-londontube-dark .highlight .vi{color:#ffd204}.codeexample-base16-londontube-dark .highlight .il{color:#98005d}</style><div class="codeexample codeexample-base16-londontube-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-londontube-light">Base16 Londontube Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#5a5758"></div><div class="preview-color" style="background-color:#231f20"></div><div class="preview-color" style="background-color:#ee2e24"></div><div class="preview-color" style="background-color:#00853e"></div><div class="preview-color" style="background-color:#ffd204"></div><div class="preview-color" style="background-color:#009ddc"></div><div class="preview-color" style="background-color:#98005d"></div><div class="preview-color" style="background-color:#85cebc"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#ffffff"></div><div class="preview-color" style="background-color:#737171"></div><div class="preview-color" style="background-color:#ee2e24"></div><div class="preview-color" style="background-color:#00853e"></div><div class="preview-color" style="background-color:#ffd204"></div><div class="preview-color" style="background-color:#009ddc"></div><div class="preview-color" style="background-color:#98005d"></div><div class="preview-color" style="background-color:#85cebc"></div></div></div><style>.codeexample-base16-londontube-light .highlight code, .codeexample-base16-londontube-light .highlight pre{color:#5a5758;background-color:#ffffff}.codeexample-base16-londontube-light .highlight .hll{background-color:#737171}.codeexample-base16-londontube-light .highlight .c{color:#d9d8d8}.codeexample-base16-londontube-light .highlight .err{color:#00853e;background-color:#737171}.codeexample-base16-londontube-light .highlight .g{color:#d9d8d8}.codeexample-base16-londontube-light .highlight .k{color:#009ddc}.codeexample-base16-londontube-light .highlight .l{color:#98005d}.codeexample-base16-londontube-light .highlight .n{color:#5a5758}.codeexample-base16-londontube-light .highlight .o{color:#ffd204}.codeexample-base16-londontube-light .highlight .x{color:#98005d}.codeexample-base16-londontube-light .highlight .p{color:#ffffff}.codeexample-base16-londontube-light .highlight .cm{color:#d9d8d8}.codeexample-base16-londontube-light .highlight .cp{color:#d9d8d8}.codeexample-base16-londontube-light .highlight .c1{color:#d9d8d8}.codeexample-base16-londontube-light .highlight .cs{color:#00853e;font-weight:bold}.codeexample-base16-londontube-light .highlight .gd{color:#00853e}.codeexample-base16-londontube-light .highlight .ge{color:#98005d;font-style:italic}.codeexample-base16-londontube-light .highlight .gr{color:#00853e}.codeexample-base16-londontube-light .highlight .gh{color:#5a5758;font-weight:bold}.codeexample-base16-londontube-light .highlight .gi{color:#ffd204}.codeexample-base16-londontube-light .highlight .go{color:#737171}.codeexample-base16-londontube-light .highlight .gp{color:#5a5758;font-weight:bold}.codeexample-base16-londontube-light .highlight .gs{color:#98005d;font-weight:bold}.codeexample-base16-londontube-light .highlight .gu{color:#98005d;font-weight:bold}.codeexample-base16-londontube-light .highlight .gt{color:#009ddc}.codeexample-base16-londontube-light .highlight .kc{color:#ee2e24}.codeexample-base16-londontube-light .highlight .kd{color:#ffd204}.codeexample-base16-londontube-light .highlight .kn{color:#009ddc;font-weight:bold}.codeexample-base16-londontube-light .highlight .kp{color:#00853e}.codeexample-base16-londontube-light .highlight .kr{color:#00853e}.codeexample-base16-londontube-light .highlight .kt{color:#d9d8d8}.codeexample-base16-londontube-light .highlight .ld{color:#85cebc}.codeexample-base16-londontube-light .highlight .m{color:#98005d}.codeexample-base16-londontube-light .highlight .s{color:#85cebc}.codeexample-base16-londontube-light .highlight .na{color:#00853e}.codeexample-base16-londontube-light .highlight .nb{color:#009ddc}.codeexample-base16-londontube-light .highlight .nc{color:#009ddc}.codeexample-base16-londontube-light .highlight .no{color:#98005d}.codeexample-base16-londontube-light .highlight .nd{color:#98005d}.codeexample-base16-londontube-light .highlight .ni{color:#ee2e24}.codeexample-base16-londontube-light .highlight .ne{color:#ffd204;font-weight:bold}.codeexample-base16-londontube-light .highlight .nf{color:#009ddc}.codeexample-base16-londontube-light .highlight .nl{color:#98005d}.codeexample-base16-londontube-light .highlight .nn{color:#009ddc}.codeexample-base16-londontube-light .highlight .nx{color:#98005d}.codeexample-base16-londontube-light .highlight .py{color:#98005d}.codeexample-base16-londontube-light .highlight .nt{color:#00853e}.codeexample-base16-londontube-light .highlight .nv{color:#5a5758}.codeexample-base16-londontube-light .highlight .ow{color:#ffd204}.codeexample-base16-londontube-light .highlight .w{color:#98005d}.codeexample-base16-londontube-light .highlight .mf{color:#98005d}.codeexample-base16-londontube-light .highlight .mh{color:#98005d}.codeexample-base16-londontube-light .highlight .mi{color:#98005d}.codeexample-base16-londontube-light .highlight .mo{color:#98005d}.codeexample-base16-londontube-light .highlight .sb{color:#85cebc}.codeexample-base16-londontube-light .highlight .sc{color:#85cebc}.codeexample-base16-londontube-light .highlight .sd{color:#85cebc}.codeexample-base16-londontube-light .highlight .s2{color:#85cebc}.codeexample-base16-londontube-light .highlight .se{color:#85cebc}.codeexample-base16-londontube-light .highlight .sh{color:#85cebc}.codeexample-base16-londontube-light .highlight .si{color:#85cebc}.codeexample-base16-londontube-light .highlight .sx{color:#85cebc}.codeexample-base16-londontube-light .highlight .sr{color:#85cebc}.codeexample-base16-londontube-light .highlight .s1{color:#85cebc}.codeexample-base16-londontube-light .highlight .ss{color:#85cebc}.codeexample-base16-londontube-light .highlight .bp{color:#009ddc}.codeexample-base16-londontube-light .highlight .vc{color:#009ddc}.codeexample-base16-londontube-light .highlight .vg{color:#5a5758}.codeexample-base16-londontube-light .highlight .vi{color:#ffd204}.codeexample-base16-londontube-light .highlight .il{color:#98005d}</style><div class="codeexample codeexample-base16-londontube-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-marrakesh-dark">Base16 Marrakesh Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#948e48"></div><div class="preview-color" style="background-color:#201602"></div><div class="preview-color" style="background-color:#c35359"></div><div class="preview-color" style="background-color:#18974e"></div><div class="preview-color" style="background-color:#a88339"></div><div class="preview-color" style="background-color:#477ca1"></div><div class="preview-color" style="background-color:#8868b3"></div><div class="preview-color" style="background-color:#75a738"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#201602"></div><div class="preview-color" style="background-color:#6c6823"></div><div class="preview-color" style="background-color:#c35359"></div><div class="preview-color" style="background-color:#18974e"></div><div class="preview-color" style="background-color:#a88339"></div><div class="preview-color" style="background-color:#477ca1"></div><div class="preview-color" style="background-color:#8868b3"></div><div class="preview-color" style="background-color:#75a738"></div></div></div><style>.codeexample-base16-marrakesh-dark .highlight code, .codeexample-base16-marrakesh-dark .highlight pre{color:#948e48;background-color:#201602}.codeexample-base16-marrakesh-dark .highlight .hll{background-color:#6c6823}.codeexample-base16-marrakesh-dark .highlight .c{color:#948e48}.codeexample-base16-marrakesh-dark .highlight .err{color:#18974e;background-color:#6c6823}.codeexample-base16-marrakesh-dark .highlight .g{color:#948e48}.codeexample-base16-marrakesh-dark .highlight .k{color:#477ca1}.codeexample-base16-marrakesh-dark .highlight .l{color:#8868b3}.codeexample-base16-marrakesh-dark .highlight .n{color:#948e48}.codeexample-base16-marrakesh-dark .highlight .o{color:#a88339}.codeexample-base16-marrakesh-dark .highlight .x{color:#8868b3}.codeexample-base16-marrakesh-dark .highlight .p{color:#faf0a5}.codeexample-base16-marrakesh-dark .highlight .cm{color:#948e48}.codeexample-base16-marrakesh-dark .highlight .cp{color:#948e48}.codeexample-base16-marrakesh-dark .highlight .c1{color:#948e48}.codeexample-base16-marrakesh-dark .highlight .cs{color:#18974e;font-weight:bold}.codeexample-base16-marrakesh-dark .highlight .gd{color:#18974e}.codeexample-base16-marrakesh-dark .highlight .ge{color:#8868b3;font-style:italic}.codeexample-base16-marrakesh-dark .highlight .gr{color:#18974e}.codeexample-base16-marrakesh-dark .highlight .gh{color:#948e48;font-weight:bold}.codeexample-base16-marrakesh-dark .highlight .gi{color:#a88339}.codeexample-base16-marrakesh-dark .highlight .go{color:#6c6823}.codeexample-base16-marrakesh-dark .highlight .gp{color:#948e48;font-weight:bold}.codeexample-base16-marrakesh-dark .highlight .gs{color:#8868b3;font-weight:bold}.codeexample-base16-marrakesh-dark .highlight .gu{color:#8868b3;font-weight:bold}.codeexample-base16-marrakesh-dark .highlight .gt{color:#477ca1}.codeexample-base16-marrakesh-dark .highlight .kc{color:#c35359}.codeexample-base16-marrakesh-dark .highlight .kd{color:#a88339}.codeexample-base16-marrakesh-dark .highlight .kn{color:#477ca1;font-weight:bold}.codeexample-base16-marrakesh-dark .highlight .kp{color:#18974e}.codeexample-base16-marrakesh-dark .highlight .kr{color:#18974e}.codeexample-base16-marrakesh-dark .highlight .kt{color:#948e48}.codeexample-base16-marrakesh-dark .highlight .ld{color:#75a738}.codeexample-base16-marrakesh-dark .highlight .m{color:#8868b3}.codeexample-base16-marrakesh-dark .highlight .s{color:#75a738}.codeexample-base16-marrakesh-dark .highlight .na{color:#18974e}.codeexample-base16-marrakesh-dark .highlight .nb{color:#477ca1}.codeexample-base16-marrakesh-dark .highlight .nc{color:#477ca1}.codeexample-base16-marrakesh-dark .highlight .no{color:#8868b3}.codeexample-base16-marrakesh-dark .highlight .nd{color:#8868b3}.codeexample-base16-marrakesh-dark .highlight .ni{color:#c35359}.codeexample-base16-marrakesh-dark .highlight .ne{color:#a88339;font-weight:bold}.codeexample-base16-marrakesh-dark .highlight .nf{color:#477ca1}.codeexample-base16-marrakesh-dark .highlight .nl{color:#8868b3}.codeexample-base16-marrakesh-dark .highlight .nn{color:#477ca1}.codeexample-base16-marrakesh-dark .highlight .nx{color:#8868b3}.codeexample-base16-marrakesh-dark .highlight .py{color:#8868b3}.codeexample-base16-marrakesh-dark .highlight .nt{color:#18974e}.codeexample-base16-marrakesh-dark .highlight .nv{color:#948e48}.codeexample-base16-marrakesh-dark .highlight .ow{color:#a88339}.codeexample-base16-marrakesh-dark .highlight .w{color:#8868b3}.codeexample-base16-marrakesh-dark .highlight .mf{color:#8868b3}.codeexample-base16-marrakesh-dark .highlight .mh{color:#8868b3}.codeexample-base16-marrakesh-dark .highlight .mi{color:#8868b3}.codeexample-base16-marrakesh-dark .highlight .mo{color:#8868b3}.codeexample-base16-marrakesh-dark .highlight .sb{color:#75a738}.codeexample-base16-marrakesh-dark .highlight .sc{color:#75a738}.codeexample-base16-marrakesh-dark .highlight .sd{color:#75a738}.codeexample-base16-marrakesh-dark .highlight .s2{color:#75a738}.codeexample-base16-marrakesh-dark .highlight .se{color:#75a738}.codeexample-base16-marrakesh-dark .highlight .sh{color:#75a738}.codeexample-base16-marrakesh-dark .highlight .si{color:#75a738}.codeexample-base16-marrakesh-dark .highlight .sx{color:#75a738}.codeexample-base16-marrakesh-dark .highlight .sr{color:#75a738}.codeexample-base16-marrakesh-dark .highlight .s1{color:#75a738}.codeexample-base16-marrakesh-dark .highlight .ss{color:#75a738}.codeexample-base16-marrakesh-dark .highlight .bp{color:#477ca1}.codeexample-base16-marrakesh-dark .highlight .vc{color:#477ca1}.codeexample-base16-marrakesh-dark .highlight .vg{color:#948e48}.codeexample-base16-marrakesh-dark .highlight .vi{color:#a88339}.codeexample-base16-marrakesh-dark .highlight .il{color:#8868b3}</style><div class="codeexample codeexample-base16-marrakesh-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-marrakesh-light">Base16 Marrakesh Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#5f5b17"></div><div class="preview-color" style="background-color:#201602"></div><div class="preview-color" style="background-color:#c35359"></div><div class="preview-color" style="background-color:#18974e"></div><div class="preview-color" style="background-color:#a88339"></div><div class="preview-color" style="background-color:#477ca1"></div><div class="preview-color" style="background-color:#8868b3"></div><div class="preview-color" style="background-color:#75a738"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#faf0a5"></div><div class="preview-color" style="background-color:#6c6823"></div><div class="preview-color" style="background-color:#c35359"></div><div class="preview-color" style="background-color:#18974e"></div><div class="preview-color" style="background-color:#a88339"></div><div class="preview-color" style="background-color:#477ca1"></div><div class="preview-color" style="background-color:#8868b3"></div><div class="preview-color" style="background-color:#75a738"></div></div></div><style>.codeexample-base16-marrakesh-light .highlight code, .codeexample-base16-marrakesh-light .highlight pre{color:#5f5b17;background-color:#faf0a5}.codeexample-base16-marrakesh-light .highlight .hll{background-color:#6c6823}.codeexample-base16-marrakesh-light .highlight .c{color:#948e48}.codeexample-base16-marrakesh-light .highlight .err{color:#18974e;background-color:#6c6823}.codeexample-base16-marrakesh-light .highlight .g{color:#948e48}.codeexample-base16-marrakesh-light .highlight .k{color:#477ca1}.codeexample-base16-marrakesh-light .highlight .l{color:#8868b3}.codeexample-base16-marrakesh-light .highlight .n{color:#5f5b17}.codeexample-base16-marrakesh-light .highlight .o{color:#a88339}.codeexample-base16-marrakesh-light .highlight .x{color:#8868b3}.codeexample-base16-marrakesh-light .highlight .p{color:#faf0a5}.codeexample-base16-marrakesh-light .highlight .cm{color:#948e48}.codeexample-base16-marrakesh-light .highlight .cp{color:#948e48}.codeexample-base16-marrakesh-light .highlight .c1{color:#948e48}.codeexample-base16-marrakesh-light .highlight .cs{color:#18974e;font-weight:bold}.codeexample-base16-marrakesh-light .highlight .gd{color:#18974e}.codeexample-base16-marrakesh-light .highlight .ge{color:#8868b3;font-style:italic}.codeexample-base16-marrakesh-light .highlight .gr{color:#18974e}.codeexample-base16-marrakesh-light .highlight .gh{color:#5f5b17;font-weight:bold}.codeexample-base16-marrakesh-light .highlight .gi{color:#a88339}.codeexample-base16-marrakesh-light .highlight .go{color:#6c6823}.codeexample-base16-marrakesh-light .highlight .gp{color:#5f5b17;font-weight:bold}.codeexample-base16-marrakesh-light .highlight .gs{color:#8868b3;font-weight:bold}.codeexample-base16-marrakesh-light .highlight .gu{color:#8868b3;font-weight:bold}.codeexample-base16-marrakesh-light .highlight .gt{color:#477ca1}.codeexample-base16-marrakesh-light .highlight .kc{color:#c35359}.codeexample-base16-marrakesh-light .highlight .kd{color:#a88339}.codeexample-base16-marrakesh-light .highlight .kn{color:#477ca1;font-weight:bold}.codeexample-base16-marrakesh-light .highlight .kp{color:#18974e}.codeexample-base16-marrakesh-light .highlight .kr{color:#18974e}.codeexample-base16-marrakesh-light .highlight .kt{color:#948e48}.codeexample-base16-marrakesh-light .highlight .ld{color:#75a738}.codeexample-base16-marrakesh-light .highlight .m{color:#8868b3}.codeexample-base16-marrakesh-light .highlight .s{color:#75a738}.codeexample-base16-marrakesh-light .highlight .na{color:#18974e}.codeexample-base16-marrakesh-light .highlight .nb{color:#477ca1}.codeexample-base16-marrakesh-light .highlight .nc{color:#477ca1}.codeexample-base16-marrakesh-light .highlight .no{color:#8868b3}.codeexample-base16-marrakesh-light .highlight .nd{color:#8868b3}.codeexample-base16-marrakesh-light .highlight .ni{color:#c35359}.codeexample-base16-marrakesh-light .highlight .ne{color:#a88339;font-weight:bold}.codeexample-base16-marrakesh-light .highlight .nf{color:#477ca1}.codeexample-base16-marrakesh-light .highlight .nl{color:#8868b3}.codeexample-base16-marrakesh-light .highlight .nn{color:#477ca1}.codeexample-base16-marrakesh-light .highlight .nx{color:#8868b3}.codeexample-base16-marrakesh-light .highlight .py{color:#8868b3}.codeexample-base16-marrakesh-light .highlight .nt{color:#18974e}.codeexample-base16-marrakesh-light .highlight .nv{color:#5f5b17}.codeexample-base16-marrakesh-light .highlight .ow{color:#a88339}.codeexample-base16-marrakesh-light .highlight .w{color:#8868b3}.codeexample-base16-marrakesh-light .highlight .mf{color:#8868b3}.codeexample-base16-marrakesh-light .highlight .mh{color:#8868b3}.codeexample-base16-marrakesh-light .highlight .mi{color:#8868b3}.codeexample-base16-marrakesh-light .highlight .mo{color:#8868b3}.codeexample-base16-marrakesh-light .highlight .sb{color:#75a738}.codeexample-base16-marrakesh-light .highlight .sc{color:#75a738}.codeexample-base16-marrakesh-light .highlight .sd{color:#75a738}.codeexample-base16-marrakesh-light .highlight .s2{color:#75a738}.codeexample-base16-marrakesh-light .highlight .se{color:#75a738}.codeexample-base16-marrakesh-light .highlight .sh{color:#75a738}.codeexample-base16-marrakesh-light .highlight .si{color:#75a738}.codeexample-base16-marrakesh-light .highlight .sx{color:#75a738}.codeexample-base16-marrakesh-light .highlight .sr{color:#75a738}.codeexample-base16-marrakesh-light .highlight .s1{color:#75a738}.codeexample-base16-marrakesh-light .highlight .ss{color:#75a738}.codeexample-base16-marrakesh-light .highlight .bp{color:#477ca1}.codeexample-base16-marrakesh-light .highlight .vc{color:#477ca1}.codeexample-base16-marrakesh-light .highlight .vg{color:#5f5b17}.codeexample-base16-marrakesh-light .highlight .vi{color:#a88339}.codeexample-base16-marrakesh-light .highlight .il{color:#8868b3}</style><div class="codeexample codeexample-base16-marrakesh-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-mocha-dark">Base16 Mocha Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#d0c8c6"></div><div class="preview-color" style="background-color:#3B3228"></div><div class="preview-color" style="background-color:#cb6077"></div><div class="preview-color" style="background-color:#beb55b"></div><div class="preview-color" style="background-color:#f4bc87"></div><div class="preview-color" style="background-color:#8ab3b5"></div><div class="preview-color" style="background-color:#a89bb9"></div><div class="preview-color" style="background-color:#7bbda4"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#3B3228"></div><div class="preview-color" style="background-color:#7e705a"></div><div class="preview-color" style="background-color:#cb6077"></div><div class="preview-color" style="background-color:#beb55b"></div><div class="preview-color" style="background-color:#f4bc87"></div><div class="preview-color" style="background-color:#8ab3b5"></div><div class="preview-color" style="background-color:#a89bb9"></div><div class="preview-color" style="background-color:#7bbda4"></div></div></div><style>.codeexample-base16-mocha-dark .highlight code, .codeexample-base16-mocha-dark .highlight pre{color:#d0c8c6;background-color:#3B3228}.codeexample-base16-mocha-dark .highlight .hll{background-color:#7e705a}.codeexample-base16-mocha-dark .highlight .c{color:#d0c8c6}.codeexample-base16-mocha-dark .highlight .err{color:#beb55b;background-color:#7e705a}.codeexample-base16-mocha-dark .highlight .g{color:#d0c8c6}.codeexample-base16-mocha-dark .highlight .k{color:#8ab3b5}.codeexample-base16-mocha-dark .highlight .l{color:#a89bb9}.codeexample-base16-mocha-dark .highlight .n{color:#d0c8c6}.codeexample-base16-mocha-dark .highlight .o{color:#f4bc87}.codeexample-base16-mocha-dark .highlight .x{color:#a89bb9}.codeexample-base16-mocha-dark .highlight .p{color:#f5eeeb}.codeexample-base16-mocha-dark .highlight .cm{color:#d0c8c6}.codeexample-base16-mocha-dark .highlight .cp{color:#d0c8c6}.codeexample-base16-mocha-dark .highlight .c1{color:#d0c8c6}.codeexample-base16-mocha-dark .highlight .cs{color:#beb55b;font-weight:bold}.codeexample-base16-mocha-dark .highlight .gd{color:#beb55b}.codeexample-base16-mocha-dark .highlight .ge{color:#a89bb9;font-style:italic}.codeexample-base16-mocha-dark .highlight .gr{color:#beb55b}.codeexample-base16-mocha-dark .highlight .gh{color:#d0c8c6;font-weight:bold}.codeexample-base16-mocha-dark .highlight .gi{color:#f4bc87}.codeexample-base16-mocha-dark .highlight .go{color:#7e705a}.codeexample-base16-mocha-dark .highlight .gp{color:#d0c8c6;font-weight:bold}.codeexample-base16-mocha-dark .highlight .gs{color:#a89bb9;font-weight:bold}.codeexample-base16-mocha-dark .highlight .gu{color:#a89bb9;font-weight:bold}.codeexample-base16-mocha-dark .highlight .gt{color:#8ab3b5}.codeexample-base16-mocha-dark .highlight .kc{color:#cb6077}.codeexample-base16-mocha-dark .highlight .kd{color:#f4bc87}.codeexample-base16-mocha-dark .highlight .kn{color:#8ab3b5;font-weight:bold}.codeexample-base16-mocha-dark .highlight .kp{color:#beb55b}.codeexample-base16-mocha-dark .highlight .kr{color:#beb55b}.codeexample-base16-mocha-dark .highlight .kt{color:#d0c8c6}.codeexample-base16-mocha-dark .highlight .ld{color:#7bbda4}.codeexample-base16-mocha-dark .highlight .m{color:#a89bb9}.codeexample-base16-mocha-dark .highlight .s{color:#7bbda4}.codeexample-base16-mocha-dark .highlight .na{color:#beb55b}.codeexample-base16-mocha-dark .highlight .nb{color:#8ab3b5}.codeexample-base16-mocha-dark .highlight .nc{color:#8ab3b5}.codeexample-base16-mocha-dark .highlight .no{color:#a89bb9}.codeexample-base16-mocha-dark .highlight .nd{color:#a89bb9}.codeexample-base16-mocha-dark .highlight .ni{color:#cb6077}.codeexample-base16-mocha-dark .highlight .ne{color:#f4bc87;font-weight:bold}.codeexample-base16-mocha-dark .highlight .nf{color:#8ab3b5}.codeexample-base16-mocha-dark .highlight .nl{color:#a89bb9}.codeexample-base16-mocha-dark .highlight .nn{color:#8ab3b5}.codeexample-base16-mocha-dark .highlight .nx{color:#a89bb9}.codeexample-base16-mocha-dark .highlight .py{color:#a89bb9}.codeexample-base16-mocha-dark .highlight .nt{color:#beb55b}.codeexample-base16-mocha-dark .highlight .nv{color:#d0c8c6}.codeexample-base16-mocha-dark .highlight .ow{color:#f4bc87}.codeexample-base16-mocha-dark .highlight .w{color:#a89bb9}.codeexample-base16-mocha-dark .highlight .mf{color:#a89bb9}.codeexample-base16-mocha-dark .highlight .mh{color:#a89bb9}.codeexample-base16-mocha-dark .highlight .mi{color:#a89bb9}.codeexample-base16-mocha-dark .highlight .mo{color:#a89bb9}.codeexample-base16-mocha-dark .highlight .sb{color:#7bbda4}.codeexample-base16-mocha-dark .highlight .sc{color:#7bbda4}.codeexample-base16-mocha-dark .highlight .sd{color:#7bbda4}.codeexample-base16-mocha-dark .highlight .s2{color:#7bbda4}.codeexample-base16-mocha-dark .highlight .se{color:#7bbda4}.codeexample-base16-mocha-dark .highlight .sh{color:#7bbda4}.codeexample-base16-mocha-dark .highlight .si{color:#7bbda4}.codeexample-base16-mocha-dark .highlight .sx{color:#7bbda4}.codeexample-base16-mocha-dark .highlight .sr{color:#7bbda4}.codeexample-base16-mocha-dark .highlight .s1{color:#7bbda4}.codeexample-base16-mocha-dark .highlight .ss{color:#7bbda4}.codeexample-base16-mocha-dark .highlight .bp{color:#8ab3b5}.codeexample-base16-mocha-dark .highlight .vc{color:#8ab3b5}.codeexample-base16-mocha-dark .highlight .vg{color:#d0c8c6}.codeexample-base16-mocha-dark .highlight .vi{color:#f4bc87}.codeexample-base16-mocha-dark .highlight .il{color:#a89bb9}</style><div class="codeexample codeexample-base16-mocha-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-mocha-light">Base16 Mocha Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#645240"></div><div class="preview-color" style="background-color:#3B3228"></div><div class="preview-color" style="background-color:#cb6077"></div><div class="preview-color" style="background-color:#beb55b"></div><div class="preview-color" style="background-color:#f4bc87"></div><div class="preview-color" style="background-color:#8ab3b5"></div><div class="preview-color" style="background-color:#a89bb9"></div><div class="preview-color" style="background-color:#7bbda4"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#f5eeeb"></div><div class="preview-color" style="background-color:#7e705a"></div><div class="preview-color" style="background-color:#cb6077"></div><div class="preview-color" style="background-color:#beb55b"></div><div class="preview-color" style="background-color:#f4bc87"></div><div class="preview-color" style="background-color:#8ab3b5"></div><div class="preview-color" style="background-color:#a89bb9"></div><div class="preview-color" style="background-color:#7bbda4"></div></div></div><style>.codeexample-base16-mocha-light .highlight code, .codeexample-base16-mocha-light .highlight pre{color:#645240;background-color:#f5eeeb}.codeexample-base16-mocha-light .highlight .hll{background-color:#7e705a}.codeexample-base16-mocha-light .highlight .c{color:#d0c8c6}.codeexample-base16-mocha-light .highlight .err{color:#beb55b;background-color:#7e705a}.codeexample-base16-mocha-light .highlight .g{color:#d0c8c6}.codeexample-base16-mocha-light .highlight .k{color:#8ab3b5}.codeexample-base16-mocha-light .highlight .l{color:#a89bb9}.codeexample-base16-mocha-light .highlight .n{color:#645240}.codeexample-base16-mocha-light .highlight .o{color:#f4bc87}.codeexample-base16-mocha-light .highlight .x{color:#a89bb9}.codeexample-base16-mocha-light .highlight .p{color:#f5eeeb}.codeexample-base16-mocha-light .highlight .cm{color:#d0c8c6}.codeexample-base16-mocha-light .highlight .cp{color:#d0c8c6}.codeexample-base16-mocha-light .highlight .c1{color:#d0c8c6}.codeexample-base16-mocha-light .highlight .cs{color:#beb55b;font-weight:bold}.codeexample-base16-mocha-light .highlight .gd{color:#beb55b}.codeexample-base16-mocha-light .highlight .ge{color:#a89bb9;font-style:italic}.codeexample-base16-mocha-light .highlight .gr{color:#beb55b}.codeexample-base16-mocha-light .highlight .gh{color:#645240;font-weight:bold}.codeexample-base16-mocha-light .highlight .gi{color:#f4bc87}.codeexample-base16-mocha-light .highlight .go{color:#7e705a}.codeexample-base16-mocha-light .highlight .gp{color:#645240;font-weight:bold}.codeexample-base16-mocha-light .highlight .gs{color:#a89bb9;font-weight:bold}.codeexample-base16-mocha-light .highlight .gu{color:#a89bb9;font-weight:bold}.codeexample-base16-mocha-light .highlight .gt{color:#8ab3b5}.codeexample-base16-mocha-light .highlight .kc{color:#cb6077}.codeexample-base16-mocha-light .highlight .kd{color:#f4bc87}.codeexample-base16-mocha-light .highlight .kn{color:#8ab3b5;font-weight:bold}.codeexample-base16-mocha-light .highlight .kp{color:#beb55b}.codeexample-base16-mocha-light .highlight .kr{color:#beb55b}.codeexample-base16-mocha-light .highlight .kt{color:#d0c8c6}.codeexample-base16-mocha-light .highlight .ld{color:#7bbda4}.codeexample-base16-mocha-light .highlight .m{color:#a89bb9}.codeexample-base16-mocha-light .highlight .s{color:#7bbda4}.codeexample-base16-mocha-light .highlight .na{color:#beb55b}.codeexample-base16-mocha-light .highlight .nb{color:#8ab3b5}.codeexample-base16-mocha-light .highlight .nc{color:#8ab3b5}.codeexample-base16-mocha-light .highlight .no{color:#a89bb9}.codeexample-base16-mocha-light .highlight .nd{color:#a89bb9}.codeexample-base16-mocha-light .highlight .ni{color:#cb6077}.codeexample-base16-mocha-light .highlight .ne{color:#f4bc87;font-weight:bold}.codeexample-base16-mocha-light .highlight .nf{color:#8ab3b5}.codeexample-base16-mocha-light .highlight .nl{color:#a89bb9}.codeexample-base16-mocha-light .highlight .nn{color:#8ab3b5}.codeexample-base16-mocha-light .highlight .nx{color:#a89bb9}.codeexample-base16-mocha-light .highlight .py{color:#a89bb9}.codeexample-base16-mocha-light .highlight .nt{color:#beb55b}.codeexample-base16-mocha-light .highlight .nv{color:#645240}.codeexample-base16-mocha-light .highlight .ow{color:#f4bc87}.codeexample-base16-mocha-light .highlight .w{color:#a89bb9}.codeexample-base16-mocha-light .highlight .mf{color:#a89bb9}.codeexample-base16-mocha-light .highlight .mh{color:#a89bb9}.codeexample-base16-mocha-light .highlight .mi{color:#a89bb9}.codeexample-base16-mocha-light .highlight .mo{color:#a89bb9}.codeexample-base16-mocha-light .highlight .sb{color:#7bbda4}.codeexample-base16-mocha-light .highlight .sc{color:#7bbda4}.codeexample-base16-mocha-light .highlight .sd{color:#7bbda4}.codeexample-base16-mocha-light .highlight .s2{color:#7bbda4}.codeexample-base16-mocha-light .highlight .se{color:#7bbda4}.codeexample-base16-mocha-light .highlight .sh{color:#7bbda4}.codeexample-base16-mocha-light .highlight .si{color:#7bbda4}.codeexample-base16-mocha-light .highlight .sx{color:#7bbda4}.codeexample-base16-mocha-light .highlight .sr{color:#7bbda4}.codeexample-base16-mocha-light .highlight .s1{color:#7bbda4}.codeexample-base16-mocha-light .highlight .ss{color:#7bbda4}.codeexample-base16-mocha-light .highlight .bp{color:#8ab3b5}.codeexample-base16-mocha-light .highlight .vc{color:#8ab3b5}.codeexample-base16-mocha-light .highlight .vg{color:#645240}.codeexample-base16-mocha-light .highlight .vi{color:#f4bc87}.codeexample-base16-mocha-light .highlight .il{color:#a89bb9}</style><div class="codeexample codeexample-base16-mocha-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-monokai-dark">Base16 Monokai Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#f8f8f2"></div><div class="preview-color" style="background-color:#272822"></div><div class="preview-color" style="background-color:#f92672"></div><div class="preview-color" style="background-color:#a6e22e"></div><div class="preview-color" style="background-color:#f4bf75"></div><div class="preview-color" style="background-color:#66d9ef"></div><div class="preview-color" style="background-color:#ae81ff"></div><div class="preview-color" style="background-color:#a1efe4"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#272822"></div><div class="preview-color" style="background-color:#75715e"></div><div class="preview-color" style="background-color:#f92672"></div><div class="preview-color" style="background-color:#a6e22e"></div><div class="preview-color" style="background-color:#f4bf75"></div><div class="preview-color" style="background-color:#66d9ef"></div><div class="preview-color" style="background-color:#ae81ff"></div><div class="preview-color" style="background-color:#a1efe4"></div></div></div><style>.codeexample-base16-monokai-dark .highlight code, .codeexample-base16-monokai-dark .highlight pre{color:#f8f8f2;background-color:#272822}.codeexample-base16-monokai-dark .highlight .hll{background-color:#75715e}.codeexample-base16-monokai-dark .highlight .c{color:#f8f8f2}.codeexample-base16-monokai-dark .highlight .err{color:#a6e22e;background-color:#75715e}.codeexample-base16-monokai-dark .highlight .g{color:#f8f8f2}.codeexample-base16-monokai-dark .highlight .k{color:#66d9ef}.codeexample-base16-monokai-dark .highlight .l{color:#ae81ff}.codeexample-base16-monokai-dark .highlight .n{color:#f8f8f2}.codeexample-base16-monokai-dark .highlight .o{color:#f4bf75}.codeexample-base16-monokai-dark .highlight .x{color:#ae81ff}.codeexample-base16-monokai-dark .highlight .p{color:#f9f8f5}.codeexample-base16-monokai-dark .highlight .cm{color:#f8f8f2}.codeexample-base16-monokai-dark .highlight .cp{color:#f8f8f2}.codeexample-base16-monokai-dark .highlight .c1{color:#f8f8f2}.codeexample-base16-monokai-dark .highlight .cs{color:#a6e22e;font-weight:bold}.codeexample-base16-monokai-dark .highlight .gd{color:#a6e22e}.codeexample-base16-monokai-dark .highlight .ge{color:#ae81ff;font-style:italic}.codeexample-base16-monokai-dark .highlight .gr{color:#a6e22e}.codeexample-base16-monokai-dark .highlight .gh{color:#f8f8f2;font-weight:bold}.codeexample-base16-monokai-dark .highlight .gi{color:#f4bf75}.codeexample-base16-monokai-dark .highlight .go{color:#75715e}.codeexample-base16-monokai-dark .highlight .gp{color:#f8f8f2;font-weight:bold}.codeexample-base16-monokai-dark .highlight .gs{color:#ae81ff;font-weight:bold}.codeexample-base16-monokai-dark .highlight .gu{color:#ae81ff;font-weight:bold}.codeexample-base16-monokai-dark .highlight .gt{color:#66d9ef}.codeexample-base16-monokai-dark .highlight .kc{color:#f92672}.codeexample-base16-monokai-dark .highlight .kd{color:#f4bf75}.codeexample-base16-monokai-dark .highlight .kn{color:#66d9ef;font-weight:bold}.codeexample-base16-monokai-dark .highlight .kp{color:#a6e22e}.codeexample-base16-monokai-dark .highlight .kr{color:#a6e22e}.codeexample-base16-monokai-dark .highlight .kt{color:#f8f8f2}.codeexample-base16-monokai-dark .highlight .ld{color:#a1efe4}.codeexample-base16-monokai-dark .highlight .m{color:#ae81ff}.codeexample-base16-monokai-dark .highlight .s{color:#a1efe4}.codeexample-base16-monokai-dark .highlight .na{color:#a6e22e}.codeexample-base16-monokai-dark .highlight .nb{color:#66d9ef}.codeexample-base16-monokai-dark .highlight .nc{color:#66d9ef}.codeexample-base16-monokai-dark .highlight .no{color:#ae81ff}.codeexample-base16-monokai-dark .highlight .nd{color:#ae81ff}.codeexample-base16-monokai-dark .highlight .ni{color:#f92672}.codeexample-base16-monokai-dark .highlight .ne{color:#f4bf75;font-weight:bold}.codeexample-base16-monokai-dark .highlight .nf{color:#66d9ef}.codeexample-base16-monokai-dark .highlight .nl{color:#ae81ff}.codeexample-base16-monokai-dark .highlight .nn{color:#66d9ef}.codeexample-base16-monokai-dark .highlight .nx{color:#ae81ff}.codeexample-base16-monokai-dark .highlight .py{color:#ae81ff}.codeexample-base16-monokai-dark .highlight .nt{color:#a6e22e}.codeexample-base16-monokai-dark .highlight .nv{color:#f8f8f2}.codeexample-base16-monokai-dark .highlight .ow{color:#f4bf75}.codeexample-base16-monokai-dark .highlight .w{color:#ae81ff}.codeexample-base16-monokai-dark .highlight .mf{color:#ae81ff}.codeexample-base16-monokai-dark .highlight .mh{color:#ae81ff}.codeexample-base16-monokai-dark .highlight .mi{color:#ae81ff}.codeexample-base16-monokai-dark .highlight .mo{color:#ae81ff}.codeexample-base16-monokai-dark .highlight .sb{color:#a1efe4}.codeexample-base16-monokai-dark .highlight .sc{color:#a1efe4}.codeexample-base16-monokai-dark .highlight .sd{color:#a1efe4}.codeexample-base16-monokai-dark .highlight .s2{color:#a1efe4}.codeexample-base16-monokai-dark .highlight .se{color:#a1efe4}.codeexample-base16-monokai-dark .highlight .sh{color:#a1efe4}.codeexample-base16-monokai-dark .highlight .si{color:#a1efe4}.codeexample-base16-monokai-dark .highlight .sx{color:#a1efe4}.codeexample-base16-monokai-dark .highlight .sr{color:#a1efe4}.codeexample-base16-monokai-dark .highlight .s1{color:#a1efe4}.codeexample-base16-monokai-dark .highlight .ss{color:#a1efe4}.codeexample-base16-monokai-dark .highlight .bp{color:#66d9ef}.codeexample-base16-monokai-dark .highlight .vc{color:#66d9ef}.codeexample-base16-monokai-dark .highlight .vg{color:#f8f8f2}.codeexample-base16-monokai-dark .highlight .vi{color:#f4bf75}.codeexample-base16-monokai-dark .highlight .il{color:#ae81ff}</style><div class="codeexample codeexample-base16-monokai-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-monokai-light">Base16 Monokai Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#49483e"></div><div class="preview-color" style="background-color:#272822"></div><div class="preview-color" style="background-color:#f92672"></div><div class="preview-color" style="background-color:#a6e22e"></div><div class="preview-color" style="background-color:#f4bf75"></div><div class="preview-color" style="background-color:#66d9ef"></div><div class="preview-color" style="background-color:#ae81ff"></div><div class="preview-color" style="background-color:#a1efe4"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#f9f8f5"></div><div class="preview-color" style="background-color:#75715e"></div><div class="preview-color" style="background-color:#f92672"></div><div class="preview-color" style="background-color:#a6e22e"></div><div class="preview-color" style="background-color:#f4bf75"></div><div class="preview-color" style="background-color:#66d9ef"></div><div class="preview-color" style="background-color:#ae81ff"></div><div class="preview-color" style="background-color:#a1efe4"></div></div></div><style>.codeexample-base16-monokai-light .highlight code, .codeexample-base16-monokai-light .highlight pre{color:#49483e;background-color:#f9f8f5}.codeexample-base16-monokai-light .highlight .hll{background-color:#75715e}.codeexample-base16-monokai-light .highlight .c{color:#f8f8f2}.codeexample-base16-monokai-light .highlight .err{color:#a6e22e;background-color:#75715e}.codeexample-base16-monokai-light .highlight .g{color:#f8f8f2}.codeexample-base16-monokai-light .highlight .k{color:#66d9ef}.codeexample-base16-monokai-light .highlight .l{color:#ae81ff}.codeexample-base16-monokai-light .highlight .n{color:#49483e}.codeexample-base16-monokai-light .highlight .o{color:#f4bf75}.codeexample-base16-monokai-light .highlight .x{color:#ae81ff}.codeexample-base16-monokai-light .highlight .p{color:#f9f8f5}.codeexample-base16-monokai-light .highlight .cm{color:#f8f8f2}.codeexample-base16-monokai-light .highlight .cp{color:#f8f8f2}.codeexample-base16-monokai-light .highlight .c1{color:#f8f8f2}.codeexample-base16-monokai-light .highlight .cs{color:#a6e22e;font-weight:bold}.codeexample-base16-monokai-light .highlight .gd{color:#a6e22e}.codeexample-base16-monokai-light .highlight .ge{color:#ae81ff;font-style:italic}.codeexample-base16-monokai-light .highlight .gr{color:#a6e22e}.codeexample-base16-monokai-light .highlight .gh{color:#49483e;font-weight:bold}.codeexample-base16-monokai-light .highlight .gi{color:#f4bf75}.codeexample-base16-monokai-light .highlight .go{color:#75715e}.codeexample-base16-monokai-light .highlight .gp{color:#49483e;font-weight:bold}.codeexample-base16-monokai-light .highlight .gs{color:#ae81ff;font-weight:bold}.codeexample-base16-monokai-light .highlight .gu{color:#ae81ff;font-weight:bold}.codeexample-base16-monokai-light .highlight .gt{color:#66d9ef}.codeexample-base16-monokai-light .highlight .kc{color:#f92672}.codeexample-base16-monokai-light .highlight .kd{color:#f4bf75}.codeexample-base16-monokai-light .highlight .kn{color:#66d9ef;font-weight:bold}.codeexample-base16-monokai-light .highlight .kp{color:#a6e22e}.codeexample-base16-monokai-light .highlight .kr{color:#a6e22e}.codeexample-base16-monokai-light .highlight .kt{color:#f8f8f2}.codeexample-base16-monokai-light .highlight .ld{color:#a1efe4}.codeexample-base16-monokai-light .highlight .m{color:#ae81ff}.codeexample-base16-monokai-light .highlight .s{color:#a1efe4}.codeexample-base16-monokai-light .highlight .na{color:#a6e22e}.codeexample-base16-monokai-light .highlight .nb{color:#66d9ef}.codeexample-base16-monokai-light .highlight .nc{color:#66d9ef}.codeexample-base16-monokai-light .highlight .no{color:#ae81ff}.codeexample-base16-monokai-light .highlight .nd{color:#ae81ff}.codeexample-base16-monokai-light .highlight .ni{color:#f92672}.codeexample-base16-monokai-light .highlight .ne{color:#f4bf75;font-weight:bold}.codeexample-base16-monokai-light .highlight .nf{color:#66d9ef}.codeexample-base16-monokai-light .highlight .nl{color:#ae81ff}.codeexample-base16-monokai-light .highlight .nn{color:#66d9ef}.codeexample-base16-monokai-light .highlight .nx{color:#ae81ff}.codeexample-base16-monokai-light .highlight .py{color:#ae81ff}.codeexample-base16-monokai-light .highlight .nt{color:#a6e22e}.codeexample-base16-monokai-light .highlight .nv{color:#49483e}.codeexample-base16-monokai-light .highlight .ow{color:#f4bf75}.codeexample-base16-monokai-light .highlight .w{color:#ae81ff}.codeexample-base16-monokai-light .highlight .mf{color:#ae81ff}.codeexample-base16-monokai-light .highlight .mh{color:#ae81ff}.codeexample-base16-monokai-light .highlight .mi{color:#ae81ff}.codeexample-base16-monokai-light .highlight .mo{color:#ae81ff}.codeexample-base16-monokai-light .highlight .sb{color:#a1efe4}.codeexample-base16-monokai-light .highlight .sc{color:#a1efe4}.codeexample-base16-monokai-light .highlight .sd{color:#a1efe4}.codeexample-base16-monokai-light .highlight .s2{color:#a1efe4}.codeexample-base16-monokai-light .highlight .se{color:#a1efe4}.codeexample-base16-monokai-light .highlight .sh{color:#a1efe4}.codeexample-base16-monokai-light .highlight .si{color:#a1efe4}.codeexample-base16-monokai-light .highlight .sx{color:#a1efe4}.codeexample-base16-monokai-light .highlight .sr{color:#a1efe4}.codeexample-base16-monokai-light .highlight .s1{color:#a1efe4}.codeexample-base16-monokai-light .highlight .ss{color:#a1efe4}.codeexample-base16-monokai-light .highlight .bp{color:#66d9ef}.codeexample-base16-monokai-light .highlight .vc{color:#66d9ef}.codeexample-base16-monokai-light .highlight .vg{color:#49483e}.codeexample-base16-monokai-light .highlight .vi{color:#f4bf75}.codeexample-base16-monokai-light .highlight .il{color:#ae81ff}</style><div class="codeexample codeexample-base16-monokai-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-ocean-dark">Base16 Ocean Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#c0c5ce"></div><div class="preview-color" style="background-color:#2b303b"></div><div class="preview-color" style="background-color:#bf616a"></div><div class="preview-color" style="background-color:#a3be8c"></div><div class="preview-color" style="background-color:#ebcb8b"></div><div class="preview-color" style="background-color:#8fa1b3"></div><div class="preview-color" style="background-color:#b48ead"></div><div class="preview-color" style="background-color:#96b5b4"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#2b303b"></div><div class="preview-color" style="background-color:#65737e"></div><div class="preview-color" style="background-color:#bf616a"></div><div class="preview-color" style="background-color:#a3be8c"></div><div class="preview-color" style="background-color:#ebcb8b"></div><div class="preview-color" style="background-color:#8fa1b3"></div><div class="preview-color" style="background-color:#b48ead"></div><div class="preview-color" style="background-color:#96b5b4"></div></div></div><style>.codeexample-base16-ocean-dark .highlight code, .codeexample-base16-ocean-dark .highlight pre{color:#c0c5ce;background-color:#2b303b}.codeexample-base16-ocean-dark .highlight .hll{background-color:#65737e}.codeexample-base16-ocean-dark .highlight .c{color:#c0c5ce}.codeexample-base16-ocean-dark .highlight .err{color:#a3be8c;background-color:#65737e}.codeexample-base16-ocean-dark .highlight .g{color:#c0c5ce}.codeexample-base16-ocean-dark .highlight .k{color:#8fa1b3}.codeexample-base16-ocean-dark .highlight .l{color:#b48ead}.codeexample-base16-ocean-dark .highlight .n{color:#c0c5ce}.codeexample-base16-ocean-dark .highlight .o{color:#ebcb8b}.codeexample-base16-ocean-dark .highlight .x{color:#b48ead}.codeexample-base16-ocean-dark .highlight .p{color:#eff1f5}.codeexample-base16-ocean-dark .highlight .cm{color:#c0c5ce}.codeexample-base16-ocean-dark .highlight .cp{color:#c0c5ce}.codeexample-base16-ocean-dark .highlight .c1{color:#c0c5ce}.codeexample-base16-ocean-dark .highlight .cs{color:#a3be8c;font-weight:bold}.codeexample-base16-ocean-dark .highlight .gd{color:#a3be8c}.codeexample-base16-ocean-dark .highlight .ge{color:#b48ead;font-style:italic}.codeexample-base16-ocean-dark .highlight .gr{color:#a3be8c}.codeexample-base16-ocean-dark .highlight .gh{color:#c0c5ce;font-weight:bold}.codeexample-base16-ocean-dark .highlight .gi{color:#ebcb8b}.codeexample-base16-ocean-dark .highlight .go{color:#65737e}.codeexample-base16-ocean-dark .highlight .gp{color:#c0c5ce;font-weight:bold}.codeexample-base16-ocean-dark .highlight .gs{color:#b48ead;font-weight:bold}.codeexample-base16-ocean-dark .highlight .gu{color:#b48ead;font-weight:bold}.codeexample-base16-ocean-dark .highlight .gt{color:#8fa1b3}.codeexample-base16-ocean-dark .highlight .kc{color:#bf616a}.codeexample-base16-ocean-dark .highlight .kd{color:#ebcb8b}.codeexample-base16-ocean-dark .highlight .kn{color:#8fa1b3;font-weight:bold}.codeexample-base16-ocean-dark .highlight .kp{color:#a3be8c}.codeexample-base16-ocean-dark .highlight .kr{color:#a3be8c}.codeexample-base16-ocean-dark .highlight .kt{color:#c0c5ce}.codeexample-base16-ocean-dark .highlight .ld{color:#96b5b4}.codeexample-base16-ocean-dark .highlight .m{color:#b48ead}.codeexample-base16-ocean-dark .highlight .s{color:#96b5b4}.codeexample-base16-ocean-dark .highlight .na{color:#a3be8c}.codeexample-base16-ocean-dark .highlight .nb{color:#8fa1b3}.codeexample-base16-ocean-dark .highlight .nc{color:#8fa1b3}.codeexample-base16-ocean-dark .highlight .no{color:#b48ead}.codeexample-base16-ocean-dark .highlight .nd{color:#b48ead}.codeexample-base16-ocean-dark .highlight .ni{color:#bf616a}.codeexample-base16-ocean-dark .highlight .ne{color:#ebcb8b;font-weight:bold}.codeexample-base16-ocean-dark .highlight .nf{color:#8fa1b3}.codeexample-base16-ocean-dark .highlight .nl{color:#b48ead}.codeexample-base16-ocean-dark .highlight .nn{color:#8fa1b3}.codeexample-base16-ocean-dark .highlight .nx{color:#b48ead}.codeexample-base16-ocean-dark .highlight .py{color:#b48ead}.codeexample-base16-ocean-dark .highlight .nt{color:#a3be8c}.codeexample-base16-ocean-dark .highlight .nv{color:#c0c5ce}.codeexample-base16-ocean-dark .highlight .ow{color:#ebcb8b}.codeexample-base16-ocean-dark .highlight .w{color:#b48ead}.codeexample-base16-ocean-dark .highlight .mf{color:#b48ead}.codeexample-base16-ocean-dark .highlight .mh{color:#b48ead}.codeexample-base16-ocean-dark .highlight .mi{color:#b48ead}.codeexample-base16-ocean-dark .highlight .mo{color:#b48ead}.codeexample-base16-ocean-dark .highlight .sb{color:#96b5b4}.codeexample-base16-ocean-dark .highlight .sc{color:#96b5b4}.codeexample-base16-ocean-dark .highlight .sd{color:#96b5b4}.codeexample-base16-ocean-dark .highlight .s2{color:#96b5b4}.codeexample-base16-ocean-dark .highlight .se{color:#96b5b4}.codeexample-base16-ocean-dark .highlight .sh{color:#96b5b4}.codeexample-base16-ocean-dark .highlight .si{color:#96b5b4}.codeexample-base16-ocean-dark .highlight .sx{color:#96b5b4}.codeexample-base16-ocean-dark .highlight .sr{color:#96b5b4}.codeexample-base16-ocean-dark .highlight .s1{color:#96b5b4}.codeexample-base16-ocean-dark .highlight .ss{color:#96b5b4}.codeexample-base16-ocean-dark .highlight .bp{color:#8fa1b3}.codeexample-base16-ocean-dark .highlight .vc{color:#8fa1b3}.codeexample-base16-ocean-dark .highlight .vg{color:#c0c5ce}.codeexample-base16-ocean-dark .highlight .vi{color:#ebcb8b}.codeexample-base16-ocean-dark .highlight .il{color:#b48ead}</style><div class="codeexample codeexample-base16-ocean-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-ocean-light">Base16 Ocean Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#4f5b66"></div><div class="preview-color" style="background-color:#2b303b"></div><div class="preview-color" style="background-color:#bf616a"></div><div class="preview-color" style="background-color:#a3be8c"></div><div class="preview-color" style="background-color:#ebcb8b"></div><div class="preview-color" style="background-color:#8fa1b3"></div><div class="preview-color" style="background-color:#b48ead"></div><div class="preview-color" style="background-color:#96b5b4"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#eff1f5"></div><div class="preview-color" style="background-color:#65737e"></div><div class="preview-color" style="background-color:#bf616a"></div><div class="preview-color" style="background-color:#a3be8c"></div><div class="preview-color" style="background-color:#ebcb8b"></div><div class="preview-color" style="background-color:#8fa1b3"></div><div class="preview-color" style="background-color:#b48ead"></div><div class="preview-color" style="background-color:#96b5b4"></div></div></div><style>.codeexample-base16-ocean-light .highlight code, .codeexample-base16-ocean-light .highlight pre{color:#4f5b66;background-color:#eff1f5}.codeexample-base16-ocean-light .highlight .hll{background-color:#65737e}.codeexample-base16-ocean-light .highlight .c{color:#c0c5ce}.codeexample-base16-ocean-light .highlight .err{color:#a3be8c;background-color:#65737e}.codeexample-base16-ocean-light .highlight .g{color:#c0c5ce}.codeexample-base16-ocean-light .highlight .k{color:#8fa1b3}.codeexample-base16-ocean-light .highlight .l{color:#b48ead}.codeexample-base16-ocean-light .highlight .n{color:#4f5b66}.codeexample-base16-ocean-light .highlight .o{color:#ebcb8b}.codeexample-base16-ocean-light .highlight .x{color:#b48ead}.codeexample-base16-ocean-light .highlight .p{color:#eff1f5}.codeexample-base16-ocean-light .highlight .cm{color:#c0c5ce}.codeexample-base16-ocean-light .highlight .cp{color:#c0c5ce}.codeexample-base16-ocean-light .highlight .c1{color:#c0c5ce}.codeexample-base16-ocean-light .highlight .cs{color:#a3be8c;font-weight:bold}.codeexample-base16-ocean-light .highlight .gd{color:#a3be8c}.codeexample-base16-ocean-light .highlight .ge{color:#b48ead;font-style:italic}.codeexample-base16-ocean-light .highlight .gr{color:#a3be8c}.codeexample-base16-ocean-light .highlight .gh{color:#4f5b66;font-weight:bold}.codeexample-base16-ocean-light .highlight .gi{color:#ebcb8b}.codeexample-base16-ocean-light .highlight .go{color:#65737e}.codeexample-base16-ocean-light .highlight .gp{color:#4f5b66;font-weight:bold}.codeexample-base16-ocean-light .highlight .gs{color:#b48ead;font-weight:bold}.codeexample-base16-ocean-light .highlight .gu{color:#b48ead;font-weight:bold}.codeexample-base16-ocean-light .highlight .gt{color:#8fa1b3}.codeexample-base16-ocean-light .highlight .kc{color:#bf616a}.codeexample-base16-ocean-light .highlight .kd{color:#ebcb8b}.codeexample-base16-ocean-light .highlight .kn{color:#8fa1b3;font-weight:bold}.codeexample-base16-ocean-light .highlight .kp{color:#a3be8c}.codeexample-base16-ocean-light .highlight .kr{color:#a3be8c}.codeexample-base16-ocean-light .highlight .kt{color:#c0c5ce}.codeexample-base16-ocean-light .highlight .ld{color:#96b5b4}.codeexample-base16-ocean-light .highlight .m{color:#b48ead}.codeexample-base16-ocean-light .highlight .s{color:#96b5b4}.codeexample-base16-ocean-light .highlight .na{color:#a3be8c}.codeexample-base16-ocean-light .highlight .nb{color:#8fa1b3}.codeexample-base16-ocean-light .highlight .nc{color:#8fa1b3}.codeexample-base16-ocean-light .highlight .no{color:#b48ead}.codeexample-base16-ocean-light .highlight .nd{color:#b48ead}.codeexample-base16-ocean-light .highlight .ni{color:#bf616a}.codeexample-base16-ocean-light .highlight .ne{color:#ebcb8b;font-weight:bold}.codeexample-base16-ocean-light .highlight .nf{color:#8fa1b3}.codeexample-base16-ocean-light .highlight .nl{color:#b48ead}.codeexample-base16-ocean-light .highlight .nn{color:#8fa1b3}.codeexample-base16-ocean-light .highlight .nx{color:#b48ead}.codeexample-base16-ocean-light .highlight .py{color:#b48ead}.codeexample-base16-ocean-light .highlight .nt{color:#a3be8c}.codeexample-base16-ocean-light .highlight .nv{color:#4f5b66}.codeexample-base16-ocean-light .highlight .ow{color:#ebcb8b}.codeexample-base16-ocean-light .highlight .w{color:#b48ead}.codeexample-base16-ocean-light .highlight .mf{color:#b48ead}.codeexample-base16-ocean-light .highlight .mh{color:#b48ead}.codeexample-base16-ocean-light .highlight .mi{color:#b48ead}.codeexample-base16-ocean-light .highlight .mo{color:#b48ead}.codeexample-base16-ocean-light .highlight .sb{color:#96b5b4}.codeexample-base16-ocean-light .highlight .sc{color:#96b5b4}.codeexample-base16-ocean-light .highlight .sd{color:#96b5b4}.codeexample-base16-ocean-light .highlight .s2{color:#96b5b4}.codeexample-base16-ocean-light .highlight .se{color:#96b5b4}.codeexample-base16-ocean-light .highlight .sh{color:#96b5b4}.codeexample-base16-ocean-light .highlight .si{color:#96b5b4}.codeexample-base16-ocean-light .highlight .sx{color:#96b5b4}.codeexample-base16-ocean-light .highlight .sr{color:#96b5b4}.codeexample-base16-ocean-light .highlight .s1{color:#96b5b4}.codeexample-base16-ocean-light .highlight .ss{color:#96b5b4}.codeexample-base16-ocean-light .highlight .bp{color:#8fa1b3}.codeexample-base16-ocean-light .highlight .vc{color:#8fa1b3}.codeexample-base16-ocean-light .highlight .vg{color:#4f5b66}.codeexample-base16-ocean-light .highlight .vi{color:#ebcb8b}.codeexample-base16-ocean-light .highlight .il{color:#b48ead}</style><div class="codeexample codeexample-base16-ocean-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-paraiso-dark">Base16 Paraiso Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#a39e9b"></div><div class="preview-color" style="background-color:#2f1e2e"></div><div class="preview-color" style="background-color:#ef6155"></div><div class="preview-color" style="background-color:#48b685"></div><div class="preview-color" style="background-color:#fec418"></div><div class="preview-color" style="background-color:#06b6ef"></div><div class="preview-color" style="background-color:#815ba4"></div><div class="preview-color" style="background-color:#5bc4bf"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#2f1e2e"></div><div class="preview-color" style="background-color:#776e71"></div><div class="preview-color" style="background-color:#ef6155"></div><div class="preview-color" style="background-color:#48b685"></div><div class="preview-color" style="background-color:#fec418"></div><div class="preview-color" style="background-color:#06b6ef"></div><div class="preview-color" style="background-color:#815ba4"></div><div class="preview-color" style="background-color:#5bc4bf"></div></div></div><style>.codeexample-base16-paraiso-dark .highlight code, .codeexample-base16-paraiso-dark .highlight pre{color:#a39e9b;background-color:#2f1e2e}.codeexample-base16-paraiso-dark .highlight .hll{background-color:#776e71}.codeexample-base16-paraiso-dark .highlight .c{color:#a39e9b}.codeexample-base16-paraiso-dark .highlight .err{color:#48b685;background-color:#776e71}.codeexample-base16-paraiso-dark .highlight .g{color:#a39e9b}.codeexample-base16-paraiso-dark .highlight .k{color:#06b6ef}.codeexample-base16-paraiso-dark .highlight .l{color:#815ba4}.codeexample-base16-paraiso-dark .highlight .n{color:#a39e9b}.codeexample-base16-paraiso-dark .highlight .o{color:#fec418}.codeexample-base16-paraiso-dark .highlight .x{color:#815ba4}.codeexample-base16-paraiso-dark .highlight .p{color:#e7e9db}.codeexample-base16-paraiso-dark .highlight .cm{color:#a39e9b}.codeexample-base16-paraiso-dark .highlight .cp{color:#a39e9b}.codeexample-base16-paraiso-dark .highlight .c1{color:#a39e9b}.codeexample-base16-paraiso-dark .highlight .cs{color:#48b685;font-weight:bold}.codeexample-base16-paraiso-dark .highlight .gd{color:#48b685}.codeexample-base16-paraiso-dark .highlight .ge{color:#815ba4;font-style:italic}.codeexample-base16-paraiso-dark .highlight .gr{color:#48b685}.codeexample-base16-paraiso-dark .highlight .gh{color:#a39e9b;font-weight:bold}.codeexample-base16-paraiso-dark .highlight .gi{color:#fec418}.codeexample-base16-paraiso-dark .highlight .go{color:#776e71}.codeexample-base16-paraiso-dark .highlight .gp{color:#a39e9b;font-weight:bold}.codeexample-base16-paraiso-dark .highlight .gs{color:#815ba4;font-weight:bold}.codeexample-base16-paraiso-dark .highlight .gu{color:#815ba4;font-weight:bold}.codeexample-base16-paraiso-dark .highlight .gt{color:#06b6ef}.codeexample-base16-paraiso-dark .highlight .kc{color:#ef6155}.codeexample-base16-paraiso-dark .highlight .kd{color:#fec418}.codeexample-base16-paraiso-dark .highlight .kn{color:#06b6ef;font-weight:bold}.codeexample-base16-paraiso-dark .highlight .kp{color:#48b685}.codeexample-base16-paraiso-dark .highlight .kr{color:#48b685}.codeexample-base16-paraiso-dark .highlight .kt{color:#a39e9b}.codeexample-base16-paraiso-dark .highlight .ld{color:#5bc4bf}.codeexample-base16-paraiso-dark .highlight .m{color:#815ba4}.codeexample-base16-paraiso-dark .highlight .s{color:#5bc4bf}.codeexample-base16-paraiso-dark .highlight .na{color:#48b685}.codeexample-base16-paraiso-dark .highlight .nb{color:#06b6ef}.codeexample-base16-paraiso-dark .highlight .nc{color:#06b6ef}.codeexample-base16-paraiso-dark .highlight .no{color:#815ba4}.codeexample-base16-paraiso-dark .highlight .nd{color:#815ba4}.codeexample-base16-paraiso-dark .highlight .ni{color:#ef6155}.codeexample-base16-paraiso-dark .highlight .ne{color:#fec418;font-weight:bold}.codeexample-base16-paraiso-dark .highlight .nf{color:#06b6ef}.codeexample-base16-paraiso-dark .highlight .nl{color:#815ba4}.codeexample-base16-paraiso-dark .highlight .nn{color:#06b6ef}.codeexample-base16-paraiso-dark .highlight .nx{color:#815ba4}.codeexample-base16-paraiso-dark .highlight .py{color:#815ba4}.codeexample-base16-paraiso-dark .highlight .nt{color:#48b685}.codeexample-base16-paraiso-dark .highlight .nv{color:#a39e9b}.codeexample-base16-paraiso-dark .highlight .ow{color:#fec418}.codeexample-base16-paraiso-dark .highlight .w{color:#815ba4}.codeexample-base16-paraiso-dark .highlight .mf{color:#815ba4}.codeexample-base16-paraiso-dark .highlight .mh{color:#815ba4}.codeexample-base16-paraiso-dark .highlight .mi{color:#815ba4}.codeexample-base16-paraiso-dark .highlight .mo{color:#815ba4}.codeexample-base16-paraiso-dark .highlight .sb{color:#5bc4bf}.codeexample-base16-paraiso-dark .highlight .sc{color:#5bc4bf}.codeexample-base16-paraiso-dark .highlight .sd{color:#5bc4bf}.codeexample-base16-paraiso-dark .highlight .s2{color:#5bc4bf}.codeexample-base16-paraiso-dark .highlight .se{color:#5bc4bf}.codeexample-base16-paraiso-dark .highlight .sh{color:#5bc4bf}.codeexample-base16-paraiso-dark .highlight .si{color:#5bc4bf}.codeexample-base16-paraiso-dark .highlight .sx{color:#5bc4bf}.codeexample-base16-paraiso-dark .highlight .sr{color:#5bc4bf}.codeexample-base16-paraiso-dark .highlight .s1{color:#5bc4bf}.codeexample-base16-paraiso-dark .highlight .ss{color:#5bc4bf}.codeexample-base16-paraiso-dark .highlight .bp{color:#06b6ef}.codeexample-base16-paraiso-dark .highlight .vc{color:#06b6ef}.codeexample-base16-paraiso-dark .highlight .vg{color:#a39e9b}.codeexample-base16-paraiso-dark .highlight .vi{color:#fec418}.codeexample-base16-paraiso-dark .highlight .il{color:#815ba4}</style><div class="codeexample codeexample-base16-paraiso-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-paraiso-light">Base16 Paraiso Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#4f424c"></div><div class="preview-color" style="background-color:#2f1e2e"></div><div class="preview-color" style="background-color:#ef6155"></div><div class="preview-color" style="background-color:#48b685"></div><div class="preview-color" style="background-color:#fec418"></div><div class="preview-color" style="background-color:#06b6ef"></div><div class="preview-color" style="background-color:#815ba4"></div><div class="preview-color" style="background-color:#5bc4bf"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#e7e9db"></div><div class="preview-color" style="background-color:#776e71"></div><div class="preview-color" style="background-color:#ef6155"></div><div class="preview-color" style="background-color:#48b685"></div><div class="preview-color" style="background-color:#fec418"></div><div class="preview-color" style="background-color:#06b6ef"></div><div class="preview-color" style="background-color:#815ba4"></div><div class="preview-color" style="background-color:#5bc4bf"></div></div></div><style>.codeexample-base16-paraiso-light .highlight code, .codeexample-base16-paraiso-light .highlight pre{color:#4f424c;background-color:#e7e9db}.codeexample-base16-paraiso-light .highlight .hll{background-color:#776e71}.codeexample-base16-paraiso-light .highlight .c{color:#a39e9b}.codeexample-base16-paraiso-light .highlight .err{color:#48b685;background-color:#776e71}.codeexample-base16-paraiso-light .highlight .g{color:#a39e9b}.codeexample-base16-paraiso-light .highlight .k{color:#06b6ef}.codeexample-base16-paraiso-light .highlight .l{color:#815ba4}.codeexample-base16-paraiso-light .highlight .n{color:#4f424c}.codeexample-base16-paraiso-light .highlight .o{color:#fec418}.codeexample-base16-paraiso-light .highlight .x{color:#815ba4}.codeexample-base16-paraiso-light .highlight .p{color:#e7e9db}.codeexample-base16-paraiso-light .highlight .cm{color:#a39e9b}.codeexample-base16-paraiso-light .highlight .cp{color:#a39e9b}.codeexample-base16-paraiso-light .highlight .c1{color:#a39e9b}.codeexample-base16-paraiso-light .highlight .cs{color:#48b685;font-weight:bold}.codeexample-base16-paraiso-light .highlight .gd{color:#48b685}.codeexample-base16-paraiso-light .highlight .ge{color:#815ba4;font-style:italic}.codeexample-base16-paraiso-light .highlight .gr{color:#48b685}.codeexample-base16-paraiso-light .highlight .gh{color:#4f424c;font-weight:bold}.codeexample-base16-paraiso-light .highlight .gi{color:#fec418}.codeexample-base16-paraiso-light .highlight .go{color:#776e71}.codeexample-base16-paraiso-light .highlight .gp{color:#4f424c;font-weight:bold}.codeexample-base16-paraiso-light .highlight .gs{color:#815ba4;font-weight:bold}.codeexample-base16-paraiso-light .highlight .gu{color:#815ba4;font-weight:bold}.codeexample-base16-paraiso-light .highlight .gt{color:#06b6ef}.codeexample-base16-paraiso-light .highlight .kc{color:#ef6155}.codeexample-base16-paraiso-light .highlight .kd{color:#fec418}.codeexample-base16-paraiso-light .highlight .kn{color:#06b6ef;font-weight:bold}.codeexample-base16-paraiso-light .highlight .kp{color:#48b685}.codeexample-base16-paraiso-light .highlight .kr{color:#48b685}.codeexample-base16-paraiso-light .highlight .kt{color:#a39e9b}.codeexample-base16-paraiso-light .highlight .ld{color:#5bc4bf}.codeexample-base16-paraiso-light .highlight .m{color:#815ba4}.codeexample-base16-paraiso-light .highlight .s{color:#5bc4bf}.codeexample-base16-paraiso-light .highlight .na{color:#48b685}.codeexample-base16-paraiso-light .highlight .nb{color:#06b6ef}.codeexample-base16-paraiso-light .highlight .nc{color:#06b6ef}.codeexample-base16-paraiso-light .highlight .no{color:#815ba4}.codeexample-base16-paraiso-light .highlight .nd{color:#815ba4}.codeexample-base16-paraiso-light .highlight .ni{color:#ef6155}.codeexample-base16-paraiso-light .highlight .ne{color:#fec418;font-weight:bold}.codeexample-base16-paraiso-light .highlight .nf{color:#06b6ef}.codeexample-base16-paraiso-light .highlight .nl{color:#815ba4}.codeexample-base16-paraiso-light .highlight .nn{color:#06b6ef}.codeexample-base16-paraiso-light .highlight .nx{color:#815ba4}.codeexample-base16-paraiso-light .highlight .py{color:#815ba4}.codeexample-base16-paraiso-light .highlight .nt{color:#48b685}.codeexample-base16-paraiso-light .highlight .nv{color:#4f424c}.codeexample-base16-paraiso-light .highlight .ow{color:#fec418}.codeexample-base16-paraiso-light .highlight .w{color:#815ba4}.codeexample-base16-paraiso-light .highlight .mf{color:#815ba4}.codeexample-base16-paraiso-light .highlight .mh{color:#815ba4}.codeexample-base16-paraiso-light .highlight .mi{color:#815ba4}.codeexample-base16-paraiso-light .highlight .mo{color:#815ba4}.codeexample-base16-paraiso-light .highlight .sb{color:#5bc4bf}.codeexample-base16-paraiso-light .highlight .sc{color:#5bc4bf}.codeexample-base16-paraiso-light .highlight .sd{color:#5bc4bf}.codeexample-base16-paraiso-light .highlight .s2{color:#5bc4bf}.codeexample-base16-paraiso-light .highlight .se{color:#5bc4bf}.codeexample-base16-paraiso-light .highlight .sh{color:#5bc4bf}.codeexample-base16-paraiso-light .highlight .si{color:#5bc4bf}.codeexample-base16-paraiso-light .highlight .sx{color:#5bc4bf}.codeexample-base16-paraiso-light .highlight .sr{color:#5bc4bf}.codeexample-base16-paraiso-light .highlight .s1{color:#5bc4bf}.codeexample-base16-paraiso-light .highlight .ss{color:#5bc4bf}.codeexample-base16-paraiso-light .highlight .bp{color:#06b6ef}.codeexample-base16-paraiso-light .highlight .vc{color:#06b6ef}.codeexample-base16-paraiso-light .highlight .vg{color:#4f424c}.codeexample-base16-paraiso-light .highlight .vi{color:#fec418}.codeexample-base16-paraiso-light .highlight .il{color:#815ba4}</style><div class="codeexample codeexample-base16-paraiso-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-railscasts-dark">Base16 Railscasts Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#e6e1dc"></div><div class="preview-color" style="background-color:#2b2b2b"></div><div class="preview-color" style="background-color:#da4939"></div><div class="preview-color" style="background-color:#a5c261"></div><div class="preview-color" style="background-color:#ffc66d"></div><div class="preview-color" style="background-color:#6d9cbe"></div><div class="preview-color" style="background-color:#b6b3eb"></div><div class="preview-color" style="background-color:#519f50"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#2b2b2b"></div><div class="preview-color" style="background-color:#5a647e"></div><div class="preview-color" style="background-color:#da4939"></div><div class="preview-color" style="background-color:#a5c261"></div><div class="preview-color" style="background-color:#ffc66d"></div><div class="preview-color" style="background-color:#6d9cbe"></div><div class="preview-color" style="background-color:#b6b3eb"></div><div class="preview-color" style="background-color:#519f50"></div></div></div><style>.codeexample-base16-railscasts-dark .highlight code, .codeexample-base16-railscasts-dark .highlight pre{color:#e6e1dc;background-color:#2b2b2b}.codeexample-base16-railscasts-dark .highlight .hll{background-color:#5a647e}.codeexample-base16-railscasts-dark .highlight .c{color:#e6e1dc}.codeexample-base16-railscasts-dark .highlight .err{color:#a5c261;background-color:#5a647e}.codeexample-base16-railscasts-dark .highlight .g{color:#e6e1dc}.codeexample-base16-railscasts-dark .highlight .k{color:#6d9cbe}.codeexample-base16-railscasts-dark .highlight .l{color:#b6b3eb}.codeexample-base16-railscasts-dark .highlight .n{color:#e6e1dc}.codeexample-base16-railscasts-dark .highlight .o{color:#ffc66d}.codeexample-base16-railscasts-dark .highlight .x{color:#b6b3eb}.codeexample-base16-railscasts-dark .highlight .p{color:#f9f7f3}.codeexample-base16-railscasts-dark .highlight .cm{color:#e6e1dc}.codeexample-base16-railscasts-dark .highlight .cp{color:#e6e1dc}.codeexample-base16-railscasts-dark .highlight .c1{color:#e6e1dc}.codeexample-base16-railscasts-dark .highlight .cs{color:#a5c261;font-weight:bold}.codeexample-base16-railscasts-dark .highlight .gd{color:#a5c261}.codeexample-base16-railscasts-dark .highlight .ge{color:#b6b3eb;font-style:italic}.codeexample-base16-railscasts-dark .highlight .gr{color:#a5c261}.codeexample-base16-railscasts-dark .highlight .gh{color:#e6e1dc;font-weight:bold}.codeexample-base16-railscasts-dark .highlight .gi{color:#ffc66d}.codeexample-base16-railscasts-dark .highlight .go{color:#5a647e}.codeexample-base16-railscasts-dark .highlight .gp{color:#e6e1dc;font-weight:bold}.codeexample-base16-railscasts-dark .highlight .gs{color:#b6b3eb;font-weight:bold}.codeexample-base16-railscasts-dark .highlight .gu{color:#b6b3eb;font-weight:bold}.codeexample-base16-railscasts-dark .highlight .gt{color:#6d9cbe}.codeexample-base16-railscasts-dark .highlight .kc{color:#da4939}.codeexample-base16-railscasts-dark .highlight .kd{color:#ffc66d}.codeexample-base16-railscasts-dark .highlight .kn{color:#6d9cbe;font-weight:bold}.codeexample-base16-railscasts-dark .highlight .kp{color:#a5c261}.codeexample-base16-railscasts-dark .highlight .kr{color:#a5c261}.codeexample-base16-railscasts-dark .highlight .kt{color:#e6e1dc}.codeexample-base16-railscasts-dark .highlight .ld{color:#519f50}.codeexample-base16-railscasts-dark .highlight .m{color:#b6b3eb}.codeexample-base16-railscasts-dark .highlight .s{color:#519f50}.codeexample-base16-railscasts-dark .highlight .na{color:#a5c261}.codeexample-base16-railscasts-dark .highlight .nb{color:#6d9cbe}.codeexample-base16-railscasts-dark .highlight .nc{color:#6d9cbe}.codeexample-base16-railscasts-dark .highlight .no{color:#b6b3eb}.codeexample-base16-railscasts-dark .highlight .nd{color:#b6b3eb}.codeexample-base16-railscasts-dark .highlight .ni{color:#da4939}.codeexample-base16-railscasts-dark .highlight .ne{color:#ffc66d;font-weight:bold}.codeexample-base16-railscasts-dark .highlight .nf{color:#6d9cbe}.codeexample-base16-railscasts-dark .highlight .nl{color:#b6b3eb}.codeexample-base16-railscasts-dark .highlight .nn{color:#6d9cbe}.codeexample-base16-railscasts-dark .highlight .nx{color:#b6b3eb}.codeexample-base16-railscasts-dark .highlight .py{color:#b6b3eb}.codeexample-base16-railscasts-dark .highlight .nt{color:#a5c261}.codeexample-base16-railscasts-dark .highlight .nv{color:#e6e1dc}.codeexample-base16-railscasts-dark .highlight .ow{color:#ffc66d}.codeexample-base16-railscasts-dark .highlight .w{color:#b6b3eb}.codeexample-base16-railscasts-dark .highlight .mf{color:#b6b3eb}.codeexample-base16-railscasts-dark .highlight .mh{color:#b6b3eb}.codeexample-base16-railscasts-dark .highlight .mi{color:#b6b3eb}.codeexample-base16-railscasts-dark .highlight .mo{color:#b6b3eb}.codeexample-base16-railscasts-dark .highlight .sb{color:#519f50}.codeexample-base16-railscasts-dark .highlight .sc{color:#519f50}.codeexample-base16-railscasts-dark .highlight .sd{color:#519f50}.codeexample-base16-railscasts-dark .highlight .s2{color:#519f50}.codeexample-base16-railscasts-dark .highlight .se{color:#519f50}.codeexample-base16-railscasts-dark .highlight .sh{color:#519f50}.codeexample-base16-railscasts-dark .highlight .si{color:#519f50}.codeexample-base16-railscasts-dark .highlight .sx{color:#519f50}.codeexample-base16-railscasts-dark .highlight .sr{color:#519f50}.codeexample-base16-railscasts-dark .highlight .s1{color:#519f50}.codeexample-base16-railscasts-dark .highlight .ss{color:#519f50}.codeexample-base16-railscasts-dark .highlight .bp{color:#6d9cbe}.codeexample-base16-railscasts-dark .highlight .vc{color:#6d9cbe}.codeexample-base16-railscasts-dark .highlight .vg{color:#e6e1dc}.codeexample-base16-railscasts-dark .highlight .vi{color:#ffc66d}.codeexample-base16-railscasts-dark .highlight .il{color:#b6b3eb}</style><div class="codeexample codeexample-base16-railscasts-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-railscasts-light">Base16 Railscasts Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#3a4055"></div><div class="preview-color" style="background-color:#2b2b2b"></div><div class="preview-color" style="background-color:#da4939"></div><div class="preview-color" style="background-color:#a5c261"></div><div class="preview-color" style="background-color:#ffc66d"></div><div class="preview-color" style="background-color:#6d9cbe"></div><div class="preview-color" style="background-color:#b6b3eb"></div><div class="preview-color" style="background-color:#519f50"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#f9f7f3"></div><div class="preview-color" style="background-color:#5a647e"></div><div class="preview-color" style="background-color:#da4939"></div><div class="preview-color" style="background-color:#a5c261"></div><div class="preview-color" style="background-color:#ffc66d"></div><div class="preview-color" style="background-color:#6d9cbe"></div><div class="preview-color" style="background-color:#b6b3eb"></div><div class="preview-color" style="background-color:#519f50"></div></div></div><style>.codeexample-base16-railscasts-light .highlight code, .codeexample-base16-railscasts-light .highlight pre{color:#3a4055;background-color:#f9f7f3}.codeexample-base16-railscasts-light .highlight .hll{background-color:#5a647e}.codeexample-base16-railscasts-light .highlight .c{color:#e6e1dc}.codeexample-base16-railscasts-light .highlight .err{color:#a5c261;background-color:#5a647e}.codeexample-base16-railscasts-light .highlight .g{color:#e6e1dc}.codeexample-base16-railscasts-light .highlight .k{color:#6d9cbe}.codeexample-base16-railscasts-light .highlight .l{color:#b6b3eb}.codeexample-base16-railscasts-light .highlight .n{color:#3a4055}.codeexample-base16-railscasts-light .highlight .o{color:#ffc66d}.codeexample-base16-railscasts-light .highlight .x{color:#b6b3eb}.codeexample-base16-railscasts-light .highlight .p{color:#f9f7f3}.codeexample-base16-railscasts-light .highlight .cm{color:#e6e1dc}.codeexample-base16-railscasts-light .highlight .cp{color:#e6e1dc}.codeexample-base16-railscasts-light .highlight .c1{color:#e6e1dc}.codeexample-base16-railscasts-light .highlight .cs{color:#a5c261;font-weight:bold}.codeexample-base16-railscasts-light .highlight .gd{color:#a5c261}.codeexample-base16-railscasts-light .highlight .ge{color:#b6b3eb;font-style:italic}.codeexample-base16-railscasts-light .highlight .gr{color:#a5c261}.codeexample-base16-railscasts-light .highlight .gh{color:#3a4055;font-weight:bold}.codeexample-base16-railscasts-light .highlight .gi{color:#ffc66d}.codeexample-base16-railscasts-light .highlight .go{color:#5a647e}.codeexample-base16-railscasts-light .highlight .gp{color:#3a4055;font-weight:bold}.codeexample-base16-railscasts-light .highlight .gs{color:#b6b3eb;font-weight:bold}.codeexample-base16-railscasts-light .highlight .gu{color:#b6b3eb;font-weight:bold}.codeexample-base16-railscasts-light .highlight .gt{color:#6d9cbe}.codeexample-base16-railscasts-light .highlight .kc{color:#da4939}.codeexample-base16-railscasts-light .highlight .kd{color:#ffc66d}.codeexample-base16-railscasts-light .highlight .kn{color:#6d9cbe;font-weight:bold}.codeexample-base16-railscasts-light .highlight .kp{color:#a5c261}.codeexample-base16-railscasts-light .highlight .kr{color:#a5c261}.codeexample-base16-railscasts-light .highlight .kt{color:#e6e1dc}.codeexample-base16-railscasts-light .highlight .ld{color:#519f50}.codeexample-base16-railscasts-light .highlight .m{color:#b6b3eb}.codeexample-base16-railscasts-light .highlight .s{color:#519f50}.codeexample-base16-railscasts-light .highlight .na{color:#a5c261}.codeexample-base16-railscasts-light .highlight .nb{color:#6d9cbe}.codeexample-base16-railscasts-light .highlight .nc{color:#6d9cbe}.codeexample-base16-railscasts-light .highlight .no{color:#b6b3eb}.codeexample-base16-railscasts-light .highlight .nd{color:#b6b3eb}.codeexample-base16-railscasts-light .highlight .ni{color:#da4939}.codeexample-base16-railscasts-light .highlight .ne{color:#ffc66d;font-weight:bold}.codeexample-base16-railscasts-light .highlight .nf{color:#6d9cbe}.codeexample-base16-railscasts-light .highlight .nl{color:#b6b3eb}.codeexample-base16-railscasts-light .highlight .nn{color:#6d9cbe}.codeexample-base16-railscasts-light .highlight .nx{color:#b6b3eb}.codeexample-base16-railscasts-light .highlight .py{color:#b6b3eb}.codeexample-base16-railscasts-light .highlight .nt{color:#a5c261}.codeexample-base16-railscasts-light .highlight .nv{color:#3a4055}.codeexample-base16-railscasts-light .highlight .ow{color:#ffc66d}.codeexample-base16-railscasts-light .highlight .w{color:#b6b3eb}.codeexample-base16-railscasts-light .highlight .mf{color:#b6b3eb}.codeexample-base16-railscasts-light .highlight .mh{color:#b6b3eb}.codeexample-base16-railscasts-light .highlight .mi{color:#b6b3eb}.codeexample-base16-railscasts-light .highlight .mo{color:#b6b3eb}.codeexample-base16-railscasts-light .highlight .sb{color:#519f50}.codeexample-base16-railscasts-light .highlight .sc{color:#519f50}.codeexample-base16-railscasts-light .highlight .sd{color:#519f50}.codeexample-base16-railscasts-light .highlight .s2{color:#519f50}.codeexample-base16-railscasts-light .highlight .se{color:#519f50}.codeexample-base16-railscasts-light .highlight .sh{color:#519f50}.codeexample-base16-railscasts-light .highlight .si{color:#519f50}.codeexample-base16-railscasts-light .highlight .sx{color:#519f50}.codeexample-base16-railscasts-light .highlight .sr{color:#519f50}.codeexample-base16-railscasts-light .highlight .s1{color:#519f50}.codeexample-base16-railscasts-light .highlight .ss{color:#519f50}.codeexample-base16-railscasts-light .highlight .bp{color:#6d9cbe}.codeexample-base16-railscasts-light .highlight .vc{color:#6d9cbe}.codeexample-base16-railscasts-light .highlight .vg{color:#3a4055}.codeexample-base16-railscasts-light .highlight .vi{color:#ffc66d}.codeexample-base16-railscasts-light .highlight .il{color:#b6b3eb}</style><div class="codeexample codeexample-base16-railscasts-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-shapeshifter-dark">Base16 Shapeshifter Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#ababab"></div><div class="preview-color" style="background-color:#000000"></div><div class="preview-color" style="background-color:#e92f2f"></div><div class="preview-color" style="background-color:#0ed839"></div><div class="preview-color" style="background-color:#dddd13"></div><div class="preview-color" style="background-color:#3b48e3"></div><div class="preview-color" style="background-color:#f996e2"></div><div class="preview-color" style="background-color:#23edda"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#000000"></div><div class="preview-color" style="background-color:#343434"></div><div class="preview-color" style="background-color:#e92f2f"></div><div class="preview-color" style="background-color:#0ed839"></div><div class="preview-color" style="background-color:#dddd13"></div><div class="preview-color" style="background-color:#3b48e3"></div><div class="preview-color" style="background-color:#f996e2"></div><div class="preview-color" style="background-color:#23edda"></div></div></div><style>.codeexample-base16-shapeshifter-dark .highlight code, .codeexample-base16-shapeshifter-dark .highlight pre{color:#ababab;background-color:#000000}.codeexample-base16-shapeshifter-dark .highlight .hll{background-color:#343434}.codeexample-base16-shapeshifter-dark .highlight .c{color:#ababab}.codeexample-base16-shapeshifter-dark .highlight .err{color:#0ed839;background-color:#343434}.codeexample-base16-shapeshifter-dark .highlight .g{color:#ababab}.codeexample-base16-shapeshifter-dark .highlight .k{color:#3b48e3}.codeexample-base16-shapeshifter-dark .highlight .l{color:#f996e2}.codeexample-base16-shapeshifter-dark .highlight .n{color:#ababab}.codeexample-base16-shapeshifter-dark .highlight .o{color:#dddd13}.codeexample-base16-shapeshifter-dark .highlight .x{color:#f996e2}.codeexample-base16-shapeshifter-dark .highlight .p{color:#f9f9f9}.codeexample-base16-shapeshifter-dark .highlight .cm{color:#ababab}.codeexample-base16-shapeshifter-dark .highlight .cp{color:#ababab}.codeexample-base16-shapeshifter-dark .highlight .c1{color:#ababab}.codeexample-base16-shapeshifter-dark .highlight .cs{color:#0ed839;font-weight:bold}.codeexample-base16-shapeshifter-dark .highlight .gd{color:#0ed839}.codeexample-base16-shapeshifter-dark .highlight .ge{color:#f996e2;font-style:italic}.codeexample-base16-shapeshifter-dark .highlight .gr{color:#0ed839}.codeexample-base16-shapeshifter-dark .highlight .gh{color:#ababab;font-weight:bold}.codeexample-base16-shapeshifter-dark .highlight .gi{color:#dddd13}.codeexample-base16-shapeshifter-dark .highlight .go{color:#343434}.codeexample-base16-shapeshifter-dark .highlight .gp{color:#ababab;font-weight:bold}.codeexample-base16-shapeshifter-dark .highlight .gs{color:#f996e2;font-weight:bold}.codeexample-base16-shapeshifter-dark .highlight .gu{color:#f996e2;font-weight:bold}.codeexample-base16-shapeshifter-dark .highlight .gt{color:#3b48e3}.codeexample-base16-shapeshifter-dark .highlight .kc{color:#e92f2f}.codeexample-base16-shapeshifter-dark .highlight .kd{color:#dddd13}.codeexample-base16-shapeshifter-dark .highlight .kn{color:#3b48e3;font-weight:bold}.codeexample-base16-shapeshifter-dark .highlight .kp{color:#0ed839}.codeexample-base16-shapeshifter-dark .highlight .kr{color:#0ed839}.codeexample-base16-shapeshifter-dark .highlight .kt{color:#ababab}.codeexample-base16-shapeshifter-dark .highlight .ld{color:#23edda}.codeexample-base16-shapeshifter-dark .highlight .m{color:#f996e2}.codeexample-base16-shapeshifter-dark .highlight .s{color:#23edda}.codeexample-base16-shapeshifter-dark .highlight .na{color:#0ed839}.codeexample-base16-shapeshifter-dark .highlight .nb{color:#3b48e3}.codeexample-base16-shapeshifter-dark .highlight .nc{color:#3b48e3}.codeexample-base16-shapeshifter-dark .highlight .no{color:#f996e2}.codeexample-base16-shapeshifter-dark .highlight .nd{color:#f996e2}.codeexample-base16-shapeshifter-dark .highlight .ni{color:#e92f2f}.codeexample-base16-shapeshifter-dark .highlight .ne{color:#dddd13;font-weight:bold}.codeexample-base16-shapeshifter-dark .highlight .nf{color:#3b48e3}.codeexample-base16-shapeshifter-dark .highlight .nl{color:#f996e2}.codeexample-base16-shapeshifter-dark .highlight .nn{color:#3b48e3}.codeexample-base16-shapeshifter-dark .highlight .nx{color:#f996e2}.codeexample-base16-shapeshifter-dark .highlight .py{color:#f996e2}.codeexample-base16-shapeshifter-dark .highlight .nt{color:#0ed839}.codeexample-base16-shapeshifter-dark .highlight .nv{color:#ababab}.codeexample-base16-shapeshifter-dark .highlight .ow{color:#dddd13}.codeexample-base16-shapeshifter-dark .highlight .w{color:#f996e2}.codeexample-base16-shapeshifter-dark .highlight .mf{color:#f996e2}.codeexample-base16-shapeshifter-dark .highlight .mh{color:#f996e2}.codeexample-base16-shapeshifter-dark .highlight .mi{color:#f996e2}.codeexample-base16-shapeshifter-dark .highlight .mo{color:#f996e2}.codeexample-base16-shapeshifter-dark .highlight .sb{color:#23edda}.codeexample-base16-shapeshifter-dark .highlight .sc{color:#23edda}.codeexample-base16-shapeshifter-dark .highlight .sd{color:#23edda}.codeexample-base16-shapeshifter-dark .highlight .s2{color:#23edda}.codeexample-base16-shapeshifter-dark .highlight .se{color:#23edda}.codeexample-base16-shapeshifter-dark .highlight .sh{color:#23edda}.codeexample-base16-shapeshifter-dark .highlight .si{color:#23edda}.codeexample-base16-shapeshifter-dark .highlight .sx{color:#23edda}.codeexample-base16-shapeshifter-dark .highlight .sr{color:#23edda}.codeexample-base16-shapeshifter-dark .highlight .s1{color:#23edda}.codeexample-base16-shapeshifter-dark .highlight .ss{color:#23edda}.codeexample-base16-shapeshifter-dark .highlight .bp{color:#3b48e3}.codeexample-base16-shapeshifter-dark .highlight .vc{color:#3b48e3}.codeexample-base16-shapeshifter-dark .highlight .vg{color:#ababab}.codeexample-base16-shapeshifter-dark .highlight .vi{color:#dddd13}.codeexample-base16-shapeshifter-dark .highlight .il{color:#f996e2}</style><div class="codeexample codeexample-base16-shapeshifter-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-shapeshifter-light">Base16 Shapeshifter Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#102015"></div><div class="preview-color" style="background-color:#000000"></div><div class="preview-color" style="background-color:#e92f2f"></div><div class="preview-color" style="background-color:#0ed839"></div><div class="preview-color" style="background-color:#dddd13"></div><div class="preview-color" style="background-color:#3b48e3"></div><div class="preview-color" style="background-color:#f996e2"></div><div class="preview-color" style="background-color:#23edda"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#f9f9f9"></div><div class="preview-color" style="background-color:#343434"></div><div class="preview-color" style="background-color:#e92f2f"></div><div class="preview-color" style="background-color:#0ed839"></div><div class="preview-color" style="background-color:#dddd13"></div><div class="preview-color" style="background-color:#3b48e3"></div><div class="preview-color" style="background-color:#f996e2"></div><div class="preview-color" style="background-color:#23edda"></div></div></div><style>.codeexample-base16-shapeshifter-light .highlight code, .codeexample-base16-shapeshifter-light .highlight pre{color:#102015;background-color:#f9f9f9}.codeexample-base16-shapeshifter-light .highlight .hll{background-color:#343434}.codeexample-base16-shapeshifter-light .highlight .c{color:#ababab}.codeexample-base16-shapeshifter-light .highlight .err{color:#0ed839;background-color:#343434}.codeexample-base16-shapeshifter-light .highlight .g{color:#ababab}.codeexample-base16-shapeshifter-light .highlight .k{color:#3b48e3}.codeexample-base16-shapeshifter-light .highlight .l{color:#f996e2}.codeexample-base16-shapeshifter-light .highlight .n{color:#102015}.codeexample-base16-shapeshifter-light .highlight .o{color:#dddd13}.codeexample-base16-shapeshifter-light .highlight .x{color:#f996e2}.codeexample-base16-shapeshifter-light .highlight .p{color:#f9f9f9}.codeexample-base16-shapeshifter-light .highlight .cm{color:#ababab}.codeexample-base16-shapeshifter-light .highlight .cp{color:#ababab}.codeexample-base16-shapeshifter-light .highlight .c1{color:#ababab}.codeexample-base16-shapeshifter-light .highlight .cs{color:#0ed839;font-weight:bold}.codeexample-base16-shapeshifter-light .highlight .gd{color:#0ed839}.codeexample-base16-shapeshifter-light .highlight .ge{color:#f996e2;font-style:italic}.codeexample-base16-shapeshifter-light .highlight .gr{color:#0ed839}.codeexample-base16-shapeshifter-light .highlight .gh{color:#102015;font-weight:bold}.codeexample-base16-shapeshifter-light .highlight .gi{color:#dddd13}.codeexample-base16-shapeshifter-light .highlight .go{color:#343434}.codeexample-base16-shapeshifter-light .highlight .gp{color:#102015;font-weight:bold}.codeexample-base16-shapeshifter-light .highlight .gs{color:#f996e2;font-weight:bold}.codeexample-base16-shapeshifter-light .highlight .gu{color:#f996e2;font-weight:bold}.codeexample-base16-shapeshifter-light .highlight .gt{color:#3b48e3}.codeexample-base16-shapeshifter-light .highlight .kc{color:#e92f2f}.codeexample-base16-shapeshifter-light .highlight .kd{color:#dddd13}.codeexample-base16-shapeshifter-light .highlight .kn{color:#3b48e3;font-weight:bold}.codeexample-base16-shapeshifter-light .highlight .kp{color:#0ed839}.codeexample-base16-shapeshifter-light .highlight .kr{color:#0ed839}.codeexample-base16-shapeshifter-light .highlight .kt{color:#ababab}.codeexample-base16-shapeshifter-light .highlight .ld{color:#23edda}.codeexample-base16-shapeshifter-light .highlight .m{color:#f996e2}.codeexample-base16-shapeshifter-light .highlight .s{color:#23edda}.codeexample-base16-shapeshifter-light .highlight .na{color:#0ed839}.codeexample-base16-shapeshifter-light .highlight .nb{color:#3b48e3}.codeexample-base16-shapeshifter-light .highlight .nc{color:#3b48e3}.codeexample-base16-shapeshifter-light .highlight .no{color:#f996e2}.codeexample-base16-shapeshifter-light .highlight .nd{color:#f996e2}.codeexample-base16-shapeshifter-light .highlight .ni{color:#e92f2f}.codeexample-base16-shapeshifter-light .highlight .ne{color:#dddd13;font-weight:bold}.codeexample-base16-shapeshifter-light .highlight .nf{color:#3b48e3}.codeexample-base16-shapeshifter-light .highlight .nl{color:#f996e2}.codeexample-base16-shapeshifter-light .highlight .nn{color:#3b48e3}.codeexample-base16-shapeshifter-light .highlight .nx{color:#f996e2}.codeexample-base16-shapeshifter-light .highlight .py{color:#f996e2}.codeexample-base16-shapeshifter-light .highlight .nt{color:#0ed839}.codeexample-base16-shapeshifter-light .highlight .nv{color:#102015}.codeexample-base16-shapeshifter-light .highlight .ow{color:#dddd13}.codeexample-base16-shapeshifter-light .highlight .w{color:#f996e2}.codeexample-base16-shapeshifter-light .highlight .mf{color:#f996e2}.codeexample-base16-shapeshifter-light .highlight .mh{color:#f996e2}.codeexample-base16-shapeshifter-light .highlight .mi{color:#f996e2}.codeexample-base16-shapeshifter-light .highlight .mo{color:#f996e2}.codeexample-base16-shapeshifter-light .highlight .sb{color:#23edda}.codeexample-base16-shapeshifter-light .highlight .sc{color:#23edda}.codeexample-base16-shapeshifter-light .highlight .sd{color:#23edda}.codeexample-base16-shapeshifter-light .highlight .s2{color:#23edda}.codeexample-base16-shapeshifter-light .highlight .se{color:#23edda}.codeexample-base16-shapeshifter-light .highlight .sh{color:#23edda}.codeexample-base16-shapeshifter-light .highlight .si{color:#23edda}.codeexample-base16-shapeshifter-light .highlight .sx{color:#23edda}.codeexample-base16-shapeshifter-light .highlight .sr{color:#23edda}.codeexample-base16-shapeshifter-light .highlight .s1{color:#23edda}.codeexample-base16-shapeshifter-light .highlight .ss{color:#23edda}.codeexample-base16-shapeshifter-light .highlight .bp{color:#3b48e3}.codeexample-base16-shapeshifter-light .highlight .vc{color:#3b48e3}.codeexample-base16-shapeshifter-light .highlight .vg{color:#102015}.codeexample-base16-shapeshifter-light .highlight .vi{color:#dddd13}.codeexample-base16-shapeshifter-light .highlight .il{color:#f996e2}</style><div class="codeexample codeexample-base16-shapeshifter-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-solarized-dark">Base16 Solarized Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#93a1a1"></div><div class="preview-color" style="background-color:#002b36"></div><div class="preview-color" style="background-color:#dc322f"></div><div class="preview-color" style="background-color:#859900"></div><div class="preview-color" style="background-color:#b58900"></div><div class="preview-color" style="background-color:#268bd2"></div><div class="preview-color" style="background-color:#6c71c4"></div><div class="preview-color" style="background-color:#2aa198"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#002b36"></div><div class="preview-color" style="background-color:#657b83"></div><div class="preview-color" style="background-color:#dc322f"></div><div class="preview-color" style="background-color:#859900"></div><div class="preview-color" style="background-color:#b58900"></div><div class="preview-color" style="background-color:#268bd2"></div><div class="preview-color" style="background-color:#6c71c4"></div><div class="preview-color" style="background-color:#2aa198"></div></div></div><style>.codeexample-base16-solarized-dark .highlight code, .codeexample-base16-solarized-dark .highlight pre{color:#93a1a1;background-color:#002b36}.codeexample-base16-solarized-dark .highlight .hll{background-color:#657b83}.codeexample-base16-solarized-dark .highlight .c{color:#93a1a1}.codeexample-base16-solarized-dark .highlight .err{color:#859900;background-color:#657b83}.codeexample-base16-solarized-dark .highlight .g{color:#93a1a1}.codeexample-base16-solarized-dark .highlight .k{color:#268bd2}.codeexample-base16-solarized-dark .highlight .l{color:#6c71c4}.codeexample-base16-solarized-dark .highlight .n{color:#93a1a1}.codeexample-base16-solarized-dark .highlight .o{color:#b58900}.codeexample-base16-solarized-dark .highlight .x{color:#6c71c4}.codeexample-base16-solarized-dark .highlight .p{color:#fdf6e3}.codeexample-base16-solarized-dark .highlight .cm{color:#93a1a1}.codeexample-base16-solarized-dark .highlight .cp{color:#93a1a1}.codeexample-base16-solarized-dark .highlight .c1{color:#93a1a1}.codeexample-base16-solarized-dark .highlight .cs{color:#859900;font-weight:bold}.codeexample-base16-solarized-dark .highlight .gd{color:#859900}.codeexample-base16-solarized-dark .highlight .ge{color:#6c71c4;font-style:italic}.codeexample-base16-solarized-dark .highlight .gr{color:#859900}.codeexample-base16-solarized-dark .highlight .gh{color:#93a1a1;font-weight:bold}.codeexample-base16-solarized-dark .highlight .gi{color:#b58900}.codeexample-base16-solarized-dark .highlight .go{color:#657b83}.codeexample-base16-solarized-dark .highlight .gp{color:#93a1a1;font-weight:bold}.codeexample-base16-solarized-dark .highlight .gs{color:#6c71c4;font-weight:bold}.codeexample-base16-solarized-dark .highlight .gu{color:#6c71c4;font-weight:bold}.codeexample-base16-solarized-dark .highlight .gt{color:#268bd2}.codeexample-base16-solarized-dark .highlight .kc{color:#dc322f}.codeexample-base16-solarized-dark .highlight .kd{color:#b58900}.codeexample-base16-solarized-dark .highlight .kn{color:#268bd2;font-weight:bold}.codeexample-base16-solarized-dark .highlight .kp{color:#859900}.codeexample-base16-solarized-dark .highlight .kr{color:#859900}.codeexample-base16-solarized-dark .highlight .kt{color:#93a1a1}.codeexample-base16-solarized-dark .highlight .ld{color:#2aa198}.codeexample-base16-solarized-dark .highlight .m{color:#6c71c4}.codeexample-base16-solarized-dark .highlight .s{color:#2aa198}.codeexample-base16-solarized-dark .highlight .na{color:#859900}.codeexample-base16-solarized-dark .highlight .nb{color:#268bd2}.codeexample-base16-solarized-dark .highlight .nc{color:#268bd2}.codeexample-base16-solarized-dark .highlight .no{color:#6c71c4}.codeexample-base16-solarized-dark .highlight .nd{color:#6c71c4}.codeexample-base16-solarized-dark .highlight .ni{color:#dc322f}.codeexample-base16-solarized-dark .highlight .ne{color:#b58900;font-weight:bold}.codeexample-base16-solarized-dark .highlight .nf{color:#268bd2}.codeexample-base16-solarized-dark .highlight .nl{color:#6c71c4}.codeexample-base16-solarized-dark .highlight .nn{color:#268bd2}.codeexample-base16-solarized-dark .highlight .nx{color:#6c71c4}.codeexample-base16-solarized-dark .highlight .py{color:#6c71c4}.codeexample-base16-solarized-dark .highlight .nt{color:#859900}.codeexample-base16-solarized-dark .highlight .nv{color:#93a1a1}.codeexample-base16-solarized-dark .highlight .ow{color:#b58900}.codeexample-base16-solarized-dark .highlight .w{color:#6c71c4}.codeexample-base16-solarized-dark .highlight .mf{color:#6c71c4}.codeexample-base16-solarized-dark .highlight .mh{color:#6c71c4}.codeexample-base16-solarized-dark .highlight .mi{color:#6c71c4}.codeexample-base16-solarized-dark .highlight .mo{color:#6c71c4}.codeexample-base16-solarized-dark .highlight .sb{color:#2aa198}.codeexample-base16-solarized-dark .highlight .sc{color:#2aa198}.codeexample-base16-solarized-dark .highlight .sd{color:#2aa198}.codeexample-base16-solarized-dark .highlight .s2{color:#2aa198}.codeexample-base16-solarized-dark .highlight .se{color:#2aa198}.codeexample-base16-solarized-dark .highlight .sh{color:#2aa198}.codeexample-base16-solarized-dark .highlight .si{color:#2aa198}.codeexample-base16-solarized-dark .highlight .sx{color:#2aa198}.codeexample-base16-solarized-dark .highlight .sr{color:#2aa198}.codeexample-base16-solarized-dark .highlight .s1{color:#2aa198}.codeexample-base16-solarized-dark .highlight .ss{color:#2aa198}.codeexample-base16-solarized-dark .highlight .bp{color:#268bd2}.codeexample-base16-solarized-dark .highlight .vc{color:#268bd2}.codeexample-base16-solarized-dark .highlight .vg{color:#93a1a1}.codeexample-base16-solarized-dark .highlight .vi{color:#b58900}.codeexample-base16-solarized-dark .highlight .il{color:#6c71c4}</style><div class="codeexample codeexample-base16-solarized-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-solarized-light">Base16 Solarized Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#586e75"></div><div class="preview-color" style="background-color:#002b36"></div><div class="preview-color" style="background-color:#dc322f"></div><div class="preview-color" style="background-color:#859900"></div><div class="preview-color" style="background-color:#b58900"></div><div class="preview-color" style="background-color:#268bd2"></div><div class="preview-color" style="background-color:#6c71c4"></div><div class="preview-color" style="background-color:#2aa198"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#fdf6e3"></div><div class="preview-color" style="background-color:#657b83"></div><div class="preview-color" style="background-color:#cb4b16"></div><div class="preview-color" style="background-color:#073642"></div><div class="preview-color" style="background-color:#586e75"></div><div class="preview-color" style="background-color:#839496"></div><div class="preview-color" style="background-color:#eee8d5"></div><div class="preview-color" style="background-color:#d33682"></div></div></div><style>.codeexample-base16-solarized-light .highlight code, .codeexample-base16-solarized-light .highlight pre{color:#586e75;background-color:#fdf6e3}.codeexample-base16-solarized-light .highlight .hll{background-color:#657b83}.codeexample-base16-solarized-light .highlight .c{color:#93a1a1}.codeexample-base16-solarized-light .highlight .err{color:#073642;background-color:#657b83}.codeexample-base16-solarized-light .highlight .g{color:#93a1a1}.codeexample-base16-solarized-light .highlight .k{color:#268bd2}.codeexample-base16-solarized-light .highlight .l{color:#6c71c4}.codeexample-base16-solarized-light .highlight .n{color:#586e75}.codeexample-base16-solarized-light .highlight .o{color:#586e75}.codeexample-base16-solarized-light .highlight .x{color:#6c71c4}.codeexample-base16-solarized-light .highlight .p{color:#fdf6e3}.codeexample-base16-solarized-light .highlight .cm{color:#93a1a1}.codeexample-base16-solarized-light .highlight .cp{color:#93a1a1}.codeexample-base16-solarized-light .highlight .c1{color:#93a1a1}.codeexample-base16-solarized-light .highlight .cs{color:#859900;font-weight:bold}.codeexample-base16-solarized-light .highlight .gd{color:#859900}.codeexample-base16-solarized-light .highlight .ge{color:#6c71c4;font-style:italic}.codeexample-base16-solarized-light .highlight .gr{color:#859900}.codeexample-base16-solarized-light .highlight .gh{color:#586e75;font-weight:bold}.codeexample-base16-solarized-light .highlight .gi{color:#586e75}.codeexample-base16-solarized-light .highlight .go{color:#657b83}.codeexample-base16-solarized-light .highlight .gp{color:#586e75;font-weight:bold}.codeexample-base16-solarized-light .highlight .gs{color:#6c71c4;font-weight:bold}.codeexample-base16-solarized-light .highlight .gu{color:#6c71c4;font-weight:bold}.codeexample-base16-solarized-light .highlight .gt{color:#839496}.codeexample-base16-solarized-light .highlight .kc{color:#cb4b16}.codeexample-base16-solarized-light .highlight .kd{color:#586e75}.codeexample-base16-solarized-light .highlight .kn{color:#268bd2;font-weight:bold}.codeexample-base16-solarized-light .highlight .kp{color:#859900}.codeexample-base16-solarized-light .highlight .kr{color:#073642}.codeexample-base16-solarized-light .highlight .kt{color:#93a1a1}.codeexample-base16-solarized-light .highlight .ld{color:#d33682}.codeexample-base16-solarized-light .highlight .m{color:#eee8d5}.codeexample-base16-solarized-light .highlight .s{color:#d33682}.codeexample-base16-solarized-light .highlight .na{color:#859900}.codeexample-base16-solarized-light .highlight .nb{color:#839496}.codeexample-base16-solarized-light .highlight .nc{color:#839496}.codeexample-base16-solarized-light .highlight .no{color:#6c71c4}.codeexample-base16-solarized-light .highlight .nd{color:#6c71c4}.codeexample-base16-solarized-light .highlight .ni{color:#cb4b16}.codeexample-base16-solarized-light .highlight .ne{color:#b58900;font-weight:bold}.codeexample-base16-solarized-light .highlight .nf{color:#839496}.codeexample-base16-solarized-light .highlight .nl{color:#6c71c4}.codeexample-base16-solarized-light .highlight .nn{color:#839496}.codeexample-base16-solarized-light .highlight .nx{color:#6c71c4}.codeexample-base16-solarized-light .highlight .py{color:#6c71c4}.codeexample-base16-solarized-light .highlight .nt{color:#859900}.codeexample-base16-solarized-light .highlight .nv{color:#586e75}.codeexample-base16-solarized-light .highlight .ow{color:#586e75}.codeexample-base16-solarized-light .highlight .w{color:#6c71c4}.codeexample-base16-solarized-light .highlight .mf{color:#eee8d5}.codeexample-base16-solarized-light .highlight .mh{color:#eee8d5}.codeexample-base16-solarized-light .highlight .mi{color:#eee8d5}.codeexample-base16-solarized-light .highlight .mo{color:#eee8d5}.codeexample-base16-solarized-light .highlight .sb{color:#d33682}.codeexample-base16-solarized-light .highlight .sc{color:#d33682}.codeexample-base16-solarized-light .highlight .sd{color:#d33682}.codeexample-base16-solarized-light .highlight .s2{color:#d33682}.codeexample-base16-solarized-light .highlight .se{color:#d33682}.codeexample-base16-solarized-light .highlight .sh{color:#d33682}.codeexample-base16-solarized-light .highlight .si{color:#d33682}.codeexample-base16-solarized-light .highlight .sx{color:#d33682}.codeexample-base16-solarized-light .highlight .sr{color:#d33682}.codeexample-base16-solarized-light .highlight .s1{color:#d33682}.codeexample-base16-solarized-light .highlight .ss{color:#d33682}.codeexample-base16-solarized-light .highlight .bp{color:#839496}.codeexample-base16-solarized-light .highlight .vc{color:#839496}.codeexample-base16-solarized-light .highlight .vg{color:#586e75}.codeexample-base16-solarized-light .highlight .vi{color:#586e75}.codeexample-base16-solarized-light .highlight .il{color:#eee8d5}</style><div class="codeexample codeexample-base16-solarized-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-summerfruit-dark">Base16 Summerfruit Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#D0D0D0"></div><div class="preview-color" style="background-color:#151515"></div><div class="preview-color" style="background-color:#FF0086"></div><div class="preview-color" style="background-color:#00C918"></div><div class="preview-color" style="background-color:#ABA800"></div><div class="preview-color" style="background-color:#3777E6"></div><div class="preview-color" style="background-color:#AD00A1"></div><div class="preview-color" style="background-color:#1faaaa"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#151515"></div><div class="preview-color" style="background-color:#505050"></div><div class="preview-color" style="background-color:#FF0086"></div><div class="preview-color" style="background-color:#00C918"></div><div class="preview-color" style="background-color:#ABA800"></div><div class="preview-color" style="background-color:#3777E6"></div><div class="preview-color" style="background-color:#AD00A1"></div><div class="preview-color" style="background-color:#1faaaa"></div></div></div><style>.codeexample-base16-summerfruit-dark .highlight code, .codeexample-base16-summerfruit-dark .highlight pre{color:#D0D0D0;background-color:#151515}.codeexample-base16-summerfruit-dark .highlight .hll{background-color:#505050}.codeexample-base16-summerfruit-dark .highlight .c{color:#D0D0D0}.codeexample-base16-summerfruit-dark .highlight .err{color:#00C918;background-color:#505050}.codeexample-base16-summerfruit-dark .highlight .g{color:#D0D0D0}.codeexample-base16-summerfruit-dark .highlight .k{color:#3777E6}.codeexample-base16-summerfruit-dark .highlight .l{color:#AD00A1}.codeexample-base16-summerfruit-dark .highlight .n{color:#D0D0D0}.codeexample-base16-summerfruit-dark .highlight .o{color:#ABA800}.codeexample-base16-summerfruit-dark .highlight .x{color:#AD00A1}.codeexample-base16-summerfruit-dark .highlight .p{color:#FFFFFF}.codeexample-base16-summerfruit-dark .highlight .cm{color:#D0D0D0}.codeexample-base16-summerfruit-dark .highlight .cp{color:#D0D0D0}.codeexample-base16-summerfruit-dark .highlight .c1{color:#D0D0D0}.codeexample-base16-summerfruit-dark .highlight .cs{color:#00C918;font-weight:bold}.codeexample-base16-summerfruit-dark .highlight .gd{color:#00C918}.codeexample-base16-summerfruit-dark .highlight .ge{color:#AD00A1;font-style:italic}.codeexample-base16-summerfruit-dark .highlight .gr{color:#00C918}.codeexample-base16-summerfruit-dark .highlight .gh{color:#D0D0D0;font-weight:bold}.codeexample-base16-summerfruit-dark .highlight .gi{color:#ABA800}.codeexample-base16-summerfruit-dark .highlight .go{color:#505050}.codeexample-base16-summerfruit-dark .highlight .gp{color:#D0D0D0;font-weight:bold}.codeexample-base16-summerfruit-dark .highlight .gs{color:#AD00A1;font-weight:bold}.codeexample-base16-summerfruit-dark .highlight .gu{color:#AD00A1;font-weight:bold}.codeexample-base16-summerfruit-dark .highlight .gt{color:#3777E6}.codeexample-base16-summerfruit-dark .highlight .kc{color:#FF0086}.codeexample-base16-summerfruit-dark .highlight .kd{color:#ABA800}.codeexample-base16-summerfruit-dark .highlight .kn{color:#3777E6;font-weight:bold}.codeexample-base16-summerfruit-dark .highlight .kp{color:#00C918}.codeexample-base16-summerfruit-dark .highlight .kr{color:#00C918}.codeexample-base16-summerfruit-dark .highlight .kt{color:#D0D0D0}.codeexample-base16-summerfruit-dark .highlight .ld{color:#1faaaa}.codeexample-base16-summerfruit-dark .highlight .m{color:#AD00A1}.codeexample-base16-summerfruit-dark .highlight .s{color:#1faaaa}.codeexample-base16-summerfruit-dark .highlight .na{color:#00C918}.codeexample-base16-summerfruit-dark .highlight .nb{color:#3777E6}.codeexample-base16-summerfruit-dark .highlight .nc{color:#3777E6}.codeexample-base16-summerfruit-dark .highlight .no{color:#AD00A1}.codeexample-base16-summerfruit-dark .highlight .nd{color:#AD00A1}.codeexample-base16-summerfruit-dark .highlight .ni{color:#FF0086}.codeexample-base16-summerfruit-dark .highlight .ne{color:#ABA800;font-weight:bold}.codeexample-base16-summerfruit-dark .highlight .nf{color:#3777E6}.codeexample-base16-summerfruit-dark .highlight .nl{color:#AD00A1}.codeexample-base16-summerfruit-dark .highlight .nn{color:#3777E6}.codeexample-base16-summerfruit-dark .highlight .nx{color:#AD00A1}.codeexample-base16-summerfruit-dark .highlight .py{color:#AD00A1}.codeexample-base16-summerfruit-dark .highlight .nt{color:#00C918}.codeexample-base16-summerfruit-dark .highlight .nv{color:#D0D0D0}.codeexample-base16-summerfruit-dark .highlight .ow{color:#ABA800}.codeexample-base16-summerfruit-dark .highlight .w{color:#AD00A1}.codeexample-base16-summerfruit-dark .highlight .mf{color:#AD00A1}.codeexample-base16-summerfruit-dark .highlight .mh{color:#AD00A1}.codeexample-base16-summerfruit-dark .highlight .mi{color:#AD00A1}.codeexample-base16-summerfruit-dark .highlight .mo{color:#AD00A1}.codeexample-base16-summerfruit-dark .highlight .sb{color:#1faaaa}.codeexample-base16-summerfruit-dark .highlight .sc{color:#1faaaa}.codeexample-base16-summerfruit-dark .highlight .sd{color:#1faaaa}.codeexample-base16-summerfruit-dark .highlight .s2{color:#1faaaa}.codeexample-base16-summerfruit-dark .highlight .se{color:#1faaaa}.codeexample-base16-summerfruit-dark .highlight .sh{color:#1faaaa}.codeexample-base16-summerfruit-dark .highlight .si{color:#1faaaa}.codeexample-base16-summerfruit-dark .highlight .sx{color:#1faaaa}.codeexample-base16-summerfruit-dark .highlight .sr{color:#1faaaa}.codeexample-base16-summerfruit-dark .highlight .s1{color:#1faaaa}.codeexample-base16-summerfruit-dark .highlight .ss{color:#1faaaa}.codeexample-base16-summerfruit-dark .highlight .bp{color:#3777E6}.codeexample-base16-summerfruit-dark .highlight .vc{color:#3777E6}.codeexample-base16-summerfruit-dark .highlight .vg{color:#D0D0D0}.codeexample-base16-summerfruit-dark .highlight .vi{color:#ABA800}.codeexample-base16-summerfruit-dark .highlight .il{color:#AD00A1}</style><div class="codeexample codeexample-base16-summerfruit-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-summerfruit-light">Base16 Summerfruit Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#303030"></div><div class="preview-color" style="background-color:#151515"></div><div class="preview-color" style="background-color:#FF0086"></div><div class="preview-color" style="background-color:#00C918"></div><div class="preview-color" style="background-color:#ABA800"></div><div class="preview-color" style="background-color:#3777E6"></div><div class="preview-color" style="background-color:#AD00A1"></div><div class="preview-color" style="background-color:#1faaaa"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#FFFFFF"></div><div class="preview-color" style="background-color:#505050"></div><div class="preview-color" style="background-color:#FF0086"></div><div class="preview-color" style="background-color:#00C918"></div><div class="preview-color" style="background-color:#ABA800"></div><div class="preview-color" style="background-color:#3777E6"></div><div class="preview-color" style="background-color:#AD00A1"></div><div class="preview-color" style="background-color:#1faaaa"></div></div></div><style>.codeexample-base16-summerfruit-light .highlight code, .codeexample-base16-summerfruit-light .highlight pre{color:#303030;background-color:#FFFFFF}.codeexample-base16-summerfruit-light .highlight .hll{background-color:#505050}.codeexample-base16-summerfruit-light .highlight .c{color:#D0D0D0}.codeexample-base16-summerfruit-light .highlight .err{color:#00C918;background-color:#505050}.codeexample-base16-summerfruit-light .highlight .g{color:#D0D0D0}.codeexample-base16-summerfruit-light .highlight .k{color:#3777E6}.codeexample-base16-summerfruit-light .highlight .l{color:#AD00A1}.codeexample-base16-summerfruit-light .highlight .n{color:#303030}.codeexample-base16-summerfruit-light .highlight .o{color:#ABA800}.codeexample-base16-summerfruit-light .highlight .x{color:#AD00A1}.codeexample-base16-summerfruit-light .highlight .p{color:#FFFFFF}.codeexample-base16-summerfruit-light .highlight .cm{color:#D0D0D0}.codeexample-base16-summerfruit-light .highlight .cp{color:#D0D0D0}.codeexample-base16-summerfruit-light .highlight .c1{color:#D0D0D0}.codeexample-base16-summerfruit-light .highlight .cs{color:#00C918;font-weight:bold}.codeexample-base16-summerfruit-light .highlight .gd{color:#00C918}.codeexample-base16-summerfruit-light .highlight .ge{color:#AD00A1;font-style:italic}.codeexample-base16-summerfruit-light .highlight .gr{color:#00C918}.codeexample-base16-summerfruit-light .highlight .gh{color:#303030;font-weight:bold}.codeexample-base16-summerfruit-light .highlight .gi{color:#ABA800}.codeexample-base16-summerfruit-light .highlight .go{color:#505050}.codeexample-base16-summerfruit-light .highlight .gp{color:#303030;font-weight:bold}.codeexample-base16-summerfruit-light .highlight .gs{color:#AD00A1;font-weight:bold}.codeexample-base16-summerfruit-light .highlight .gu{color:#AD00A1;font-weight:bold}.codeexample-base16-summerfruit-light .highlight .gt{color:#3777E6}.codeexample-base16-summerfruit-light .highlight .kc{color:#FF0086}.codeexample-base16-summerfruit-light .highlight .kd{color:#ABA800}.codeexample-base16-summerfruit-light .highlight .kn{color:#3777E6;font-weight:bold}.codeexample-base16-summerfruit-light .highlight .kp{color:#00C918}.codeexample-base16-summerfruit-light .highlight .kr{color:#00C918}.codeexample-base16-summerfruit-light .highlight .kt{color:#D0D0D0}.codeexample-base16-summerfruit-light .highlight .ld{color:#1faaaa}.codeexample-base16-summerfruit-light .highlight .m{color:#AD00A1}.codeexample-base16-summerfruit-light .highlight .s{color:#1faaaa}.codeexample-base16-summerfruit-light .highlight .na{color:#00C918}.codeexample-base16-summerfruit-light .highlight .nb{color:#3777E6}.codeexample-base16-summerfruit-light .highlight .nc{color:#3777E6}.codeexample-base16-summerfruit-light .highlight .no{color:#AD00A1}.codeexample-base16-summerfruit-light .highlight .nd{color:#AD00A1}.codeexample-base16-summerfruit-light .highlight .ni{color:#FF0086}.codeexample-base16-summerfruit-light .highlight .ne{color:#ABA800;font-weight:bold}.codeexample-base16-summerfruit-light .highlight .nf{color:#3777E6}.codeexample-base16-summerfruit-light .highlight .nl{color:#AD00A1}.codeexample-base16-summerfruit-light .highlight .nn{color:#3777E6}.codeexample-base16-summerfruit-light .highlight .nx{color:#AD00A1}.codeexample-base16-summerfruit-light .highlight .py{color:#AD00A1}.codeexample-base16-summerfruit-light .highlight .nt{color:#00C918}.codeexample-base16-summerfruit-light .highlight .nv{color:#303030}.codeexample-base16-summerfruit-light .highlight .ow{color:#ABA800}.codeexample-base16-summerfruit-light .highlight .w{color:#AD00A1}.codeexample-base16-summerfruit-light .highlight .mf{color:#AD00A1}.codeexample-base16-summerfruit-light .highlight .mh{color:#AD00A1}.codeexample-base16-summerfruit-light .highlight .mi{color:#AD00A1}.codeexample-base16-summerfruit-light .highlight .mo{color:#AD00A1}.codeexample-base16-summerfruit-light .highlight .sb{color:#1faaaa}.codeexample-base16-summerfruit-light .highlight .sc{color:#1faaaa}.codeexample-base16-summerfruit-light .highlight .sd{color:#1faaaa}.codeexample-base16-summerfruit-light .highlight .s2{color:#1faaaa}.codeexample-base16-summerfruit-light .highlight .se{color:#1faaaa}.codeexample-base16-summerfruit-light .highlight .sh{color:#1faaaa}.codeexample-base16-summerfruit-light .highlight .si{color:#1faaaa}.codeexample-base16-summerfruit-light .highlight .sx{color:#1faaaa}.codeexample-base16-summerfruit-light .highlight .sr{color:#1faaaa}.codeexample-base16-summerfruit-light .highlight .s1{color:#1faaaa}.codeexample-base16-summerfruit-light .highlight .ss{color:#1faaaa}.codeexample-base16-summerfruit-light .highlight .bp{color:#3777E6}.codeexample-base16-summerfruit-light .highlight .vc{color:#3777E6}.codeexample-base16-summerfruit-light .highlight .vg{color:#303030}.codeexample-base16-summerfruit-light .highlight .vi{color:#ABA800}.codeexample-base16-summerfruit-light .highlight .il{color:#AD00A1}</style><div class="codeexample codeexample-base16-summerfruit-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-tomorrow-dark">Base16 Tomorrow Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#c5c8c6"></div><div class="preview-color" style="background-color:#1d1f21"></div><div class="preview-color" style="background-color:#cc6666"></div><div class="preview-color" style="background-color:#b5bd68"></div><div class="preview-color" style="background-color:#f0c674"></div><div class="preview-color" style="background-color:#81a2be"></div><div class="preview-color" style="background-color:#b294bb"></div><div class="preview-color" style="background-color:#8abeb7"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#1d1f21"></div><div class="preview-color" style="background-color:#969896"></div><div class="preview-color" style="background-color:#cc6666"></div><div class="preview-color" style="background-color:#b5bd68"></div><div class="preview-color" style="background-color:#f0c674"></div><div class="preview-color" style="background-color:#81a2be"></div><div class="preview-color" style="background-color:#b294bb"></div><div class="preview-color" style="background-color:#8abeb7"></div></div></div><style>.codeexample-base16-tomorrow-dark .highlight code, .codeexample-base16-tomorrow-dark .highlight pre{color:#c5c8c6;background-color:#1d1f21}.codeexample-base16-tomorrow-dark .highlight .hll{background-color:#969896}.codeexample-base16-tomorrow-dark .highlight .c{color:#c5c8c6}.codeexample-base16-tomorrow-dark .highlight .err{color:#b5bd68;background-color:#969896}.codeexample-base16-tomorrow-dark .highlight .g{color:#c5c8c6}.codeexample-base16-tomorrow-dark .highlight .k{color:#81a2be}.codeexample-base16-tomorrow-dark .highlight .l{color:#b294bb}.codeexample-base16-tomorrow-dark .highlight .n{color:#c5c8c6}.codeexample-base16-tomorrow-dark .highlight .o{color:#f0c674}.codeexample-base16-tomorrow-dark .highlight .x{color:#b294bb}.codeexample-base16-tomorrow-dark .highlight .p{color:#ffffff}.codeexample-base16-tomorrow-dark .highlight .cm{color:#c5c8c6}.codeexample-base16-tomorrow-dark .highlight .cp{color:#c5c8c6}.codeexample-base16-tomorrow-dark .highlight .c1{color:#c5c8c6}.codeexample-base16-tomorrow-dark .highlight .cs{color:#b5bd68;font-weight:bold}.codeexample-base16-tomorrow-dark .highlight .gd{color:#b5bd68}.codeexample-base16-tomorrow-dark .highlight .ge{color:#b294bb;font-style:italic}.codeexample-base16-tomorrow-dark .highlight .gr{color:#b5bd68}.codeexample-base16-tomorrow-dark .highlight .gh{color:#c5c8c6;font-weight:bold}.codeexample-base16-tomorrow-dark .highlight .gi{color:#f0c674}.codeexample-base16-tomorrow-dark .highlight .go{color:#969896}.codeexample-base16-tomorrow-dark .highlight .gp{color:#c5c8c6;font-weight:bold}.codeexample-base16-tomorrow-dark .highlight .gs{color:#b294bb;font-weight:bold}.codeexample-base16-tomorrow-dark .highlight .gu{color:#b294bb;font-weight:bold}.codeexample-base16-tomorrow-dark .highlight .gt{color:#81a2be}.codeexample-base16-tomorrow-dark .highlight .kc{color:#cc6666}.codeexample-base16-tomorrow-dark .highlight .kd{color:#f0c674}.codeexample-base16-tomorrow-dark .highlight .kn{color:#81a2be;font-weight:bold}.codeexample-base16-tomorrow-dark .highlight .kp{color:#b5bd68}.codeexample-base16-tomorrow-dark .highlight .kr{color:#b5bd68}.codeexample-base16-tomorrow-dark .highlight .kt{color:#c5c8c6}.codeexample-base16-tomorrow-dark .highlight .ld{color:#8abeb7}.codeexample-base16-tomorrow-dark .highlight .m{color:#b294bb}.codeexample-base16-tomorrow-dark .highlight .s{color:#8abeb7}.codeexample-base16-tomorrow-dark .highlight .na{color:#b5bd68}.codeexample-base16-tomorrow-dark .highlight .nb{color:#81a2be}.codeexample-base16-tomorrow-dark .highlight .nc{color:#81a2be}.codeexample-base16-tomorrow-dark .highlight .no{color:#b294bb}.codeexample-base16-tomorrow-dark .highlight .nd{color:#b294bb}.codeexample-base16-tomorrow-dark .highlight .ni{color:#cc6666}.codeexample-base16-tomorrow-dark .highlight .ne{color:#f0c674;font-weight:bold}.codeexample-base16-tomorrow-dark .highlight .nf{color:#81a2be}.codeexample-base16-tomorrow-dark .highlight .nl{color:#b294bb}.codeexample-base16-tomorrow-dark .highlight .nn{color:#81a2be}.codeexample-base16-tomorrow-dark .highlight .nx{color:#b294bb}.codeexample-base16-tomorrow-dark .highlight .py{color:#b294bb}.codeexample-base16-tomorrow-dark .highlight .nt{color:#b5bd68}.codeexample-base16-tomorrow-dark .highlight .nv{color:#c5c8c6}.codeexample-base16-tomorrow-dark .highlight .ow{color:#f0c674}.codeexample-base16-tomorrow-dark .highlight .w{color:#b294bb}.codeexample-base16-tomorrow-dark .highlight .mf{color:#b294bb}.codeexample-base16-tomorrow-dark .highlight .mh{color:#b294bb}.codeexample-base16-tomorrow-dark .highlight .mi{color:#b294bb}.codeexample-base16-tomorrow-dark .highlight .mo{color:#b294bb}.codeexample-base16-tomorrow-dark .highlight .sb{color:#8abeb7}.codeexample-base16-tomorrow-dark .highlight .sc{color:#8abeb7}.codeexample-base16-tomorrow-dark .highlight .sd{color:#8abeb7}.codeexample-base16-tomorrow-dark .highlight .s2{color:#8abeb7}.codeexample-base16-tomorrow-dark .highlight .se{color:#8abeb7}.codeexample-base16-tomorrow-dark .highlight .sh{color:#8abeb7}.codeexample-base16-tomorrow-dark .highlight .si{color:#8abeb7}.codeexample-base16-tomorrow-dark .highlight .sx{color:#8abeb7}.codeexample-base16-tomorrow-dark .highlight .sr{color:#8abeb7}.codeexample-base16-tomorrow-dark .highlight .s1{color:#8abeb7}.codeexample-base16-tomorrow-dark .highlight .ss{color:#8abeb7}.codeexample-base16-tomorrow-dark .highlight .bp{color:#81a2be}.codeexample-base16-tomorrow-dark .highlight .vc{color:#81a2be}.codeexample-base16-tomorrow-dark .highlight .vg{color:#c5c8c6}.codeexample-base16-tomorrow-dark .highlight .vi{color:#f0c674}.codeexample-base16-tomorrow-dark .highlight .il{color:#b294bb}</style><div class="codeexample codeexample-base16-tomorrow-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-tomorrow-light">Base16 Tomorrow Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#373b41"></div><div class="preview-color" style="background-color:#1d1f21"></div><div class="preview-color" style="background-color:#cc6666"></div><div class="preview-color" style="background-color:#b5bd68"></div><div class="preview-color" style="background-color:#f0c674"></div><div class="preview-color" style="background-color:#81a2be"></div><div class="preview-color" style="background-color:#b294bb"></div><div class="preview-color" style="background-color:#8abeb7"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#ffffff"></div><div class="preview-color" style="background-color:#969896"></div><div class="preview-color" style="background-color:#cc6666"></div><div class="preview-color" style="background-color:#b5bd68"></div><div class="preview-color" style="background-color:#f0c674"></div><div class="preview-color" style="background-color:#81a2be"></div><div class="preview-color" style="background-color:#b294bb"></div><div class="preview-color" style="background-color:#8abeb7"></div></div></div><style>.codeexample-base16-tomorrow-light .highlight code, .codeexample-base16-tomorrow-light .highlight pre{color:#373b41;background-color:#ffffff}.codeexample-base16-tomorrow-light .highlight .hll{background-color:#969896}.codeexample-base16-tomorrow-light .highlight .c{color:#c5c8c6}.codeexample-base16-tomorrow-light .highlight .err{color:#b5bd68;background-color:#969896}.codeexample-base16-tomorrow-light .highlight .g{color:#c5c8c6}.codeexample-base16-tomorrow-light .highlight .k{color:#81a2be}.codeexample-base16-tomorrow-light .highlight .l{color:#b294bb}.codeexample-base16-tomorrow-light .highlight .n{color:#373b41}.codeexample-base16-tomorrow-light .highlight .o{color:#f0c674}.codeexample-base16-tomorrow-light .highlight .x{color:#b294bb}.codeexample-base16-tomorrow-light .highlight .p{color:#ffffff}.codeexample-base16-tomorrow-light .highlight .cm{color:#c5c8c6}.codeexample-base16-tomorrow-light .highlight .cp{color:#c5c8c6}.codeexample-base16-tomorrow-light .highlight .c1{color:#c5c8c6}.codeexample-base16-tomorrow-light .highlight .cs{color:#b5bd68;font-weight:bold}.codeexample-base16-tomorrow-light .highlight .gd{color:#b5bd68}.codeexample-base16-tomorrow-light .highlight .ge{color:#b294bb;font-style:italic}.codeexample-base16-tomorrow-light .highlight .gr{color:#b5bd68}.codeexample-base16-tomorrow-light .highlight .gh{color:#373b41;font-weight:bold}.codeexample-base16-tomorrow-light .highlight .gi{color:#f0c674}.codeexample-base16-tomorrow-light .highlight .go{color:#969896}.codeexample-base16-tomorrow-light .highlight .gp{color:#373b41;font-weight:bold}.codeexample-base16-tomorrow-light .highlight .gs{color:#b294bb;font-weight:bold}.codeexample-base16-tomorrow-light .highlight .gu{color:#b294bb;font-weight:bold}.codeexample-base16-tomorrow-light .highlight .gt{color:#81a2be}.codeexample-base16-tomorrow-light .highlight .kc{color:#cc6666}.codeexample-base16-tomorrow-light .highlight .kd{color:#f0c674}.codeexample-base16-tomorrow-light .highlight .kn{color:#81a2be;font-weight:bold}.codeexample-base16-tomorrow-light .highlight .kp{color:#b5bd68}.codeexample-base16-tomorrow-light .highlight .kr{color:#b5bd68}.codeexample-base16-tomorrow-light .highlight .kt{color:#c5c8c6}.codeexample-base16-tomorrow-light .highlight .ld{color:#8abeb7}.codeexample-base16-tomorrow-light .highlight .m{color:#b294bb}.codeexample-base16-tomorrow-light .highlight .s{color:#8abeb7}.codeexample-base16-tomorrow-light .highlight .na{color:#b5bd68}.codeexample-base16-tomorrow-light .highlight .nb{color:#81a2be}.codeexample-base16-tomorrow-light .highlight .nc{color:#81a2be}.codeexample-base16-tomorrow-light .highlight .no{color:#b294bb}.codeexample-base16-tomorrow-light .highlight .nd{color:#b294bb}.codeexample-base16-tomorrow-light .highlight .ni{color:#cc6666}.codeexample-base16-tomorrow-light .highlight .ne{color:#f0c674;font-weight:bold}.codeexample-base16-tomorrow-light .highlight .nf{color:#81a2be}.codeexample-base16-tomorrow-light .highlight .nl{color:#b294bb}.codeexample-base16-tomorrow-light .highlight .nn{color:#81a2be}.codeexample-base16-tomorrow-light .highlight .nx{color:#b294bb}.codeexample-base16-tomorrow-light .highlight .py{color:#b294bb}.codeexample-base16-tomorrow-light .highlight .nt{color:#b5bd68}.codeexample-base16-tomorrow-light .highlight .nv{color:#373b41}.codeexample-base16-tomorrow-light .highlight .ow{color:#f0c674}.codeexample-base16-tomorrow-light .highlight .w{color:#b294bb}.codeexample-base16-tomorrow-light .highlight .mf{color:#b294bb}.codeexample-base16-tomorrow-light .highlight .mh{color:#b294bb}.codeexample-base16-tomorrow-light .highlight .mi{color:#b294bb}.codeexample-base16-tomorrow-light .highlight .mo{color:#b294bb}.codeexample-base16-tomorrow-light .highlight .sb{color:#8abeb7}.codeexample-base16-tomorrow-light .highlight .sc{color:#8abeb7}.codeexample-base16-tomorrow-light .highlight .sd{color:#8abeb7}.codeexample-base16-tomorrow-light .highlight .s2{color:#8abeb7}.codeexample-base16-tomorrow-light .highlight .se{color:#8abeb7}.codeexample-base16-tomorrow-light .highlight .sh{color:#8abeb7}.codeexample-base16-tomorrow-light .highlight .si{color:#8abeb7}.codeexample-base16-tomorrow-light .highlight .sx{color:#8abeb7}.codeexample-base16-tomorrow-light .highlight .sr{color:#8abeb7}.codeexample-base16-tomorrow-light .highlight .s1{color:#8abeb7}.codeexample-base16-tomorrow-light .highlight .ss{color:#8abeb7}.codeexample-base16-tomorrow-light .highlight .bp{color:#81a2be}.codeexample-base16-tomorrow-light .highlight .vc{color:#81a2be}.codeexample-base16-tomorrow-light .highlight .vg{color:#373b41}.codeexample-base16-tomorrow-light .highlight .vi{color:#f0c674}.codeexample-base16-tomorrow-light .highlight .il{color:#b294bb}</style><div class="codeexample codeexample-base16-tomorrow-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-twilight-dark">Base16 Twilight Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#a7a7a7"></div><div class="preview-color" style="background-color:#1e1e1e"></div><div class="preview-color" style="background-color:#cf6a4c"></div><div class="preview-color" style="background-color:#8f9d6a"></div><div class="preview-color" style="background-color:#f9ee98"></div><div class="preview-color" style="background-color:#7587a6"></div><div class="preview-color" style="background-color:#9b859d"></div><div class="preview-color" style="background-color:#afc4db"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#1e1e1e"></div><div class="preview-color" style="background-color:#5f5a60"></div><div class="preview-color" style="background-color:#cf6a4c"></div><div class="preview-color" style="background-color:#8f9d6a"></div><div class="preview-color" style="background-color:#f9ee98"></div><div class="preview-color" style="background-color:#7587a6"></div><div class="preview-color" style="background-color:#9b859d"></div><div class="preview-color" style="background-color:#afc4db"></div></div></div><style>.codeexample-base16-twilight-dark .highlight code, .codeexample-base16-twilight-dark .highlight pre{color:#a7a7a7;background-color:#1e1e1e}.codeexample-base16-twilight-dark .highlight .hll{background-color:#5f5a60}.codeexample-base16-twilight-dark .highlight .c{color:#a7a7a7}.codeexample-base16-twilight-dark .highlight .err{color:#8f9d6a;background-color:#5f5a60}.codeexample-base16-twilight-dark .highlight .g{color:#a7a7a7}.codeexample-base16-twilight-dark .highlight .k{color:#7587a6}.codeexample-base16-twilight-dark .highlight .l{color:#9b859d}.codeexample-base16-twilight-dark .highlight .n{color:#a7a7a7}.codeexample-base16-twilight-dark .highlight .o{color:#f9ee98}.codeexample-base16-twilight-dark .highlight .x{color:#9b859d}.codeexample-base16-twilight-dark .highlight .p{color:#ffffff}.codeexample-base16-twilight-dark .highlight .cm{color:#a7a7a7}.codeexample-base16-twilight-dark .highlight .cp{color:#a7a7a7}.codeexample-base16-twilight-dark .highlight .c1{color:#a7a7a7}.codeexample-base16-twilight-dark .highlight .cs{color:#8f9d6a;font-weight:bold}.codeexample-base16-twilight-dark .highlight .gd{color:#8f9d6a}.codeexample-base16-twilight-dark .highlight .ge{color:#9b859d;font-style:italic}.codeexample-base16-twilight-dark .highlight .gr{color:#8f9d6a}.codeexample-base16-twilight-dark .highlight .gh{color:#a7a7a7;font-weight:bold}.codeexample-base16-twilight-dark .highlight .gi{color:#f9ee98}.codeexample-base16-twilight-dark .highlight .go{color:#5f5a60}.codeexample-base16-twilight-dark .highlight .gp{color:#a7a7a7;font-weight:bold}.codeexample-base16-twilight-dark .highlight .gs{color:#9b859d;font-weight:bold}.codeexample-base16-twilight-dark .highlight .gu{color:#9b859d;font-weight:bold}.codeexample-base16-twilight-dark .highlight .gt{color:#7587a6}.codeexample-base16-twilight-dark .highlight .kc{color:#cf6a4c}.codeexample-base16-twilight-dark .highlight .kd{color:#f9ee98}.codeexample-base16-twilight-dark .highlight .kn{color:#7587a6;font-weight:bold}.codeexample-base16-twilight-dark .highlight .kp{color:#8f9d6a}.codeexample-base16-twilight-dark .highlight .kr{color:#8f9d6a}.codeexample-base16-twilight-dark .highlight .kt{color:#a7a7a7}.codeexample-base16-twilight-dark .highlight .ld{color:#afc4db}.codeexample-base16-twilight-dark .highlight .m{color:#9b859d}.codeexample-base16-twilight-dark .highlight .s{color:#afc4db}.codeexample-base16-twilight-dark .highlight .na{color:#8f9d6a}.codeexample-base16-twilight-dark .highlight .nb{color:#7587a6}.codeexample-base16-twilight-dark .highlight .nc{color:#7587a6}.codeexample-base16-twilight-dark .highlight .no{color:#9b859d}.codeexample-base16-twilight-dark .highlight .nd{color:#9b859d}.codeexample-base16-twilight-dark .highlight .ni{color:#cf6a4c}.codeexample-base16-twilight-dark .highlight .ne{color:#f9ee98;font-weight:bold}.codeexample-base16-twilight-dark .highlight .nf{color:#7587a6}.codeexample-base16-twilight-dark .highlight .nl{color:#9b859d}.codeexample-base16-twilight-dark .highlight .nn{color:#7587a6}.codeexample-base16-twilight-dark .highlight .nx{color:#9b859d}.codeexample-base16-twilight-dark .highlight .py{color:#9b859d}.codeexample-base16-twilight-dark .highlight .nt{color:#8f9d6a}.codeexample-base16-twilight-dark .highlight .nv{color:#a7a7a7}.codeexample-base16-twilight-dark .highlight .ow{color:#f9ee98}.codeexample-base16-twilight-dark .highlight .w{color:#9b859d}.codeexample-base16-twilight-dark .highlight .mf{color:#9b859d}.codeexample-base16-twilight-dark .highlight .mh{color:#9b859d}.codeexample-base16-twilight-dark .highlight .mi{color:#9b859d}.codeexample-base16-twilight-dark .highlight .mo{color:#9b859d}.codeexample-base16-twilight-dark .highlight .sb{color:#afc4db}.codeexample-base16-twilight-dark .highlight .sc{color:#afc4db}.codeexample-base16-twilight-dark .highlight .sd{color:#afc4db}.codeexample-base16-twilight-dark .highlight .s2{color:#afc4db}.codeexample-base16-twilight-dark .highlight .se{color:#afc4db}.codeexample-base16-twilight-dark .highlight .sh{color:#afc4db}.codeexample-base16-twilight-dark .highlight .si{color:#afc4db}.codeexample-base16-twilight-dark .highlight .sx{color:#afc4db}.codeexample-base16-twilight-dark .highlight .sr{color:#afc4db}.codeexample-base16-twilight-dark .highlight .s1{color:#afc4db}.codeexample-base16-twilight-dark .highlight .ss{color:#afc4db}.codeexample-base16-twilight-dark .highlight .bp{color:#7587a6}.codeexample-base16-twilight-dark .highlight .vc{color:#7587a6}.codeexample-base16-twilight-dark .highlight .vg{color:#a7a7a7}.codeexample-base16-twilight-dark .highlight .vi{color:#f9ee98}.codeexample-base16-twilight-dark .highlight .il{color:#9b859d}</style><div class="codeexample codeexample-base16-twilight-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="base16-twilight-light">Base16 Twilight Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#464b50"></div><div class="preview-color" style="background-color:#1e1e1e"></div><div class="preview-color" style="background-color:#cf6a4c"></div><div class="preview-color" style="background-color:#8f9d6a"></div><div class="preview-color" style="background-color:#f9ee98"></div><div class="preview-color" style="background-color:#7587a6"></div><div class="preview-color" style="background-color:#9b859d"></div><div class="preview-color" style="background-color:#afc4db"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#ffffff"></div><div class="preview-color" style="background-color:#5f5a60"></div><div class="preview-color" style="background-color:#cf6a4c"></div><div class="preview-color" style="background-color:#8f9d6a"></div><div class="preview-color" style="background-color:#f9ee98"></div><div class="preview-color" style="background-color:#7587a6"></div><div class="preview-color" style="background-color:#9b859d"></div><div class="preview-color" style="background-color:#afc4db"></div></div></div><style>.codeexample-base16-twilight-light .highlight code, .codeexample-base16-twilight-light .highlight pre{color:#464b50;background-color:#ffffff}.codeexample-base16-twilight-light .highlight .hll{background-color:#5f5a60}.codeexample-base16-twilight-light .highlight .c{color:#a7a7a7}.codeexample-base16-twilight-light .highlight .err{color:#8f9d6a;background-color:#5f5a60}.codeexample-base16-twilight-light .highlight .g{color:#a7a7a7}.codeexample-base16-twilight-light .highlight .k{color:#7587a6}.codeexample-base16-twilight-light .highlight .l{color:#9b859d}.codeexample-base16-twilight-light .highlight .n{color:#464b50}.codeexample-base16-twilight-light .highlight .o{color:#f9ee98}.codeexample-base16-twilight-light .highlight .x{color:#9b859d}.codeexample-base16-twilight-light .highlight .p{color:#ffffff}.codeexample-base16-twilight-light .highlight .cm{color:#a7a7a7}.codeexample-base16-twilight-light .highlight .cp{color:#a7a7a7}.codeexample-base16-twilight-light .highlight .c1{color:#a7a7a7}.codeexample-base16-twilight-light .highlight .cs{color:#8f9d6a;font-weight:bold}.codeexample-base16-twilight-light .highlight .gd{color:#8f9d6a}.codeexample-base16-twilight-light .highlight .ge{color:#9b859d;font-style:italic}.codeexample-base16-twilight-light .highlight .gr{color:#8f9d6a}.codeexample-base16-twilight-light .highlight .gh{color:#464b50;font-weight:bold}.codeexample-base16-twilight-light .highlight .gi{color:#f9ee98}.codeexample-base16-twilight-light .highlight .go{color:#5f5a60}.codeexample-base16-twilight-light .highlight .gp{color:#464b50;font-weight:bold}.codeexample-base16-twilight-light .highlight .gs{color:#9b859d;font-weight:bold}.codeexample-base16-twilight-light .highlight .gu{color:#9b859d;font-weight:bold}.codeexample-base16-twilight-light .highlight .gt{color:#7587a6}.codeexample-base16-twilight-light .highlight .kc{color:#cf6a4c}.codeexample-base16-twilight-light .highlight .kd{color:#f9ee98}.codeexample-base16-twilight-light .highlight .kn{color:#7587a6;font-weight:bold}.codeexample-base16-twilight-light .highlight .kp{color:#8f9d6a}.codeexample-base16-twilight-light .highlight .kr{color:#8f9d6a}.codeexample-base16-twilight-light .highlight .kt{color:#a7a7a7}.codeexample-base16-twilight-light .highlight .ld{color:#afc4db}.codeexample-base16-twilight-light .highlight .m{color:#9b859d}.codeexample-base16-twilight-light .highlight .s{color:#afc4db}.codeexample-base16-twilight-light .highlight .na{color:#8f9d6a}.codeexample-base16-twilight-light .highlight .nb{color:#7587a6}.codeexample-base16-twilight-light .highlight .nc{color:#7587a6}.codeexample-base16-twilight-light .highlight .no{color:#9b859d}.codeexample-base16-twilight-light .highlight .nd{color:#9b859d}.codeexample-base16-twilight-light .highlight .ni{color:#cf6a4c}.codeexample-base16-twilight-light .highlight .ne{color:#f9ee98;font-weight:bold}.codeexample-base16-twilight-light .highlight .nf{color:#7587a6}.codeexample-base16-twilight-light .highlight .nl{color:#9b859d}.codeexample-base16-twilight-light .highlight .nn{color:#7587a6}.codeexample-base16-twilight-light .highlight .nx{color:#9b859d}.codeexample-base16-twilight-light .highlight .py{color:#9b859d}.codeexample-base16-twilight-light .highlight .nt{color:#8f9d6a}.codeexample-base16-twilight-light .highlight .nv{color:#464b50}.codeexample-base16-twilight-light .highlight .ow{color:#f9ee98}.codeexample-base16-twilight-light .highlight .w{color:#9b859d}.codeexample-base16-twilight-light .highlight .mf{color:#9b859d}.codeexample-base16-twilight-light .highlight .mh{color:#9b859d}.codeexample-base16-twilight-light .highlight .mi{color:#9b859d}.codeexample-base16-twilight-light .highlight .mo{color:#9b859d}.codeexample-base16-twilight-light .highlight .sb{color:#afc4db}.codeexample-base16-twilight-light .highlight .sc{color:#afc4db}.codeexample-base16-twilight-light .highlight .sd{color:#afc4db}.codeexample-base16-twilight-light .highlight .s2{color:#afc4db}.codeexample-base16-twilight-light .highlight .se{color:#afc4db}.codeexample-base16-twilight-light .highlight .sh{color:#afc4db}.codeexample-base16-twilight-light .highlight .si{color:#afc4db}.codeexample-base16-twilight-light .highlight .sx{color:#afc4db}.codeexample-base16-twilight-light .highlight .sr{color:#afc4db}.codeexample-base16-twilight-light .highlight .s1{color:#afc4db}.codeexample-base16-twilight-light .highlight .ss{color:#afc4db}.codeexample-base16-twilight-light .highlight .bp{color:#7587a6}.codeexample-base16-twilight-light .highlight .vc{color:#7587a6}.codeexample-base16-twilight-light .highlight .vg{color:#464b50}.codeexample-base16-twilight-light .highlight .vi{color:#f9ee98}.codeexample-base16-twilight-light .highlight .il{color:#9b859d}</style><div class="codeexample codeexample-base16-twilight-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="dracula">Dracula</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#f8f8f2"></div><div class="preview-color" style="background-color:#000000"></div><div class="preview-color" style="background-color:#ff5555"></div><div class="preview-color" style="background-color:#50fa7b"></div><div class="preview-color" style="background-color:#f1fa8c"></div><div class="preview-color" style="background-color:#caa9fa"></div><div class="preview-color" style="background-color:#ff79c6"></div><div class="preview-color" style="background-color:#8be9fd"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#282a36"></div><div class="preview-color" style="background-color:#4d4d4d"></div><div class="preview-color" style="background-color:#ff6e67"></div><div class="preview-color" style="background-color:#5af78e"></div><div class="preview-color" style="background-color:#f4f99d"></div><div class="preview-color" style="background-color:#caa9fa"></div><div class="preview-color" style="background-color:#ff92d0"></div><div class="preview-color" style="background-color:#9aedfe"></div></div></div><style>.codeexample-dracula .highlight code, .codeexample-dracula .highlight pre{color:#f8f8f2;background-color:#282a36}.codeexample-dracula .highlight .hll{background-color:#4d4d4d}.codeexample-dracula .highlight .c{color:#bfbfbf}.codeexample-dracula .highlight .err{color:#5af78e;background-color:#4d4d4d}.codeexample-dracula .highlight .g{color:#bfbfbf}.codeexample-dracula .highlight .k{color:#caa9fa}.codeexample-dracula .highlight .l{color:#ff79c6}.codeexample-dracula .highlight .n{color:#f8f8f2}.codeexample-dracula .highlight .o{color:#f4f99d}.codeexample-dracula .highlight .x{color:#ff79c6}.codeexample-dracula .highlight .p{color:#e6e6e6}.codeexample-dracula .highlight .cm{color:#bfbfbf}.codeexample-dracula .highlight .cp{color:#bfbfbf}.codeexample-dracula .highlight .c1{color:#bfbfbf}.codeexample-dracula .highlight .cs{color:#50fa7b;font-weight:bold}.codeexample-dracula .highlight .gd{color:#50fa7b}.codeexample-dracula .highlight .ge{color:#ff79c6;font-style:italic}.codeexample-dracula .highlight .gr{color:#50fa7b}.codeexample-dracula .highlight .gh{color:#f8f8f2;font-weight:bold}.codeexample-dracula .highlight .gi{color:#f4f99d}.codeexample-dracula .highlight .go{color:#4d4d4d}.codeexample-dracula .highlight .gp{color:#f8f8f2;font-weight:bold}.codeexample-dracula .highlight .gs{color:#ff79c6;font-weight:bold}.codeexample-dracula .highlight .gu{color:#ff79c6;font-weight:bold}.codeexample-dracula .highlight .gt{color:#caa9fa}.codeexample-dracula .highlight .kc{color:#ff6e67}.codeexample-dracula .highlight .kd{color:#f4f99d}.codeexample-dracula .highlight .kn{color:#caa9fa;font-weight:bold}.codeexample-dracula .highlight .kp{color:#50fa7b}.codeexample-dracula .highlight .kr{color:#5af78e}.codeexample-dracula .highlight .kt{color:#bfbfbf}.codeexample-dracula .highlight .ld{color:#9aedfe}.codeexample-dracula .highlight .m{color:#ff92d0}.codeexample-dracula .highlight .s{color:#9aedfe}.codeexample-dracula .highlight .na{color:#50fa7b}.codeexample-dracula .highlight .nb{color:#caa9fa}.codeexample-dracula .highlight .nc{color:#caa9fa}.codeexample-dracula .highlight .no{color:#ff79c6}.codeexample-dracula .highlight .nd{color:#ff79c6}.codeexample-dracula .highlight .ni{color:#ff6e67}.codeexample-dracula .highlight .ne{color:#f1fa8c;font-weight:bold}.codeexample-dracula .highlight .nf{color:#caa9fa}.codeexample-dracula .highlight .nl{color:#ff79c6}.codeexample-dracula .highlight .nn{color:#caa9fa}.codeexample-dracula .highlight .nx{color:#ff79c6}.codeexample-dracula .highlight .py{color:#ff79c6}.codeexample-dracula .highlight .nt{color:#50fa7b}.codeexample-dracula .highlight .nv{color:#f8f8f2}.codeexample-dracula .highlight .ow{color:#f4f99d}.codeexample-dracula .highlight .w{color:#ff79c6}.codeexample-dracula .highlight .mf{color:#ff92d0}.codeexample-dracula .highlight .mh{color:#ff92d0}.codeexample-dracula .highlight .mi{color:#ff92d0}.codeexample-dracula .highlight .mo{color:#ff92d0}.codeexample-dracula .highlight .sb{color:#9aedfe}.codeexample-dracula .highlight .sc{color:#9aedfe}.codeexample-dracula .highlight .sd{color:#9aedfe}.codeexample-dracula .highlight .s2{color:#9aedfe}.codeexample-dracula .highlight .se{color:#9aedfe}.codeexample-dracula .highlight .sh{color:#9aedfe}.codeexample-dracula .highlight .si{color:#9aedfe}.codeexample-dracula .highlight .sx{color:#9aedfe}.codeexample-dracula .highlight .sr{color:#9aedfe}.codeexample-dracula .highlight .s1{color:#9aedfe}.codeexample-dracula .highlight .ss{color:#9aedfe}.codeexample-dracula .highlight .bp{color:#caa9fa}.codeexample-dracula .highlight .vc{color:#caa9fa}.codeexample-dracula .highlight .vg{color:#f8f8f2}.codeexample-dracula .highlight .vi{color:#f4f99d}.codeexample-dracula .highlight .il{color:#ff92d0}</style><div class="codeexample codeexample-dracula">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="gnometerm">Gnometerm</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:none"></div><div class="preview-color" style="background-color:#000000"></div><div class="preview-color" style="background-color:#cc0000"></div><div class="preview-color" style="background-color:#4e9a06"></div><div class="preview-color" style="background-color:#c4a000"></div><div class="preview-color" style="background-color:#3465a4"></div><div class="preview-color" style="background-color:#75507b"></div><div class="preview-color" style="background-color:#06989a"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:none"></div><div class="preview-color" style="background-color:#555753"></div><div class="preview-color" style="background-color:#ef2929"></div><div class="preview-color" style="background-color:#8ae234"></div><div class="preview-color" style="background-color:#fce94f"></div><div class="preview-color" style="background-color:#729fcf"></div><div class="preview-color" style="background-color:#ad7fa8"></div><div class="preview-color" style="background-color:#34e2e2"></div></div></div><style>.codeexample-gnometerm .highlight code, .codeexample-gnometerm .highlight pre{color:none;background-color:none}.codeexample-gnometerm .highlight .hll{background-color:#555753}.codeexample-gnometerm .highlight .c{color:#d3d7cf}.codeexample-gnometerm .highlight .err{color:#8ae234;background-color:#555753}.codeexample-gnometerm .highlight .g{color:#d3d7cf}.codeexample-gnometerm .highlight .k{color:#3465a4}.codeexample-gnometerm .highlight .l{color:#75507b}.codeexample-gnometerm .highlight .n{color:none}.codeexample-gnometerm .highlight .o{color:#fce94f}.codeexample-gnometerm .highlight .x{color:#75507b}.codeexample-gnometerm .highlight .p{color:#eeeeec}.codeexample-gnometerm .highlight .cm{color:#d3d7cf}.codeexample-gnometerm .highlight .cp{color:#d3d7cf}.codeexample-gnometerm .highlight .c1{color:#d3d7cf}.codeexample-gnometerm .highlight .cs{color:#4e9a06;font-weight:bold}.codeexample-gnometerm .highlight .gd{color:#4e9a06}.codeexample-gnometerm .highlight .ge{color:#75507b;font-style:italic}.codeexample-gnometerm .highlight .gr{color:#4e9a06}.codeexample-gnometerm .highlight .gh{color:none;font-weight:bold}.codeexample-gnometerm .highlight .gi{color:#fce94f}.codeexample-gnometerm .highlight .go{color:#555753}.codeexample-gnometerm .highlight .gp{color:none;font-weight:bold}.codeexample-gnometerm .highlight .gs{color:#75507b;font-weight:bold}.codeexample-gnometerm .highlight .gu{color:#75507b;font-weight:bold}.codeexample-gnometerm .highlight .gt{color:#729fcf}.codeexample-gnometerm .highlight .kc{color:#ef2929}.codeexample-gnometerm .highlight .kd{color:#fce94f}.codeexample-gnometerm .highlight .kn{color:#3465a4;font-weight:bold}.codeexample-gnometerm .highlight .kp{color:#4e9a06}.codeexample-gnometerm .highlight .kr{color:#8ae234}.codeexample-gnometerm .highlight .kt{color:#d3d7cf}.codeexample-gnometerm .highlight .ld{color:#34e2e2}.codeexample-gnometerm .highlight .m{color:#ad7fa8}.codeexample-gnometerm .highlight .s{color:#34e2e2}.codeexample-gnometerm .highlight .na{color:#4e9a06}.codeexample-gnometerm .highlight .nb{color:#729fcf}.codeexample-gnometerm .highlight .nc{color:#729fcf}.codeexample-gnometerm .highlight .no{color:#75507b}.codeexample-gnometerm .highlight .nd{color:#75507b}.codeexample-gnometerm .highlight .ni{color:#ef2929}.codeexample-gnometerm .highlight .ne{color:#c4a000;font-weight:bold}.codeexample-gnometerm .highlight .nf{color:#729fcf}.codeexample-gnometerm .highlight .nl{color:#75507b}.codeexample-gnometerm .highlight .nn{color:#729fcf}.codeexample-gnometerm .highlight .nx{color:#75507b}.codeexample-gnometerm .highlight .py{color:#75507b}.codeexample-gnometerm .highlight .nt{color:#4e9a06}.codeexample-gnometerm .highlight .nv{color:none}.codeexample-gnometerm .highlight .ow{color:#fce94f}.codeexample-gnometerm .highlight .w{color:#75507b}.codeexample-gnometerm .highlight .mf{color:#ad7fa8}.codeexample-gnometerm .highlight .mh{color:#ad7fa8}.codeexample-gnometerm .highlight .mi{color:#ad7fa8}.codeexample-gnometerm .highlight .mo{color:#ad7fa8}.codeexample-gnometerm .highlight .sb{color:#34e2e2}.codeexample-gnometerm .highlight .sc{color:#34e2e2}.codeexample-gnometerm .highlight .sd{color:#34e2e2}.codeexample-gnometerm .highlight .s2{color:#34e2e2}.codeexample-gnometerm .highlight .se{color:#34e2e2}.codeexample-gnometerm .highlight .sh{color:#34e2e2}.codeexample-gnometerm .highlight .si{color:#34e2e2}.codeexample-gnometerm .highlight .sx{color:#34e2e2}.codeexample-gnometerm .highlight .sr{color:#34e2e2}.codeexample-gnometerm .highlight .s1{color:#34e2e2}.codeexample-gnometerm .highlight .ss{color:#34e2e2}.codeexample-gnometerm .highlight .bp{color:#729fcf}.codeexample-gnometerm .highlight .vc{color:#729fcf}.codeexample-gnometerm .highlight .vg{color:none}.codeexample-gnometerm .highlight .vi{color:#fce94f}.codeexample-gnometerm .highlight .il{color:#ad7fa8}</style><div class="codeexample codeexample-gnometerm">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="gotham">Gotham</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#98d1ce"></div><div class="preview-color" style="background-color:#0a0f14"></div><div class="preview-color" style="background-color:#c33027"></div><div class="preview-color" style="background-color:#26a98b"></div><div class="preview-color" style="background-color:#edb54b"></div><div class="preview-color" style="background-color:#195465"></div><div class="preview-color" style="background-color:#4e5165"></div><div class="preview-color" style="background-color:#33859d"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#0a0f14"></div><div class="preview-color" style="background-color:#10151b"></div><div class="preview-color" style="background-color:#d26939"></div><div class="preview-color" style="background-color:#081f2d"></div><div class="preview-color" style="background-color:#245361"></div><div class="preview-color" style="background-color:#093748"></div><div class="preview-color" style="background-color:#888ba5"></div><div class="preview-color" style="background-color:#599caa"></div></div></div><style>.codeexample-gotham .highlight code, .codeexample-gotham .highlight pre{color:#98d1ce;background-color:#0a0f14}.codeexample-gotham .highlight .hll{background-color:#10151b}.codeexample-gotham .highlight .c{color:#98d1ce}.codeexample-gotham .highlight .err{color:#081f2d;background-color:#10151b}.codeexample-gotham .highlight .g{color:#98d1ce}.codeexample-gotham .highlight .k{color:#195465}.codeexample-gotham .highlight .l{color:#4e5165}.codeexample-gotham .highlight .n{color:#98d1ce}.codeexample-gotham .highlight .o{color:#245361}.codeexample-gotham .highlight .x{color:#4e5165}.codeexample-gotham .highlight .p{color:#d3ebe9}.codeexample-gotham .highlight .cm{color:#98d1ce}.codeexample-gotham .highlight .cp{color:#98d1ce}.codeexample-gotham .highlight .c1{color:#98d1ce}.codeexample-gotham .highlight .cs{color:#26a98b;font-weight:bold}.codeexample-gotham .highlight .gd{color:#26a98b}.codeexample-gotham .highlight .ge{color:#4e5165;font-style:italic}.codeexample-gotham .highlight .gr{color:#26a98b}.codeexample-gotham .highlight .gh{color:#98d1ce;font-weight:bold}.codeexample-gotham .highlight .gi{color:#245361}.codeexample-gotham .highlight .go{color:#10151b}.codeexample-gotham .highlight .gp{color:#98d1ce;font-weight:bold}.codeexample-gotham .highlight .gs{color:#4e5165;font-weight:bold}.codeexample-gotham .highlight .gu{color:#4e5165;font-weight:bold}.codeexample-gotham .highlight .gt{color:#093748}.codeexample-gotham .highlight .kc{color:#d26939}.codeexample-gotham .highlight .kd{color:#245361}.codeexample-gotham .highlight .kn{color:#195465;font-weight:bold}.codeexample-gotham .highlight .kp{color:#26a98b}.codeexample-gotham .highlight .kr{color:#081f2d}.codeexample-gotham .highlight .kt{color:#98d1ce}.codeexample-gotham .highlight .ld{color:#599caa}.codeexample-gotham .highlight .m{color:#888ba5}.codeexample-gotham .highlight .s{color:#599caa}.codeexample-gotham .highlight .na{color:#26a98b}.codeexample-gotham .highlight .nb{color:#093748}.codeexample-gotham .highlight .nc{color:#093748}.codeexample-gotham .highlight .no{color:#4e5165}.codeexample-gotham .highlight .nd{color:#4e5165}.codeexample-gotham .highlight .ni{color:#d26939}.codeexample-gotham .highlight .ne{color:#edb54b;font-weight:bold}.codeexample-gotham .highlight .nf{color:#093748}.codeexample-gotham .highlight .nl{color:#4e5165}.codeexample-gotham .highlight .nn{color:#093748}.codeexample-gotham .highlight .nx{color:#4e5165}.codeexample-gotham .highlight .py{color:#4e5165}.codeexample-gotham .highlight .nt{color:#26a98b}.codeexample-gotham .highlight .nv{color:#98d1ce}.codeexample-gotham .highlight .ow{color:#245361}.codeexample-gotham .highlight .w{color:#4e5165}.codeexample-gotham .highlight .mf{color:#888ba5}.codeexample-gotham .highlight .mh{color:#888ba5}.codeexample-gotham .highlight .mi{color:#888ba5}.codeexample-gotham .highlight .mo{color:#888ba5}.codeexample-gotham .highlight .sb{color:#599caa}.codeexample-gotham .highlight .sc{color:#599caa}.codeexample-gotham .highlight .sd{color:#599caa}.codeexample-gotham .highlight .s2{color:#599caa}.codeexample-gotham .highlight .se{color:#599caa}.codeexample-gotham .highlight .sh{color:#599caa}.codeexample-gotham .highlight .si{color:#599caa}.codeexample-gotham .highlight .sx{color:#599caa}.codeexample-gotham .highlight .sr{color:#599caa}.codeexample-gotham .highlight .s1{color:#599caa}.codeexample-gotham .highlight .ss{color:#599caa}.codeexample-gotham .highlight .bp{color:#093748}.codeexample-gotham .highlight .vc{color:#093748}.codeexample-gotham .highlight .vg{color:#98d1ce}.codeexample-gotham .highlight .vi{color:#245361}.codeexample-gotham .highlight .il{color:#888ba5}</style><div class="codeexample codeexample-gotham">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="gruvbox-dark">Gruvbox Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#ebdbb2"></div><div class="preview-color" style="background-color:#282828"></div><div class="preview-color" style="background-color:#cc241d"></div><div class="preview-color" style="background-color:#98971a"></div><div class="preview-color" style="background-color:#d79921"></div><div class="preview-color" style="background-color:#458588"></div><div class="preview-color" style="background-color:#b16286"></div><div class="preview-color" style="background-color:#689d6a"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#1d2021"></div><div class="preview-color" style="background-color:#928374"></div><div class="preview-color" style="background-color:#fb4934"></div><div class="preview-color" style="background-color:#b8bb26"></div><div class="preview-color" style="background-color:#fabd2f"></div><div class="preview-color" style="background-color:#83a598"></div><div class="preview-color" style="background-color:#d3869b"></div><div class="preview-color" style="background-color:#8ec07c"></div></div></div><style>.codeexample-gruvbox-dark .highlight code, .codeexample-gruvbox-dark .highlight pre{color:#ebdbb2;background-color:#1d2021}.codeexample-gruvbox-dark .highlight .hll{background-color:#928374}.codeexample-gruvbox-dark .highlight .c{color:#a89984}.codeexample-gruvbox-dark .highlight .err{color:#b8bb26;background-color:#928374}.codeexample-gruvbox-dark .highlight .g{color:#a89984}.codeexample-gruvbox-dark .highlight .k{color:#458588}.codeexample-gruvbox-dark .highlight .l{color:#b16286}.codeexample-gruvbox-dark .highlight .n{color:#ebdbb2}.codeexample-gruvbox-dark .highlight .o{color:#fabd2f}.codeexample-gruvbox-dark .highlight .x{color:#b16286}.codeexample-gruvbox-dark .highlight .p{color:#ebdbb2}.codeexample-gruvbox-dark .highlight .cm{color:#a89984}.codeexample-gruvbox-dark .highlight .cp{color:#a89984}.codeexample-gruvbox-dark .highlight .c1{color:#a89984}.codeexample-gruvbox-dark .highlight .cs{color:#98971a;font-weight:bold}.codeexample-gruvbox-dark .highlight .gd{color:#98971a}.codeexample-gruvbox-dark .highlight .ge{color:#b16286;font-style:italic}.codeexample-gruvbox-dark .highlight .gr{color:#98971a}.codeexample-gruvbox-dark .highlight .gh{color:#ebdbb2;font-weight:bold}.codeexample-gruvbox-dark .highlight .gi{color:#fabd2f}.codeexample-gruvbox-dark .highlight .go{color:#928374}.codeexample-gruvbox-dark .highlight .gp{color:#ebdbb2;font-weight:bold}.codeexample-gruvbox-dark .highlight .gs{color:#b16286;font-weight:bold}.codeexample-gruvbox-dark .highlight .gu{color:#b16286;font-weight:bold}.codeexample-gruvbox-dark .highlight .gt{color:#83a598}.codeexample-gruvbox-dark .highlight .kc{color:#fb4934}.codeexample-gruvbox-dark .highlight .kd{color:#fabd2f}.codeexample-gruvbox-dark .highlight .kn{color:#458588;font-weight:bold}.codeexample-gruvbox-dark .highlight .kp{color:#98971a}.codeexample-gruvbox-dark .highlight .kr{color:#b8bb26}.codeexample-gruvbox-dark .highlight .kt{color:#a89984}.codeexample-gruvbox-dark .highlight .ld{color:#8ec07c}.codeexample-gruvbox-dark .highlight .m{color:#d3869b}.codeexample-gruvbox-dark .highlight .s{color:#8ec07c}.codeexample-gruvbox-dark .highlight .na{color:#98971a}.codeexample-gruvbox-dark .highlight .nb{color:#83a598}.codeexample-gruvbox-dark .highlight .nc{color:#83a598}.codeexample-gruvbox-dark .highlight .no{color:#b16286}.codeexample-gruvbox-dark .highlight .nd{color:#b16286}.codeexample-gruvbox-dark .highlight .ni{color:#fb4934}.codeexample-gruvbox-dark .highlight .ne{color:#d79921;font-weight:bold}.codeexample-gruvbox-dark .highlight .nf{color:#83a598}.codeexample-gruvbox-dark .highlight .nl{color:#b16286}.codeexample-gruvbox-dark .highlight .nn{color:#83a598}.codeexample-gruvbox-dark .highlight .nx{color:#b16286}.codeexample-gruvbox-dark .highlight .py{color:#b16286}.codeexample-gruvbox-dark .highlight .nt{color:#98971a}.codeexample-gruvbox-dark .highlight .nv{color:#ebdbb2}.codeexample-gruvbox-dark .highlight .ow{color:#fabd2f}.codeexample-gruvbox-dark .highlight .w{color:#b16286}.codeexample-gruvbox-dark .highlight .mf{color:#d3869b}.codeexample-gruvbox-dark .highlight .mh{color:#d3869b}.codeexample-gruvbox-dark .highlight .mi{color:#d3869b}.codeexample-gruvbox-dark .highlight .mo{color:#d3869b}.codeexample-gruvbox-dark .highlight .sb{color:#8ec07c}.codeexample-gruvbox-dark .highlight .sc{color:#8ec07c}.codeexample-gruvbox-dark .highlight .sd{color:#8ec07c}.codeexample-gruvbox-dark .highlight .s2{color:#8ec07c}.codeexample-gruvbox-dark .highlight .se{color:#8ec07c}.codeexample-gruvbox-dark .highlight .sh{color:#8ec07c}.codeexample-gruvbox-dark .highlight .si{color:#8ec07c}.codeexample-gruvbox-dark .highlight .sx{color:#8ec07c}.codeexample-gruvbox-dark .highlight .sr{color:#8ec07c}.codeexample-gruvbox-dark .highlight .s1{color:#8ec07c}.codeexample-gruvbox-dark .highlight .ss{color:#8ec07c}.codeexample-gruvbox-dark .highlight .bp{color:#83a598}.codeexample-gruvbox-dark .highlight .vc{color:#83a598}.codeexample-gruvbox-dark .highlight .vg{color:#ebdbb2}.codeexample-gruvbox-dark .highlight .vi{color:#fabd2f}.codeexample-gruvbox-dark .highlight .il{color:#d3869b}</style><div class="codeexample codeexample-gruvbox-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="gruvbox-light">Gruvbox Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#3c3836"></div><div class="preview-color" style="background-color:#fdf4c1"></div><div class="preview-color" style="background-color:#cc241d"></div><div class="preview-color" style="background-color:#98971a"></div><div class="preview-color" style="background-color:#d79921"></div><div class="preview-color" style="background-color:#458588"></div><div class="preview-color" style="background-color:#b16286"></div><div class="preview-color" style="background-color:#689d6a"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#f9f5d7"></div><div class="preview-color" style="background-color:#928374"></div><div class="preview-color" style="background-color:#9d0006"></div><div class="preview-color" style="background-color:#79740e"></div><div class="preview-color" style="background-color:#b57614"></div><div class="preview-color" style="background-color:#076678"></div><div class="preview-color" style="background-color:#8f3f71"></div><div class="preview-color" style="background-color:#427b58"></div></div></div><style>.codeexample-gruvbox-light .highlight code, .codeexample-gruvbox-light .highlight pre{color:#3c3836;background-color:#f9f5d7}.codeexample-gruvbox-light .highlight .hll{background-color:#928374}.codeexample-gruvbox-light .highlight .c{color:#7c6f64}.codeexample-gruvbox-light .highlight .err{color:#79740e;background-color:#928374}.codeexample-gruvbox-light .highlight .g{color:#7c6f64}.codeexample-gruvbox-light .highlight .k{color:#458588}.codeexample-gruvbox-light .highlight .l{color:#b16286}.codeexample-gruvbox-light .highlight .n{color:#3c3836}.codeexample-gruvbox-light .highlight .o{color:#b57614}.codeexample-gruvbox-light .highlight .x{color:#b16286}.codeexample-gruvbox-light .highlight .p{color:#3c3836}.codeexample-gruvbox-light .highlight .cm{color:#7c6f64}.codeexample-gruvbox-light .highlight .cp{color:#7c6f64}.codeexample-gruvbox-light .highlight .c1{color:#7c6f64}.codeexample-gruvbox-light .highlight .cs{color:#98971a;font-weight:bold}.codeexample-gruvbox-light .highlight .gd{color:#98971a}.codeexample-gruvbox-light .highlight .ge{color:#b16286;font-style:italic}.codeexample-gruvbox-light .highlight .gr{color:#98971a}.codeexample-gruvbox-light .highlight .gh{color:#3c3836;font-weight:bold}.codeexample-gruvbox-light .highlight .gi{color:#b57614}.codeexample-gruvbox-light .highlight .go{color:#928374}.codeexample-gruvbox-light .highlight .gp{color:#3c3836;font-weight:bold}.codeexample-gruvbox-light .highlight .gs{color:#b16286;font-weight:bold}.codeexample-gruvbox-light .highlight .gu{color:#b16286;font-weight:bold}.codeexample-gruvbox-light .highlight .gt{color:#076678}.codeexample-gruvbox-light .highlight .kc{color:#9d0006}.codeexample-gruvbox-light .highlight .kd{color:#b57614}.codeexample-gruvbox-light .highlight .kn{color:#458588;font-weight:bold}.codeexample-gruvbox-light .highlight .kp{color:#98971a}.codeexample-gruvbox-light .highlight .kr{color:#79740e}.codeexample-gruvbox-light .highlight .kt{color:#7c6f64}.codeexample-gruvbox-light .highlight .ld{color:#427b58}.codeexample-gruvbox-light .highlight .m{color:#8f3f71}.codeexample-gruvbox-light .highlight .s{color:#427b58}.codeexample-gruvbox-light .highlight .na{color:#98971a}.codeexample-gruvbox-light .highlight .nb{color:#076678}.codeexample-gruvbox-light .highlight .nc{color:#076678}.codeexample-gruvbox-light .highlight .no{color:#b16286}.codeexample-gruvbox-light .highlight .nd{color:#b16286}.codeexample-gruvbox-light .highlight .ni{color:#9d0006}.codeexample-gruvbox-light .highlight .ne{color:#d79921;font-weight:bold}.codeexample-gruvbox-light .highlight .nf{color:#076678}.codeexample-gruvbox-light .highlight .nl{color:#b16286}.codeexample-gruvbox-light .highlight .nn{color:#076678}.codeexample-gruvbox-light .highlight .nx{color:#b16286}.codeexample-gruvbox-light .highlight .py{color:#b16286}.codeexample-gruvbox-light .highlight .nt{color:#98971a}.codeexample-gruvbox-light .highlight .nv{color:#3c3836}.codeexample-gruvbox-light .highlight .ow{color:#b57614}.codeexample-gruvbox-light .highlight .w{color:#b16286}.codeexample-gruvbox-light .highlight .mf{color:#8f3f71}.codeexample-gruvbox-light .highlight .mh{color:#8f3f71}.codeexample-gruvbox-light .highlight .mi{color:#8f3f71}.codeexample-gruvbox-light .highlight .mo{color:#8f3f71}.codeexample-gruvbox-light .highlight .sb{color:#427b58}.codeexample-gruvbox-light .highlight .sc{color:#427b58}.codeexample-gruvbox-light .highlight .sd{color:#427b58}.codeexample-gruvbox-light .highlight .s2{color:#427b58}.codeexample-gruvbox-light .highlight .se{color:#427b58}.codeexample-gruvbox-light .highlight .sh{color:#427b58}.codeexample-gruvbox-light .highlight .si{color:#427b58}.codeexample-gruvbox-light .highlight .sx{color:#427b58}.codeexample-gruvbox-light .highlight .sr{color:#427b58}.codeexample-gruvbox-light .highlight .s1{color:#427b58}.codeexample-gruvbox-light .highlight .ss{color:#427b58}.codeexample-gruvbox-light .highlight .bp{color:#076678}.codeexample-gruvbox-light .highlight .vc{color:#076678}.codeexample-gruvbox-light .highlight .vg{color:#3c3836}.codeexample-gruvbox-light .highlight .vi{color:#b57614}.codeexample-gruvbox-light .highlight .il{color:#8f3f71}</style><div class="codeexample codeexample-gruvbox-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="material">Material</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#eceff1"></div><div class="preview-color" style="background-color:#263238"></div><div class="preview-color" style="background-color:#ff9800"></div><div class="preview-color" style="background-color:#8bc34a"></div><div class="preview-color" style="background-color:#ffc107"></div><div class="preview-color" style="background-color:#03a9f4"></div><div class="preview-color" style="background-color:#e91e63"></div><div class="preview-color" style="background-color:#009688"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#263238"></div><div class="preview-color" style="background-color:#37474f"></div><div class="preview-color" style="background-color:#ffa74d"></div><div class="preview-color" style="background-color:#9ccc65"></div><div class="preview-color" style="background-color:#ffa000"></div><div class="preview-color" style="background-color:#81d4fa"></div><div class="preview-color" style="background-color:#ad1457"></div><div class="preview-color" style="background-color:#26a69a"></div></div></div><style>.codeexample-material .highlight code, .codeexample-material .highlight pre{color:#eceff1;background-color:#263238}.codeexample-material .highlight .hll{background-color:#37474f}.codeexample-material .highlight .c{color:#cfd8dc}.codeexample-material .highlight .err{color:#9ccc65;background-color:#37474f}.codeexample-material .highlight .g{color:#cfd8dc}.codeexample-material .highlight .k{color:#03a9f4}.codeexample-material .highlight .l{color:#e91e63}.codeexample-material .highlight .n{color:#eceff1}.codeexample-material .highlight .o{color:#ffa000}.codeexample-material .highlight .x{color:#e91e63}.codeexample-material .highlight .p{color:#eceff1}.codeexample-material .highlight .cm{color:#cfd8dc}.codeexample-material .highlight .cp{color:#cfd8dc}.codeexample-material .highlight .c1{color:#cfd8dc}.codeexample-material .highlight .cs{color:#8bc34a;font-weight:bold}.codeexample-material .highlight .gd{color:#8bc34a}.codeexample-material .highlight .ge{color:#e91e63;font-style:italic}.codeexample-material .highlight .gr{color:#8bc34a}.codeexample-material .highlight .gh{color:#eceff1;font-weight:bold}.codeexample-material .highlight .gi{color:#ffa000}.codeexample-material .highlight .go{color:#37474f}.codeexample-material .highlight .gp{color:#eceff1;font-weight:bold}.codeexample-material .highlight .gs{color:#e91e63;font-weight:bold}.codeexample-material .highlight .gu{color:#e91e63;font-weight:bold}.codeexample-material .highlight .gt{color:#81d4fa}.codeexample-material .highlight .kc{color:#ffa74d}.codeexample-material .highlight .kd{color:#ffa000}.codeexample-material .highlight .kn{color:#03a9f4;font-weight:bold}.codeexample-material .highlight .kp{color:#8bc34a}.codeexample-material .highlight .kr{color:#9ccc65}.codeexample-material .highlight .kt{color:#cfd8dc}.codeexample-material .highlight .ld{color:#26a69a}.codeexample-material .highlight .m{color:#ad1457}.codeexample-material .highlight .s{color:#26a69a}.codeexample-material .highlight .na{color:#8bc34a}.codeexample-material .highlight .nb{color:#81d4fa}.codeexample-material .highlight .nc{color:#81d4fa}.codeexample-material .highlight .no{color:#e91e63}.codeexample-material .highlight .nd{color:#e91e63}.codeexample-material .highlight .ni{color:#ffa74d}.codeexample-material .highlight .ne{color:#ffc107;font-weight:bold}.codeexample-material .highlight .nf{color:#81d4fa}.codeexample-material .highlight .nl{color:#e91e63}.codeexample-material .highlight .nn{color:#81d4fa}.codeexample-material .highlight .nx{color:#e91e63}.codeexample-material .highlight .py{color:#e91e63}.codeexample-material .highlight .nt{color:#8bc34a}.codeexample-material .highlight .nv{color:#eceff1}.codeexample-material .highlight .ow{color:#ffa000}.codeexample-material .highlight .w{color:#e91e63}.codeexample-material .highlight .mf{color:#ad1457}.codeexample-material .highlight .mh{color:#ad1457}.codeexample-material .highlight .mi{color:#ad1457}.codeexample-material .highlight .mo{color:#ad1457}.codeexample-material .highlight .sb{color:#26a69a}.codeexample-material .highlight .sc{color:#26a69a}.codeexample-material .highlight .sd{color:#26a69a}.codeexample-material .highlight .s2{color:#26a69a}.codeexample-material .highlight .se{color:#26a69a}.codeexample-material .highlight .sh{color:#26a69a}.codeexample-material .highlight .si{color:#26a69a}.codeexample-material .highlight .sx{color:#26a69a}.codeexample-material .highlight .sr{color:#26a69a}.codeexample-material .highlight .s1{color:#26a69a}.codeexample-material .highlight .ss{color:#26a69a}.codeexample-material .highlight .bp{color:#81d4fa}.codeexample-material .highlight .vc{color:#81d4fa}.codeexample-material .highlight .vg{color:#eceff1}.codeexample-material .highlight .vi{color:#ffa000}.codeexample-material .highlight .il{color:#ad1457}</style><div class="codeexample codeexample-material">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="nancy">Nancy</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#fff"></div><div class="preview-color" style="background-color:#1b1d1e"></div><div class="preview-color" style="background-color:#f92672"></div><div class="preview-color" style="background-color:#82b414"></div><div class="preview-color" style="background-color:#fd971f"></div><div class="preview-color" style="background-color:#4e82aa"></div><div class="preview-color" style="background-color:#8c54fe"></div><div class="preview-color" style="background-color:#465457"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#010101"></div><div class="preview-color" style="background-color:#505354"></div><div class="preview-color" style="background-color:#ff5995"></div><div class="preview-color" style="background-color:#b6e354"></div><div class="preview-color" style="background-color:#feed6c"></div><div class="preview-color" style="background-color:#0c73c2"></div><div class="preview-color" style="background-color:#9e6ffe"></div><div class="preview-color" style="background-color:#899ca1"></div></div></div><style>.codeexample-nancy .highlight code, .codeexample-nancy .highlight pre{color:#fff;background-color:#010101}.codeexample-nancy .highlight .hll{background-color:#505354}.codeexample-nancy .highlight .c{color:#ccccc6}.codeexample-nancy .highlight .err{color:#b6e354;background-color:#505354}.codeexample-nancy .highlight .g{color:#ccccc6}.codeexample-nancy .highlight .k{color:#4e82aa}.codeexample-nancy .highlight .l{color:#8c54fe}.codeexample-nancy .highlight .n{color:#fff}.codeexample-nancy .highlight .o{color:#feed6c}.codeexample-nancy .highlight .x{color:#8c54fe}.codeexample-nancy .highlight .p{color:#f8f8f2}.codeexample-nancy .highlight .cm{color:#ccccc6}.codeexample-nancy .highlight .cp{color:#ccccc6}.codeexample-nancy .highlight .c1{color:#ccccc6}.codeexample-nancy .highlight .cs{color:#82b414;font-weight:bold}.codeexample-nancy .highlight .gd{color:#82b414}.codeexample-nancy .highlight .ge{color:#8c54fe;font-style:italic}.codeexample-nancy .highlight .gr{color:#82b414}.codeexample-nancy .highlight .gh{color:#fff;font-weight:bold}.codeexample-nancy .highlight .gi{color:#feed6c}.codeexample-nancy .highlight .go{color:#505354}.codeexample-nancy .highlight .gp{color:#fff;font-weight:bold}.codeexample-nancy .highlight .gs{color:#8c54fe;font-weight:bold}.codeexample-nancy .highlight .gu{color:#8c54fe;font-weight:bold}.codeexample-nancy .highlight .gt{color:#0c73c2}.codeexample-nancy .highlight .kc{color:#ff5995}.codeexample-nancy .highlight .kd{color:#feed6c}.codeexample-nancy .highlight .kn{color:#4e82aa;font-weight:bold}.codeexample-nancy .highlight .kp{color:#82b414}.codeexample-nancy .highlight .kr{color:#b6e354}.codeexample-nancy .highlight .kt{color:#ccccc6}.codeexample-nancy .highlight .ld{color:#899ca1}.codeexample-nancy .highlight .m{color:#9e6ffe}.codeexample-nancy .highlight .s{color:#899ca1}.codeexample-nancy .highlight .na{color:#82b414}.codeexample-nancy .highlight .nb{color:#0c73c2}.codeexample-nancy .highlight .nc{color:#0c73c2}.codeexample-nancy .highlight .no{color:#8c54fe}.codeexample-nancy .highlight .nd{color:#8c54fe}.codeexample-nancy .highlight .ni{color:#ff5995}.codeexample-nancy .highlight .ne{color:#fd971f;font-weight:bold}.codeexample-nancy .highlight .nf{color:#0c73c2}.codeexample-nancy .highlight .nl{color:#8c54fe}.codeexample-nancy .highlight .nn{color:#0c73c2}.codeexample-nancy .highlight .nx{color:#8c54fe}.codeexample-nancy .highlight .py{color:#8c54fe}.codeexample-nancy .highlight .nt{color:#82b414}.codeexample-nancy .highlight .nv{color:#fff}.codeexample-nancy .highlight .ow{color:#feed6c}.codeexample-nancy .highlight .w{color:#8c54fe}.codeexample-nancy .highlight .mf{color:#9e6ffe}.codeexample-nancy .highlight .mh{color:#9e6ffe}.codeexample-nancy .highlight .mi{color:#9e6ffe}.codeexample-nancy .highlight .mo{color:#9e6ffe}.codeexample-nancy .highlight .sb{color:#899ca1}.codeexample-nancy .highlight .sc{color:#899ca1}.codeexample-nancy .highlight .sd{color:#899ca1}.codeexample-nancy .highlight .s2{color:#899ca1}.codeexample-nancy .highlight .se{color:#899ca1}.codeexample-nancy .highlight .sh{color:#899ca1}.codeexample-nancy .highlight .si{color:#899ca1}.codeexample-nancy .highlight .sx{color:#899ca1}.codeexample-nancy .highlight .sr{color:#899ca1}.codeexample-nancy .highlight .s1{color:#899ca1}.codeexample-nancy .highlight .ss{color:#899ca1}.codeexample-nancy .highlight .bp{color:#0c73c2}.codeexample-nancy .highlight .vc{color:#0c73c2}.codeexample-nancy .highlight .vg{color:#fff}.codeexample-nancy .highlight .vi{color:#feed6c}.codeexample-nancy .highlight .il{color:#9e6ffe}</style><div class="codeexample codeexample-nancy">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="neon">Neon</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#F8F8F8"></div><div class="preview-color" style="background-color:#171717"></div><div class="preview-color" style="background-color:#D81765"></div><div class="preview-color" style="background-color:#97D01A"></div><div class="preview-color" style="background-color:#FFA800"></div><div class="preview-color" style="background-color:#16B1FB"></div><div class="preview-color" style="background-color:#FF2491"></div><div class="preview-color" style="background-color:#0FDCB6"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#171717"></div><div class="preview-color" style="background-color:#38252C"></div><div class="preview-color" style="background-color:#FF0000"></div><div class="preview-color" style="background-color:#76B639"></div><div class="preview-color" style="background-color:#E1A126"></div><div class="preview-color" style="background-color:#289CD5"></div><div class="preview-color" style="background-color:#FF2491"></div><div class="preview-color" style="background-color:#0A9B81"></div></div></div><style>.codeexample-neon .highlight code, .codeexample-neon .highlight pre{color:#F8F8F8;background-color:#171717}.codeexample-neon .highlight .hll{background-color:#38252C}.codeexample-neon .highlight .c{color:#EBEBEB}.codeexample-neon .highlight .err{color:#76B639;background-color:#38252C}.codeexample-neon .highlight .g{color:#EBEBEB}.codeexample-neon .highlight .k{color:#16B1FB}.codeexample-neon .highlight .l{color:#FF2491}.codeexample-neon .highlight .n{color:#F8F8F8}.codeexample-neon .highlight .o{color:#E1A126}.codeexample-neon .highlight .x{color:#FF2491}.codeexample-neon .highlight .p{color:#F8F8F8}.codeexample-neon .highlight .cm{color:#EBEBEB}.codeexample-neon .highlight .cp{color:#EBEBEB}.codeexample-neon .highlight .c1{color:#EBEBEB}.codeexample-neon .highlight .cs{color:#97D01A;font-weight:bold}.codeexample-neon .highlight .gd{color:#97D01A}.codeexample-neon .highlight .ge{color:#FF2491;font-style:italic}.codeexample-neon .highlight .gr{color:#97D01A}.codeexample-neon .highlight .gh{color:#F8F8F8;font-weight:bold}.codeexample-neon .highlight .gi{color:#E1A126}.codeexample-neon .highlight .go{color:#38252C}.codeexample-neon .highlight .gp{color:#F8F8F8;font-weight:bold}.codeexample-neon .highlight .gs{color:#FF2491;font-weight:bold}.codeexample-neon .highlight .gu{color:#FF2491;font-weight:bold}.codeexample-neon .highlight .gt{color:#289CD5}.codeexample-neon .highlight .kc{color:#FF0000}.codeexample-neon .highlight .kd{color:#E1A126}.codeexample-neon .highlight .kn{color:#16B1FB;font-weight:bold}.codeexample-neon .highlight .kp{color:#97D01A}.codeexample-neon .highlight .kr{color:#76B639}.codeexample-neon .highlight .kt{color:#EBEBEB}.codeexample-neon .highlight .ld{color:#0A9B81}.codeexample-neon .highlight .m{color:#FF2491}.codeexample-neon .highlight .s{color:#0A9B81}.codeexample-neon .highlight .na{color:#97D01A}.codeexample-neon .highlight .nb{color:#289CD5}.codeexample-neon .highlight .nc{color:#289CD5}.codeexample-neon .highlight .no{color:#FF2491}.codeexample-neon .highlight .nd{color:#FF2491}.codeexample-neon .highlight .ni{color:#FF0000}.codeexample-neon .highlight .ne{color:#FFA800;font-weight:bold}.codeexample-neon .highlight .nf{color:#289CD5}.codeexample-neon .highlight .nl{color:#FF2491}.codeexample-neon .highlight .nn{color:#289CD5}.codeexample-neon .highlight .nx{color:#FF2491}.codeexample-neon .highlight .py{color:#FF2491}.codeexample-neon .highlight .nt{color:#97D01A}.codeexample-neon .highlight .nv{color:#F8F8F8}.codeexample-neon .highlight .ow{color:#E1A126}.codeexample-neon .highlight .w{color:#FF2491}.codeexample-neon .highlight .mf{color:#FF2491}.codeexample-neon .highlight .mh{color:#FF2491}.codeexample-neon .highlight .mi{color:#FF2491}.codeexample-neon .highlight .mo{color:#FF2491}.codeexample-neon .highlight .sb{color:#0A9B81}.codeexample-neon .highlight .sc{color:#0A9B81}.codeexample-neon .highlight .sd{color:#0A9B81}.codeexample-neon .highlight .s2{color:#0A9B81}.codeexample-neon .highlight .se{color:#0A9B81}.codeexample-neon .highlight .sh{color:#0A9B81}.codeexample-neon .highlight .si{color:#0A9B81}.codeexample-neon .highlight .sx{color:#0A9B81}.codeexample-neon .highlight .sr{color:#0A9B81}.codeexample-neon .highlight .s1{color:#0A9B81}.codeexample-neon .highlight .ss{color:#0A9B81}.codeexample-neon .highlight .bp{color:#289CD5}.codeexample-neon .highlight .vc{color:#289CD5}.codeexample-neon .highlight .vg{color:#F8F8F8}.codeexample-neon .highlight .vi{color:#E1A126}.codeexample-neon .highlight .il{color:#FF2491}</style><div class="codeexample codeexample-neon">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="rydgel">Rydgel</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:none"></div><div class="preview-color" style="background-color:#303430"></div><div class="preview-color" style="background-color:#bf7979"></div><div class="preview-color" style="background-color:#97b26b"></div><div class="preview-color" style="background-color:#cdcdc1"></div><div class="preview-color" style="background-color:#86a2be"></div><div class="preview-color" style="background-color:#d9b798"></div><div class="preview-color" style="background-color:#a1b5cd"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:none"></div><div class="preview-color" style="background-color:#cdb5cd"></div><div class="preview-color" style="background-color:#f4a45f"></div><div class="preview-color" style="background-color:#c5f779"></div><div class="preview-color" style="background-color:#ffffed"></div><div class="preview-color" style="background-color:#98afd9"></div><div class="preview-color" style="background-color:#d7d998"></div><div class="preview-color" style="background-color:#a1b5cd"></div></div></div><style>.codeexample-rydgel .highlight code, .codeexample-rydgel .highlight pre{color:none;background-color:none}.codeexample-rydgel .highlight .hll{background-color:#cdb5cd}.codeexample-rydgel .highlight .c{color:#ffffff}.codeexample-rydgel .highlight .err{color:#c5f779;background-color:#cdb5cd}.codeexample-rydgel .highlight .g{color:#ffffff}.codeexample-rydgel .highlight .k{color:#86a2be}.codeexample-rydgel .highlight .l{color:#d9b798}.codeexample-rydgel .highlight .n{color:none}.codeexample-rydgel .highlight .o{color:#ffffed}.codeexample-rydgel .highlight .x{color:#d9b798}.codeexample-rydgel .highlight .p{color:#dedede}.codeexample-rydgel .highlight .cm{color:#ffffff}.codeexample-rydgel .highlight .cp{color:#ffffff}.codeexample-rydgel .highlight .c1{color:#ffffff}.codeexample-rydgel .highlight .cs{color:#97b26b;font-weight:bold}.codeexample-rydgel .highlight .gd{color:#97b26b}.codeexample-rydgel .highlight .ge{color:#d9b798;font-style:italic}.codeexample-rydgel .highlight .gr{color:#97b26b}.codeexample-rydgel .highlight .gh{color:none;font-weight:bold}.codeexample-rydgel .highlight .gi{color:#ffffed}.codeexample-rydgel .highlight .go{color:#cdb5cd}.codeexample-rydgel .highlight .gp{color:none;font-weight:bold}.codeexample-rydgel .highlight .gs{color:#d9b798;font-weight:bold}.codeexample-rydgel .highlight .gu{color:#d9b798;font-weight:bold}.codeexample-rydgel .highlight .gt{color:#98afd9}.codeexample-rydgel .highlight .kc{color:#f4a45f}.codeexample-rydgel .highlight .kd{color:#ffffed}.codeexample-rydgel .highlight .kn{color:#86a2be;font-weight:bold}.codeexample-rydgel .highlight .kp{color:#97b26b}.codeexample-rydgel .highlight .kr{color:#c5f779}.codeexample-rydgel .highlight .kt{color:#ffffff}.codeexample-rydgel .highlight .ld{color:#a1b5cd}.codeexample-rydgel .highlight .m{color:#d7d998}.codeexample-rydgel .highlight .s{color:#a1b5cd}.codeexample-rydgel .highlight .na{color:#97b26b}.codeexample-rydgel .highlight .nb{color:#98afd9}.codeexample-rydgel .highlight .nc{color:#98afd9}.codeexample-rydgel .highlight .no{color:#d9b798}.codeexample-rydgel .highlight .nd{color:#d9b798}.codeexample-rydgel .highlight .ni{color:#f4a45f}.codeexample-rydgel .highlight .ne{color:#cdcdc1;font-weight:bold}.codeexample-rydgel .highlight .nf{color:#98afd9}.codeexample-rydgel .highlight .nl{color:#d9b798}.codeexample-rydgel .highlight .nn{color:#98afd9}.codeexample-rydgel .highlight .nx{color:#d9b798}.codeexample-rydgel .highlight .py{color:#d9b798}.codeexample-rydgel .highlight .nt{color:#97b26b}.codeexample-rydgel .highlight .nv{color:none}.codeexample-rydgel .highlight .ow{color:#ffffed}.codeexample-rydgel .highlight .w{color:#d9b798}.codeexample-rydgel .highlight .mf{color:#d7d998}.codeexample-rydgel .highlight .mh{color:#d7d998}.codeexample-rydgel .highlight .mi{color:#d7d998}.codeexample-rydgel .highlight .mo{color:#d7d998}.codeexample-rydgel .highlight .sb{color:#a1b5cd}.codeexample-rydgel .highlight .sc{color:#a1b5cd}.codeexample-rydgel .highlight .sd{color:#a1b5cd}.codeexample-rydgel .highlight .s2{color:#a1b5cd}.codeexample-rydgel .highlight .se{color:#a1b5cd}.codeexample-rydgel .highlight .sh{color:#a1b5cd}.codeexample-rydgel .highlight .si{color:#a1b5cd}.codeexample-rydgel .highlight .sx{color:#a1b5cd}.codeexample-rydgel .highlight .sr{color:#a1b5cd}.codeexample-rydgel .highlight .s1{color:#a1b5cd}.codeexample-rydgel .highlight .ss{color:#a1b5cd}.codeexample-rydgel .highlight .bp{color:#98afd9}.codeexample-rydgel .highlight .vc{color:#98afd9}.codeexample-rydgel .highlight .vg{color:none}.codeexample-rydgel .highlight .vi{color:#ffffed}.codeexample-rydgel .highlight .il{color:#d7d998}</style><div class="codeexample codeexample-rydgel">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="solarized-dark">Solarized Dark</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#839496"></div><div class="preview-color" style="background-color:#073642"></div><div class="preview-color" style="background-color:#dc322f"></div><div class="preview-color" style="background-color:#859900"></div><div class="preview-color" style="background-color:#b58900"></div><div class="preview-color" style="background-color:#268bd2"></div><div class="preview-color" style="background-color:#d33682"></div><div class="preview-color" style="background-color:#2aa198"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#002b36"></div><div class="preview-color" style="background-color:#002b36"></div><div class="preview-color" style="background-color:#cb4b16"></div><div class="preview-color" style="background-color:#586e75"></div><div class="preview-color" style="background-color:#657b83"></div><div class="preview-color" style="background-color:#839496"></div><div class="preview-color" style="background-color:#6c71c4"></div><div class="preview-color" style="background-color:#93a1a1"></div></div></div><style>.codeexample-solarized-dark .highlight code, .codeexample-solarized-dark .highlight pre{color:#839496;background-color:#002b36}.codeexample-solarized-dark .highlight .hll{background-color:#002b36}.codeexample-solarized-dark .highlight .c{color:#eee8d5}.codeexample-solarized-dark .highlight .err{color:#586e75;background-color:#002b36}.codeexample-solarized-dark .highlight .g{color:#eee8d5}.codeexample-solarized-dark .highlight .k{color:#268bd2}.codeexample-solarized-dark .highlight .l{color:#d33682}.codeexample-solarized-dark .highlight .n{color:#839496}.codeexample-solarized-dark .highlight .o{color:#657b83}.codeexample-solarized-dark .highlight .x{color:#d33682}.codeexample-solarized-dark .highlight .p{color:#fdf6e3}.codeexample-solarized-dark .highlight .cm{color:#eee8d5}.codeexample-solarized-dark .highlight .cp{color:#eee8d5}.codeexample-solarized-dark .highlight .c1{color:#eee8d5}.codeexample-solarized-dark .highlight .cs{color:#859900;font-weight:bold}.codeexample-solarized-dark .highlight .gd{color:#859900}.codeexample-solarized-dark .highlight .ge{color:#d33682;font-style:italic}.codeexample-solarized-dark .highlight .gr{color:#859900}.codeexample-solarized-dark .highlight .gh{color:#839496;font-weight:bold}.codeexample-solarized-dark .highlight .gi{color:#657b83}.codeexample-solarized-dark .highlight .go{color:#002b36}.codeexample-solarized-dark .highlight .gp{color:#839496;font-weight:bold}.codeexample-solarized-dark .highlight .gs{color:#d33682;font-weight:bold}.codeexample-solarized-dark .highlight .gu{color:#d33682;font-weight:bold}.codeexample-solarized-dark .highlight .gt{color:#839496}.codeexample-solarized-dark .highlight .kc{color:#cb4b16}.codeexample-solarized-dark .highlight .kd{color:#657b83}.codeexample-solarized-dark .highlight .kn{color:#268bd2;font-weight:bold}.codeexample-solarized-dark .highlight .kp{color:#859900}.codeexample-solarized-dark .highlight .kr{color:#586e75}.codeexample-solarized-dark .highlight .kt{color:#eee8d5}.codeexample-solarized-dark .highlight .ld{color:#93a1a1}.codeexample-solarized-dark .highlight .m{color:#6c71c4}.codeexample-solarized-dark .highlight .s{color:#93a1a1}.codeexample-solarized-dark .highlight .na{color:#859900}.codeexample-solarized-dark .highlight .nb{color:#839496}.codeexample-solarized-dark .highlight .nc{color:#839496}.codeexample-solarized-dark .highlight .no{color:#d33682}.codeexample-solarized-dark .highlight .nd{color:#d33682}.codeexample-solarized-dark .highlight .ni{color:#cb4b16}.codeexample-solarized-dark .highlight .ne{color:#b58900;font-weight:bold}.codeexample-solarized-dark .highlight .nf{color:#839496}.codeexample-solarized-dark .highlight .nl{color:#d33682}.codeexample-solarized-dark .highlight .nn{color:#839496}.codeexample-solarized-dark .highlight .nx{color:#d33682}.codeexample-solarized-dark .highlight .py{color:#d33682}.codeexample-solarized-dark .highlight .nt{color:#859900}.codeexample-solarized-dark .highlight .nv{color:#839496}.codeexample-solarized-dark .highlight .ow{color:#657b83}.codeexample-solarized-dark .highlight .w{color:#d33682}.codeexample-solarized-dark .highlight .mf{color:#6c71c4}.codeexample-solarized-dark .highlight .mh{color:#6c71c4}.codeexample-solarized-dark .highlight .mi{color:#6c71c4}.codeexample-solarized-dark .highlight .mo{color:#6c71c4}.codeexample-solarized-dark .highlight .sb{color:#93a1a1}.codeexample-solarized-dark .highlight .sc{color:#93a1a1}.codeexample-solarized-dark .highlight .sd{color:#93a1a1}.codeexample-solarized-dark .highlight .s2{color:#93a1a1}.codeexample-solarized-dark .highlight .se{color:#93a1a1}.codeexample-solarized-dark .highlight .sh{color:#93a1a1}.codeexample-solarized-dark .highlight .si{color:#93a1a1}.codeexample-solarized-dark .highlight .sx{color:#93a1a1}.codeexample-solarized-dark .highlight .sr{color:#93a1a1}.codeexample-solarized-dark .highlight .s1{color:#93a1a1}.codeexample-solarized-dark .highlight .ss{color:#93a1a1}.codeexample-solarized-dark .highlight .bp{color:#839496}.codeexample-solarized-dark .highlight .vc{color:#839496}.codeexample-solarized-dark .highlight .vg{color:#839496}.codeexample-solarized-dark .highlight .vi{color:#657b83}.codeexample-solarized-dark .highlight .il{color:#6c71c4}</style><div class="codeexample codeexample-solarized-dark">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="solarized-light">Solarized Light</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#657b83"></div><div class="preview-color" style="background-color:#073642"></div><div class="preview-color" style="background-color:#dc322f"></div><div class="preview-color" style="background-color:#859900"></div><div class="preview-color" style="background-color:#b58900"></div><div class="preview-color" style="background-color:#268bd2"></div><div class="preview-color" style="background-color:#d33682"></div><div class="preview-color" style="background-color:#2aa198"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#fdf6e3"></div><div class="preview-color" style="background-color:#002b36"></div><div class="preview-color" style="background-color:#cb4b16"></div><div class="preview-color" style="background-color:#586e75"></div><div class="preview-color" style="background-color:#657b83"></div><div class="preview-color" style="background-color:#839496"></div><div class="preview-color" style="background-color:#6c71c4"></div><div class="preview-color" style="background-color:#93a1a1"></div></div></div><style>.codeexample-solarized-light .highlight code, .codeexample-solarized-light .highlight pre{color:#657b83;background-color:#fdf6e3}.codeexample-solarized-light .highlight .hll{background-color:#002b36}.codeexample-solarized-light .highlight .c{color:#eee8d5}.codeexample-solarized-light .highlight .err{color:#586e75;background-color:#002b36}.codeexample-solarized-light .highlight .g{color:#eee8d5}.codeexample-solarized-light .highlight .k{color:#268bd2}.codeexample-solarized-light .highlight .l{color:#d33682}.codeexample-solarized-light .highlight .n{color:#657b83}.codeexample-solarized-light .highlight .o{color:#657b83}.codeexample-solarized-light .highlight .x{color:#d33682}.codeexample-solarized-light .highlight .p{color:#fdf6e3}.codeexample-solarized-light .highlight .cm{color:#eee8d5}.codeexample-solarized-light .highlight .cp{color:#eee8d5}.codeexample-solarized-light .highlight .c1{color:#eee8d5}.codeexample-solarized-light .highlight .cs{color:#859900;font-weight:bold}.codeexample-solarized-light .highlight .gd{color:#859900}.codeexample-solarized-light .highlight .ge{color:#d33682;font-style:italic}.codeexample-solarized-light .highlight .gr{color:#859900}.codeexample-solarized-light .highlight .gh{color:#657b83;font-weight:bold}.codeexample-solarized-light .highlight .gi{color:#657b83}.codeexample-solarized-light .highlight .go{color:#002b36}.codeexample-solarized-light .highlight .gp{color:#657b83;font-weight:bold}.codeexample-solarized-light .highlight .gs{color:#d33682;font-weight:bold}.codeexample-solarized-light .highlight .gu{color:#d33682;font-weight:bold}.codeexample-solarized-light .highlight .gt{color:#839496}.codeexample-solarized-light .highlight .kc{color:#cb4b16}.codeexample-solarized-light .highlight .kd{color:#657b83}.codeexample-solarized-light .highlight .kn{color:#268bd2;font-weight:bold}.codeexample-solarized-light .highlight .kp{color:#859900}.codeexample-solarized-light .highlight .kr{color:#586e75}.codeexample-solarized-light .highlight .kt{color:#eee8d5}.codeexample-solarized-light .highlight .ld{color:#93a1a1}.codeexample-solarized-light .highlight .m{color:#6c71c4}.codeexample-solarized-light .highlight .s{color:#93a1a1}.codeexample-solarized-light .highlight .na{color:#859900}.codeexample-solarized-light .highlight .nb{color:#839496}.codeexample-solarized-light .highlight .nc{color:#839496}.codeexample-solarized-light .highlight .no{color:#d33682}.codeexample-solarized-light .highlight .nd{color:#d33682}.codeexample-solarized-light .highlight .ni{color:#cb4b16}.codeexample-solarized-light .highlight .ne{color:#b58900;font-weight:bold}.codeexample-solarized-light .highlight .nf{color:#839496}.codeexample-solarized-light .highlight .nl{color:#d33682}.codeexample-solarized-light .highlight .nn{color:#839496}.codeexample-solarized-light .highlight .nx{color:#d33682}.codeexample-solarized-light .highlight .py{color:#d33682}.codeexample-solarized-light .highlight .nt{color:#859900}.codeexample-solarized-light .highlight .nv{color:#657b83}.codeexample-solarized-light .highlight .ow{color:#657b83}.codeexample-solarized-light .highlight .w{color:#d33682}.codeexample-solarized-light .highlight .mf{color:#6c71c4}.codeexample-solarized-light .highlight .mh{color:#6c71c4}.codeexample-solarized-light .highlight .mi{color:#6c71c4}.codeexample-solarized-light .highlight .mo{color:#6c71c4}.codeexample-solarized-light .highlight .sb{color:#93a1a1}.codeexample-solarized-light .highlight .sc{color:#93a1a1}.codeexample-solarized-light .highlight .sd{color:#93a1a1}.codeexample-solarized-light .highlight .s2{color:#93a1a1}.codeexample-solarized-light .highlight .se{color:#93a1a1}.codeexample-solarized-light .highlight .sh{color:#93a1a1}.codeexample-solarized-light .highlight .si{color:#93a1a1}.codeexample-solarized-light .highlight .sx{color:#93a1a1}.codeexample-solarized-light .highlight .sr{color:#93a1a1}.codeexample-solarized-light .highlight .s1{color:#93a1a1}.codeexample-solarized-light .highlight .ss{color:#93a1a1}.codeexample-solarized-light .highlight .bp{color:#839496}.codeexample-solarized-light .highlight .vc{color:#839496}.codeexample-solarized-light .highlight .vg{color:#657b83}.codeexample-solarized-light .highlight .vi{color:#657b83}.codeexample-solarized-light .highlight .il{color:#6c71c4}</style><div class="codeexample codeexample-solarized-light">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="tomorrow-night">Tomorrow Night</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#c5c8c6"></div><div class="preview-color" style="background-color:#1d1f21"></div><div class="preview-color" style="background-color:#cc6666"></div><div class="preview-color" style="background-color:#b5bd68"></div><div class="preview-color" style="background-color:#f0c674"></div><div class="preview-color" style="background-color:#81a2be"></div><div class="preview-color" style="background-color:#b294bb"></div><div class="preview-color" style="background-color:#8abeb7"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#1d1f21"></div><div class="preview-color" style="background-color:#cc6666"></div><div class="preview-color" style="background-color:#969896"></div><div class="preview-color" style="background-color:#b5bd68"></div><div class="preview-color" style="background-color:#f0c674"></div><div class="preview-color" style="background-color:#81a2be"></div><div class="preview-color" style="background-color:#b294bb"></div><div class="preview-color" style="background-color:#8abeb7"></div></div></div><style>.codeexample-tomorrow-night .highlight code, .codeexample-tomorrow-night .highlight pre{color:#c5c8c6;background-color:#1d1f21}.codeexample-tomorrow-night .highlight .hll{background-color:#cc6666}.codeexample-tomorrow-night .highlight .c{color:#c5c8c6}.codeexample-tomorrow-night .highlight .err{color:#b5bd68;background-color:#cc6666}.codeexample-tomorrow-night .highlight .g{color:#c5c8c6}.codeexample-tomorrow-night .highlight .k{color:#81a2be}.codeexample-tomorrow-night .highlight .l{color:#b294bb}.codeexample-tomorrow-night .highlight .n{color:#c5c8c6}.codeexample-tomorrow-night .highlight .o{color:#f0c674}.codeexample-tomorrow-night .highlight .x{color:#b294bb}.codeexample-tomorrow-night .highlight .p{color:#ffffff}.codeexample-tomorrow-night .highlight .cm{color:#c5c8c6}.codeexample-tomorrow-night .highlight .cp{color:#c5c8c6}.codeexample-tomorrow-night .highlight .c1{color:#c5c8c6}.codeexample-tomorrow-night .highlight .cs{color:#b5bd68;font-weight:bold}.codeexample-tomorrow-night .highlight .gd{color:#b5bd68}.codeexample-tomorrow-night .highlight .ge{color:#b294bb;font-style:italic}.codeexample-tomorrow-night .highlight .gr{color:#b5bd68}.codeexample-tomorrow-night .highlight .gh{color:#c5c8c6;font-weight:bold}.codeexample-tomorrow-night .highlight .gi{color:#f0c674}.codeexample-tomorrow-night .highlight .go{color:#cc6666}.codeexample-tomorrow-night .highlight .gp{color:#c5c8c6;font-weight:bold}.codeexample-tomorrow-night .highlight .gs{color:#b294bb;font-weight:bold}.codeexample-tomorrow-night .highlight .gu{color:#b294bb;font-weight:bold}.codeexample-tomorrow-night .highlight .gt{color:#81a2be}.codeexample-tomorrow-night .highlight .kc{color:#969896}.codeexample-tomorrow-night .highlight .kd{color:#f0c674}.codeexample-tomorrow-night .highlight .kn{color:#81a2be;font-weight:bold}.codeexample-tomorrow-night .highlight .kp{color:#b5bd68}.codeexample-tomorrow-night .highlight .kr{color:#b5bd68}.codeexample-tomorrow-night .highlight .kt{color:#c5c8c6}.codeexample-tomorrow-night .highlight .ld{color:#8abeb7}.codeexample-tomorrow-night .highlight .m{color:#b294bb}.codeexample-tomorrow-night .highlight .s{color:#8abeb7}.codeexample-tomorrow-night .highlight .na{color:#b5bd68}.codeexample-tomorrow-night .highlight .nb{color:#81a2be}.codeexample-tomorrow-night .highlight .nc{color:#81a2be}.codeexample-tomorrow-night .highlight .no{color:#b294bb}.codeexample-tomorrow-night .highlight .nd{color:#b294bb}.codeexample-tomorrow-night .highlight .ni{color:#969896}.codeexample-tomorrow-night .highlight .ne{color:#f0c674;font-weight:bold}.codeexample-tomorrow-night .highlight .nf{color:#81a2be}.codeexample-tomorrow-night .highlight .nl{color:#b294bb}.codeexample-tomorrow-night .highlight .nn{color:#81a2be}.codeexample-tomorrow-night .highlight .nx{color:#b294bb}.codeexample-tomorrow-night .highlight .py{color:#b294bb}.codeexample-tomorrow-night .highlight .nt{color:#b5bd68}.codeexample-tomorrow-night .highlight .nv{color:#c5c8c6}.codeexample-tomorrow-night .highlight .ow{color:#f0c674}.codeexample-tomorrow-night .highlight .w{color:#b294bb}.codeexample-tomorrow-night .highlight .mf{color:#b294bb}.codeexample-tomorrow-night .highlight .mh{color:#b294bb}.codeexample-tomorrow-night .highlight .mi{color:#b294bb}.codeexample-tomorrow-night .highlight .mo{color:#b294bb}.codeexample-tomorrow-night .highlight .sb{color:#8abeb7}.codeexample-tomorrow-night .highlight .sc{color:#8abeb7}.codeexample-tomorrow-night .highlight .sd{color:#8abeb7}.codeexample-tomorrow-night .highlight .s2{color:#8abeb7}.codeexample-tomorrow-night .highlight .se{color:#8abeb7}.codeexample-tomorrow-night .highlight .sh{color:#8abeb7}.codeexample-tomorrow-night .highlight .si{color:#8abeb7}.codeexample-tomorrow-night .highlight .sx{color:#8abeb7}.codeexample-tomorrow-night .highlight .sr{color:#8abeb7}.codeexample-tomorrow-night .highlight .s1{color:#8abeb7}.codeexample-tomorrow-night .highlight .ss{color:#8abeb7}.codeexample-tomorrow-night .highlight .bp{color:#81a2be}.codeexample-tomorrow-night .highlight .vc{color:#81a2be}.codeexample-tomorrow-night .highlight .vg{color:#c5c8c6}.codeexample-tomorrow-night .highlight .vi{color:#f0c674}.codeexample-tomorrow-night .highlight .il{color:#b294bb}</style><div class="codeexample codeexample-tomorrow-night">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div><h3 id="zenburn">Zenburn</h3><div class="preview-color-block"><div class="preview-color-row"><div class="preview-color" style="background-color:#ffffff"></div><div class="preview-color" style="background-color:#000000"></div><div class="preview-color" style="background-color:#9e1828"></div><div class="preview-color" style="background-color:#aece92"></div><div class="preview-color" style="background-color:#968a38"></div><div class="preview-color" style="background-color:#414171"></div><div class="preview-color" style="background-color:#963c59"></div><div class="preview-color" style="background-color:#418179"></div></div><div class="preview-color-row"><div class="preview-color" style="background-color:#000010"></div><div class="preview-color" style="background-color:#666666"></div><div class="preview-color" style="background-color:#cf6171"></div><div class="preview-color" style="background-color:#c5f779"></div><div class="preview-color" style="background-color:#fff796"></div><div class="preview-color" style="background-color:#4186be"></div><div class="preview-color" style="background-color:#cf9ebe"></div><div class="preview-color" style="background-color:#71bebe"></div></div></div><style>.codeexample-zenburn .highlight code, .codeexample-zenburn .highlight pre{color:#ffffff;background-color:#000010}.codeexample-zenburn .highlight .hll{background-color:#666666}.codeexample-zenburn .highlight .c{color:#bebebe}.codeexample-zenburn .highlight .err{color:#c5f779;background-color:#666666}.codeexample-zenburn .highlight .g{color:#bebebe}.codeexample-zenburn .highlight .k{color:#414171}.codeexample-zenburn .highlight .l{color:#963c59}.codeexample-zenburn .highlight .n{color:#ffffff}.codeexample-zenburn .highlight .o{color:#fff796}.codeexample-zenburn .highlight .x{color:#963c59}.codeexample-zenburn .highlight .p{color:#ffffff}.codeexample-zenburn .highlight .cm{color:#bebebe}.codeexample-zenburn .highlight .cp{color:#bebebe}.codeexample-zenburn .highlight .c1{color:#bebebe}.codeexample-zenburn .highlight .cs{color:#aece92;font-weight:bold}.codeexample-zenburn .highlight .gd{color:#aece92}.codeexample-zenburn .highlight .ge{color:#963c59;font-style:italic}.codeexample-zenburn .highlight .gr{color:#aece92}.codeexample-zenburn .highlight .gh{color:#ffffff;font-weight:bold}.codeexample-zenburn .highlight .gi{color:#fff796}.codeexample-zenburn .highlight .go{color:#666666}.codeexample-zenburn .highlight .gp{color:#ffffff;font-weight:bold}.codeexample-zenburn .highlight .gs{color:#963c59;font-weight:bold}.codeexample-zenburn .highlight .gu{color:#963c59;font-weight:bold}.codeexample-zenburn .highlight .gt{color:#4186be}.codeexample-zenburn .highlight .kc{color:#cf6171}.codeexample-zenburn .highlight .kd{color:#fff796}.codeexample-zenburn .highlight .kn{color:#414171;font-weight:bold}.codeexample-zenburn .highlight .kp{color:#aece92}.codeexample-zenburn .highlight .kr{color:#c5f779}.codeexample-zenburn .highlight .kt{color:#bebebe}.codeexample-zenburn .highlight .ld{color:#71bebe}.codeexample-zenburn .highlight .m{color:#cf9ebe}.codeexample-zenburn .highlight .s{color:#71bebe}.codeexample-zenburn .highlight .na{color:#aece92}.codeexample-zenburn .highlight .nb{color:#4186be}.codeexample-zenburn .highlight .nc{color:#4186be}.codeexample-zenburn .highlight .no{color:#963c59}.codeexample-zenburn .highlight .nd{color:#963c59}.codeexample-zenburn .highlight .ni{color:#cf6171}.codeexample-zenburn .highlight .ne{color:#968a38;font-weight:bold}.codeexample-zenburn .highlight .nf{color:#4186be}.codeexample-zenburn .highlight .nl{color:#963c59}.codeexample-zenburn .highlight .nn{color:#4186be}.codeexample-zenburn .highlight .nx{color:#963c59}.codeexample-zenburn .highlight .py{color:#963c59}.codeexample-zenburn .highlight .nt{color:#aece92}.codeexample-zenburn .highlight .nv{color:#ffffff}.codeexample-zenburn .highlight .ow{color:#fff796}.codeexample-zenburn .highlight .w{color:#963c59}.codeexample-zenburn .highlight .mf{color:#cf9ebe}.codeexample-zenburn .highlight .mh{color:#cf9ebe}.codeexample-zenburn .highlight .mi{color:#cf9ebe}.codeexample-zenburn .highlight .mo{color:#cf9ebe}.codeexample-zenburn .highlight .sb{color:#71bebe}.codeexample-zenburn .highlight .sc{color:#71bebe}.codeexample-zenburn .highlight .sd{color:#71bebe}.codeexample-zenburn .highlight .s2{color:#71bebe}.codeexample-zenburn .highlight .se{color:#71bebe}.codeexample-zenburn .highlight .sh{color:#71bebe}.codeexample-zenburn .highlight .si{color:#71bebe}.codeexample-zenburn .highlight .sx{color:#71bebe}.codeexample-zenburn .highlight .sr{color:#71bebe}.codeexample-zenburn .highlight .s1{color:#71bebe}.codeexample-zenburn .highlight .ss{color:#71bebe}.codeexample-zenburn .highlight .bp{color:#4186be}.codeexample-zenburn .highlight .vc{color:#4186be}.codeexample-zenburn .highlight .vg{color:#ffffff}.codeexample-zenburn .highlight .vi{color:#fff796}.codeexample-zenburn .highlight .il{color:#cf9ebe}</style><div class="codeexample codeexample-zenburn">{% highlight ruby%}
+require "gem"
+
+string = "base16"
+symbol = :base16
+fixnum = 0
+float  = 0.00
+array  = Array.new
+array  = ['chris', 85]
+hash   = {"test" => "test"}
+regexp = /[abc]/
+
+# This is a comment
+class Person
+  
+  attr_accessor :name
+  
+  def initialize(attributes = {})
+    @name = attributes[:name]
+  end
+  
+  def self.greet
+    "hello"
+  end
+end
+
+person1 = Person.new(:name => "Chris")
+print Person::greet, " ", person1.name, "\n"
+puts "another #{Person::greet} #{person1.name}"
+{% endhighlight %}</div>


### PR DESCRIPTION
The current color previews don't give a good sense of how the colortheme will look, so I added code previews. I also added a navigation at the top. It was once again generated with https://github.com/Neo-Oli/termux-styling-preview.
There is a preview available here: https://oliverse.ch/share/termux/add-on-styling-color-preview.html

![screenshot_20160912-184806](https://cloud.githubusercontent.com/assets/7983745/18445021/ea7c3154-791b-11e6-85e7-09a8f865a2c8.png)
![screenshot_20160912-184839](https://cloud.githubusercontent.com/assets/7983745/18445025/eb7b6264-791b-11e6-88f2-1ef4ca8a8c46.png)
