### PR TITLE
README: add info about submodules and jekyll serve --future arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ This is the source repository for [termux.github.io](https://termux.github.io) a
 Install dependencies as explained at [Using Jekyll with Pages](https://help.github.com/articles/using-jekyll-with-pages/), then run
 
 ```
-bundle exec jekyll serve
+bundle exec jekyll serve --future
 ```
 
-to start a local server at http://localhost:4000.
+to start a local server at http://localhost:4000. `--future` is needed to show posts with dates in the future.
 
 If [`_config.yml`] file was updated, then stop server with `ctrl + c` and start it again for changes to take effect.
 ##

--- a/README.md
+++ b/README.md
@@ -7,7 +7,13 @@ This is the source repository for [termux.github.io](https://termux.github.io) a
 
 ## Run locally
 
-Install dependencies as explained at [Using Jekyll with Pages](https://help.github.com/articles/using-jekyll-with-pages/), then run
+Get the git submodules with:
+
+```
+git submodule update --init
+```
+
+And then install dependencies as explained at [Using Jekyll with Pages](https://help.github.com/articles/using-jekyll-with-pages/), and finally run
 
 ```
 bundle exec jekyll serve --future


### PR DESCRIPTION
For blog posts dated in the future one need to serve with `--future`. 

There are also a termux-app doc submodule these days, that needs to be pulled with `git submodules update --init` before serve works.