### PR TITLE
Re-structure, cn/ permalinks not used, layout.

### DIFF
--- a/community.md
+++ b/community.md
@@ -1,5 +1,5 @@
 ---
-layout: redirect
+layout: null
 sitemap: false
 permalink: /community
 redirect_to: https://wiki.termux.com/wiki/Community

--- a/docs.md
+++ b/docs.md
@@ -1,5 +1,5 @@
 ---
-layout: redirect
+layout: null
 sitemap: false
 permalink: /docs
 redirect_to: /en/docs

--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-layout: redirect
+layout: null
 sitemap: false
 redirect_to: /en/
 ---

--- a/issues.md
+++ b/issues.md
@@ -1,5 +1,5 @@
 ---
-layout: redirect
+layout: null
 sitemap: false
 permalink: /issues
 redirect_to: https://github.com/termux/termux-packages/issues

--- a/pages/cn/community.md
+++ b/pages/cn/community.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-sitemap: false
-redirect_to: https://wiki.termux.com/wiki/Community
----

--- a/pages/cn/docs.md
+++ b/pages/cn/docs.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-sitemap: false
-permalink: /cn/docs
----

--- a/pages/cn/issues.md
+++ b/pages/cn/issues.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-sitemap: false
-redirect_to: https://github.com/termux/termux-packages/issues
----

--- a/pages/cn/posts.md
+++ b/pages/cn/posts.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-sitemap: false
-permalink: /cn/posts
----

--- a/posts.md
+++ b/posts.md
@@ -1,5 +1,5 @@
 ---
-layout: redirect
+layout: null
 sitemap: false
 permalink: /posts
 redirect_to: /en/posts


### PR DESCRIPTION
https://www.rubydoc.info/gems/jekyll-redirect-from/0.16.0#redirect-to

### `layout: redirect` - customizing

> If you want to customize the redirect template, you can. Simply create a layout in your site's `_layouts` directory called `redirect.html`.