### PR TITLE
ci: run on ubuntu-slim instead of ubuntu-latest

### DIFF
--- a/.github/workflows/trigger_termux_com_sync.yml
+++ b/.github/workflows/trigger_termux_com_sync.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   trigger-termux-com-sync:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - name: Trigger termux.com sync
       if: github.repository == 'termux/termux.github.io'


### PR DESCRIPTION
ubuntu-slim has just 1 vCPU instead of 4 vCPU for ubuntu-latest. Runners
are limited to 15 minutes. We are just running a workflow dispatch, so
it shouldn't matter at all

ubuntu-slim was available since 28 October 2025: https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/

Should reduce our CI usage effectively by atleast some amount (less
compute wasted)
